### PR TITLE
Clarify arm64 macOS (Apple Silicon) installation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -94,7 +94,7 @@ you can install via pip, conda-forge, or from source.
 
 ### From pip, with "batteries included"
 
-napari can be installed on most macOS, Linux, and Windows systems with Python
+napari can be installed on most macOS (Intel x86), Linux, and Windows systems with Python
 {{ python_version_range }} using pip:
 
 ```sh
@@ -115,6 +115,9 @@ up a Python {{ python_version }} environment with `conda`:
 ````
 
 ### From conda
+
+Installation from conda-forge using conda or mamba is recommended for arm64 macOS machines
+(Apple Silicon):
 
 ```sh
 conda install -c conda-forge napari

--- a/docs/index.md
+++ b/docs/index.md
@@ -94,8 +94,8 @@ you can install via pip, conda-forge, or from source.
 
 ### From pip, with "batteries included"
 
-napari can be installed on most macOS (Intel x86), Linux, and Windows systems with Python
-{{ python_version_range }} using pip:
+napari can be installed on macOS (with older Intel x86 chips), Linux, and Windows systems
+with Python {{ python_version_range }} using pip:
 
 ```sh
 pip install "napari[all]"
@@ -116,7 +116,7 @@ up a Python {{ python_version }} environment with `conda`:
 
 ### From conda
 
-Installation from conda-forge using conda or mamba is recommended for arm64 macOS machines
+Installation from conda-forge using conda or mamba is required for newer, arm64 macOS machines
 (Apple Silicon):
 
 ```sh
@@ -149,7 +149,7 @@ scientific packages such as Spyder or matplotlib. If neither is available,
 running napari will result in an error message asking you to install one of
 them.
 
-Running `pip install "napari[all]"` will install the default framework – currently
+Running `pip install "napari[all]"` will install the default framework--currently
 PyQt5, but this could change in the future.
 
 To install napari with a specific framework, you can use:

--- a/docs/tutorials/fundamentals/installation.md
+++ b/docs/tutorials/fundamentals/installation.md
@@ -76,7 +76,7 @@ Choose one of the options below to install napari as a Python package.
 ````{admonition} **1. From pip**
 :class: dropdown
 
-napari can be installed on most macOS, Linux, and Windows systems with Python
+napari can be installed on most macOS (Intel x86), Linux, and Windows systems with Python
 {{ python_version_range }} using pip:
 
 ```sh
@@ -98,7 +98,8 @@ notation.)*
 :class: dropdown
 
 If you prefer to manage packages with conda, napari is available on the
-conda-forge channel. You can install it with:
+conda-forge channel. We also recommend this path for users of arm64 macOS machines
+(Apple Silicon). You can install it with:
 
 ```sh
 conda install -c conda-forge napari
@@ -183,6 +184,10 @@ pip install "napari[pyqt5]"    # for PyQt5
 # OR
 pip install "napari[pyside2]"  # for PySide2
 ```
+
+*(On arm64 macOS, it is the availability of wheels for these Qt5 backends via pip
+that is the problem. If you provide the backend, for example via conda from conda-forge,
+then you can `pip install napari`, but without the `[all]`.)*
 
 ```{note}
 If you switch backends, it's a good idea to `pip uninstall` the one

--- a/docs/tutorials/fundamentals/installation.md
+++ b/docs/tutorials/fundamentals/installation.md
@@ -99,7 +99,7 @@ notation.)*
 
 If you prefer to manage packages with conda, napari is available on the
 conda-forge channel. We also recommend this path for users of arm64 macOS machines
-(Apple Silicon). You can install it with:
+(Apple Silicon, meaning a processor with a name like "M1"). You can install it with:
 
 ```sh
 conda install -c conda-forge napari
@@ -173,8 +173,9 @@ scientific packages such as Spyder or matplotlib. If neither is available,
 running napari will result in an error message asking you to install one of
 them.
 
-Running `pip install "napari[all]"` will install the default framework – currently
-PyQt5, but this could change in the future.
+Running `pip install "napari[all]"` will install the default Qt framework, which is currently 
+PyQt5--but this could change in the future. (If you have a Mac with arm64 architecture (Apple
+Silicon), this will not work--see {ref}`note-m1`.)
 
 To install napari with a specific framework, you can use:
 
@@ -185,9 +186,15 @@ pip install "napari[pyqt5]"    # for PyQt5
 pip install "napari[pyside2]"  # for PySide2
 ```
 
