### PR TITLE
Proposing hybrid npe1-npe2 plugins

### DIFF
--- a/docs/naps/6-contributable-menus.md
+++ b/docs/naps/6-contributable-menus.md
@@ -409,6 +409,11 @@ backward compatibility. -->
 This work does not have any backward compatibility considerations for
 existing features.
 
+To make the transition manageable for plugin-developers who used the 
+napari-tools-menu to structure their menus, it would be good to enable hybrid
+npe1-npe2 plugins for an intermediate period. 
+[See also #4708](https://github.com/napari/napari/issues/4708)
+
 In future, backward compatibility concerns could arise when a menu name/ID is
 changed in `napari`, or when `napari` removes a menu that was previously 
 contributable.


### PR DESCRIPTION
Hi all,

I just read NAP-6. Fantastic work @DragaDoncila et Al! Thanks working tthis.

Just a minor proposal from my side: consider enabling plugins using the napari-tools-menu (based on npe1) and menus using npe2 at the same time - for a temporary period. It would harm users otherwise if they are forced to do the update of their workflows instantly: imagine suddenly all menus are in different places and you can't find things anymore. It's an aspect of backwards compatibility and thus, I'm adding this to that section.

Let me know what you think! Thanks again.

Best,
Robert