### PR TITLE
Feature: add `copy` button for code blocks using `sphinx-copybutton`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,6 +62,7 @@ extensions = [
     "sphinx_panels",
     "sphinx.ext.viewcode",
     "sphinx-favicon",
+    "sphinx_copybutton",
     "sphinx_gallery.gen_gallery",
     "sphinx_tags",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ sphinx-tags
 sphinx-panels
 sphinx-external-toc
 sphinx-favicon
+sphinx-copybutton
 sphinx-gallery
 sphinx_autodoc_typehints==1.12.0
 myst-nb


### PR DESCRIPTION
# Description

This PR adds the nice copy button to code blocks via `sphinx-copybutton`
https://github.com/executablebooks/sphinx-copybutton
E.g.
<img width="746" alt="image" src="https://user-images.githubusercontent.com/76622105/208301050-e751e56d-7d4e-4ef0-a07f-5de10afa94c2.png">

I've found these kinds of buttons common in other python docs (e.g. scikit-image)
You can see it at work in a PR to my fork: https://github.com/psobolewskiPhD/napari-docs/pull/5
Here's the built docs artifact: https://github.com/psobolewskiPhD/napari-docs/actions/runs/3725012413

Note that the extension allows for customization such as stripping out prompts, etc. but for now this is just the basics.
https://sphinx-copybutton.readthedocs.io/en/latest/index.html

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Fixes or improves existing content
- [x] Adds new feature
- [ ] Fixes or improves workflow, documentation build or deployment

# References
https://sphinx-copybutton.readthedocs.io/en/latest/index.html

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added [alt text](https://webaim.org/techniques/alttext/) to new images included in this PR