-*(On arm64 macOS, it is the availability of wheels for these Qt5 backends via pip
-that is the problem. If you provide the backend, for example via conda from conda-forge,
-then you can `pip install napari`, but without the `[all]`.)*
+```{note}
+:name: note-m1
+
+For arm64 macOS machines (Apple Silicon), pre-compiled PyQt5 or PySide2
+[wheels](https://realpython.com/python-wheels/) are not available on 
+[PyPI](https://pypi.org), so trying to `pip install napari[all]` or either of
+the variants above will fail. However, you can install one of those libraries separately,
+for example from `conda-forge`, and then use `pip install napari`.
+```
 
 ```{note}
 If you switch backends, it's a good idea to `pip uninstall` the one

--- a/docs/tutorials/fundamentals/installation.md
+++ b/docs/tutorials/fundamentals/installation.md
@@ -174,8 +174,8 @@ running napari will result in an error message asking you to install one of
 them.
 
 Running `pip install "napari[all]"` will install the default Qt framework, which is currently 
-PyQt5--but this could change in the future. (If you have a Mac with arm64 architecture (Apple
-Silicon), this will not work--see {ref}`note-m1`.)
+PyQt5--but this could change in the future. However, if you have a Mac with the newer arm64
+architecture (Apple Silicon), this will not work--see {ref}`note-m1`.
 
 To install napari with a specific framework, you can use:
 
@@ -189,11 +189,12 @@ pip install "napari[pyside2]"  # for PySide2
 ```{note}
 :name: note-m1
 
-For arm64 macOS machines (Apple Silicon), pre-compiled PyQt5 or PySide2
-[wheels](https://realpython.com/python-wheels/) are not available on 
-[PyPI](https://pypi.org), so trying to `pip install napari[all]` or either of
-the variants above will fail. However, you can install one of those libraries separately,
-for example from `conda-forge`, and then use `pip install napari`.
+For arm64 macOS machines (Apple Silicon), pre-compiled PyQt5 or PySide2 packages
+([wheels](https://realpython.com/python-wheels/)) are not available on 
+[PyPI](https://pypi.org), the repository used by `pip`, so trying to 
+`pip install napari[all]` or either of the variants above will fail. However, 
+you can install one of those libraries separately, for example from `conda-forge`,
+and then use `pip install napari`.
 ```
 
 ```{note}

--- a/docs/tutorials/fundamentals/quick_start.md
+++ b/docs/tutorials/fundamentals/quick_start.md
@@ -58,7 +58,7 @@ You will also see some examples of plugins. The core napari viewer focuses on do
 
 - For those familiar with Python:
 
-    napari can be installed on most macOS, Linux, and Windows systems with Python {{ python_version_range }} using pip.
+    napari can be installed on most macOS (Intel x86), Linux, and Windows systems with Python {{ python_version_range }} using pip.
 
     First, create a clean virtual environment:
 


### PR DESCRIPTION
# Description

This PR provides the basic update for installation on arm64 macOS (Apple Silicon).
`pip install napari[all]` doesn't work on this platform due to the lack of pyqt5 wheels on pypi (likewise with pyside2). As a result, I think we should just recommend conda and conda-forge. So this is what I've done here.
In the section regarding Qt backends, I clarify the above issue and note that if you provide the backend (e.g. via conda-forge) you can `pip install napari`.
I'm very open to suggestions for how to better handle that.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Fixes or improves existing content
- [ ] Adds new content page(s)
- [ ] Fixes or improves workflow, documentation build or deployment

# References

closes #43 

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added [alt text](https://webaim.org/techniques/alttext/) to new images included in this PR