### PR TITLE
Update contributing docs for [dev] install change needing Qt backend install

### DIFF
--- a/docs/developers/contributing.md
+++ b/docs/developers/contributing.md
@@ -28,7 +28,7 @@ We recommend starting with a fresh Python virtual environment, using an environm
 [conda](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html) or [venv](https://docs.python.org/3/library/venv.html). Then, install the napari package
 in editable mode and all of the developer tools, along with a supported Qt backend. For example, for PyQt5, the default, you would use the following:
 ```sh
-pip install -e ".[pyqt, dev]"  # (quotes only needed for zsh shell)
+pip install -e ".[pyqt,dev]"  # (quotes only needed for zsh shell)
 ```
 
 If you want to use PySide2 instead, you would use:

--- a/docs/developers/contributing.md
+++ b/docs/developers/contributing.md
@@ -24,10 +24,24 @@ Set the `upstream` remote to the base `napari` repository:
 git remote add upstream https://github.com/napari/napari.git
 ```
 
-Install the package in editable mode, along with all of the developer tools
+We recommend starting with a fresh Python virtual environment, using an environment manager like
+[conda](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html) or [venv](https://docs.python.org/3/library/venv.html). Then, install the napari package
+in editable mode and all of the developer tools, along with a supported Qt backend. For example, for PyQt5, the default, you would use the following:
+```sh
+pip install -e ".[pyqt, dev]"  # (quotes only needed for zsh shell)
+```
+
+If you want to use PySide2 instead, you would use:
+```sh
+pip install -e ".[pyside, dev]"  # (quotes only needed for zsh shell)
+```
+
+Finally, if you already have a Qt backend installed or want to use an experimental one like Qt6 use:
 ```sh
 pip install -e ".[dev]"  # (quotes only needed for zsh shell)
 ```
+
+
 
 We use [`pre-commit`](https://pre-commit.com) to sort imports with
 [`isort`](https://github.com/PyCQA/isort), format code with

--- a/docs/developers/contributing.md
+++ b/docs/developers/contributing.md
@@ -33,7 +33,7 @@ pip install -e ".[pyqt,dev]"  # (quotes only needed for zsh shell)
 
 If you want to use PySide2 instead, you would use:
 ```sh
-pip install -e ".[pyside, dev]"  # (quotes only needed for zsh shell)
+pip install -e ".[pyside,dev]"  # (quotes only needed for zsh shell)
 ```
 
 Finally, if you already have a Qt backend installed or want to use an experimental one like Qt6 use:


### PR DESCRIPTION
# Description
This PR updates the contribution docs for the changes to the installation pattern to remove [all] from [dev]. This means that doing a `pip install -e .[dev]` will no longer install a Qt backend (currently pyqt5). As a result, a Qt backend needs to be installed along side [dev] or be pre-existing. The goal is to make it easier for people to test other Qt backends than pyqt5 or when using platforms that don't have pyqt5 wheels on pypi (e.g. macOS arm64).

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Fixes or improves existing content
- [ ] Adds new content page(s)
- [ ] Fixes or improves workflow, documentation build or deployment

# References
This is needed in pair with napari PR: https://github.com/napari/napari/pull/5438

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added [alt text](https://webaim.org/techniques/alttext/) to new images included in this PR