### PR TITLE
Add napari survey text and link for announcement banner

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -100,7 +100,7 @@ html_theme_options = {
         "json_url": "https://napari.org/version_switcher.json",
         "version_match": version_match,
     },
-    "announcement": "Take the 8 minute <a href='https://bit.ly/napari-survey-n'>annual napari survey</a>! Your feedback is vital to ensure napari serves community needs.",
+    "announcement": "Take the 8 minute <a href='https://bit.ly/napari-survey-n' target='_blank' rel='noopener'>annual napari survey</a>! Your feedback is vital to ensure napari serves community needs.",
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -100,6 +100,7 @@ html_theme_options = {
         "json_url": "https://napari.org/version_switcher.json",
         "version_match": version_match,
     },
+    "announcement": "Take the 8 minute <a href='https://bit.ly/napari-survey-n'>annual napari survey</a>! Your feedback is vital to ensure napari serves community needs.",
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,


### PR DESCRIPTION
# Description
Adds an announcement banner to the docs pointing to the napari survey.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Fixes or improves existing content
- [x] Adds new content page(s)
- [ ] Fixes or improves workflow, documentation build or deployment

# References
This works because of the recent update on the napari-sphinx-theme: https://github.com/napari/napari-sphinx-theme/pull/127

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added [alt text](https://webaim.org/techniques/alttext/) to new images included in this PR