### PR TITLE
Fixes formatting for the contributing documentation section

### DIFF
--- a/docs/developers/documentation/index.md
+++ b/docs/developers/documentation/index.md
@@ -34,7 +34,7 @@ cd napari-docs/
 To reduce confusion and possible conflicts, the `docs` fork is being cloned into
 a local repository folder named `napari-docs`. Alternately, you could also
 rename the repository when forking `napari/docs`.
-```
+````
 
 - **If you wish to add/amend documentation that does not contain code, you will
   require a clean conda environment with napari docs dependencies installed.**


### PR DESCRIPTION
# Description
A backtick was missing in one of the "notes" blocks on the Contributing Documentation sections, and this was creating wrong formatting. This is also causing a few anchors in the rendered documentation to not be found, which in turn creates broken links. This can be seen in the "latest" version here: https://napari.org/dev/developers/documentation/index.html

Before:

![Screenshot_20221223_132900](https://user-images.githubusercontent.com/3949932/209368009-806842a2-dba3-4172-a454-21d460871260.png)

After:

![Screenshot_20221223_132926](https://user-images.githubusercontent.com/3949932/209368022-5ef1de20-da5f-4630-9c4b-24dceb9d04e6.png)


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Fixes or improves existing content
- [ ] Adds new content page(s)
- [ ] Fixes or improves workflow, documentation build or deployment

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added [alt text](https://webaim.org/techniques/alttext/) to new images included in this PR