### PR TITLE
Fix magicgui objects.inv url for intersphinx

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -144,8 +144,8 @@ intersphinx_mapping = {
         'https://napari-plugin-engine.readthedocs.io/en/latest/objects.inv',
     ],
     'magicgui': [
-        'https://napari.org/magicgui/',
-        'https://napari.org/magicgui/objects.inv',
+        'https://pyapp-kit.github.io/magicgui/',
+        'https://pyapp-kit.github.io/magicgui/objects.inv',
     ],
 }
 


### PR DESCRIPTION
# Description

The magicgui docs have moved (now live at https://pyapp-kit.github.io/magicgui/). This PR updates the intersphinx URL for magicgui so the docs are rendered and crosslinked correctly.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
