### PR TITLE
Move napari workshop template link to top of page

### DIFF
--- a/docs/further-resources/napari-workshops.md
+++ b/docs/further-resources/napari-workshops.md
@@ -7,7 +7,7 @@ This page contains a list, to make them easier to find online.
 You can find more videos of talks, tutorials and demos on the
 [napari youtube channel](https://www.youtube.com/channel/UCbTgw84ew4pxTJ9qu3W2hqg/playlists).
 
-```{note}
+```{admonition} Got a workshop?
 If you are looking to create your own workshop, you can use the
 [napari workshop template](https://github.com/napari/napari-workshop-template)
 as a starting point.

--- a/docs/further-resources/napari-workshops.md
+++ b/docs/further-resources/napari-workshops.md
@@ -7,6 +7,19 @@ This page contains a list, to make them easier to find online.
 You can find more videos of talks, tutorials and demos on the
 [napari youtube channel](https://www.youtube.com/channel/UCbTgw84ew4pxTJ9qu3W2hqg/playlists).
 
+### napari workshop template
+
+If you are looking to create your own workshop, you can use the
+[napari workshop template](https://github.com/napari/napari-workshop-template)
+as a starting point.
+
+### Add your own workshop to this list
+
+If you have organized a napari workshop and would like to see it featured here
+in this page, you can
+[send a Pull Request to the napari/docs repository](../developers/documentation/index.md)
+or contact the core developers on [zulip chat](https://napari.zulipchat.com/login/).
+
 ## Workshops
 
 *Workshops are listed from newest to oldest.*
@@ -52,16 +65,3 @@ You can find more videos of talks, tutorials and demos on the
 * June 2020, [NEUBIAS Academy@Home workshop](http://eubias.org/NEUBIAS/training-schools/neubias-academy-home/neubias-academy-archive-spring2020/)
   * [Watch it here](https://www.youtube.com/watch?v=VgvDSq5aCDQ) (1 hour and 30 minute video)
   * [Workshop materials available here](https://github.com/sofroniewn/napari-training-course)
-
-### Add your own workshop to this list
-
-If you have organized a napari workshop and would like to see it featured here
-in this page, you can
-[send a Pull Request to the napari/docs repository](../developers/documentation/index.md)
-or contact the core developers on [zulip chat](https://napari.zulipchat.com/login/).
-
-### napari workshop template
-
-If you are looking to create your own workshop, you can use the
-[napari workshop template](https://github.com/napari/napari-workshop-template)
-as a starting point.

--- a/docs/further-resources/napari-workshops.md
+++ b/docs/further-resources/napari-workshops.md
@@ -7,18 +7,16 @@ This page contains a list, to make them easier to find online.
 You can find more videos of talks, tutorials and demos on the
 [napari youtube channel](https://www.youtube.com/channel/UCbTgw84ew4pxTJ9qu3W2hqg/playlists).
 
-### napari workshop template
-
+```{note}
 If you are looking to create your own workshop, you can use the
 [napari workshop template](https://github.com/napari/napari-workshop-template)
 as a starting point.
-
-### Add your own workshop to this list
 
 If you have organized a napari workshop and would like to see it featured here
 in this page, you can
 [send a Pull Request to the napari/docs repository](../developers/documentation/index.md)
 or contact the core developers on [zulip chat](https://napari.zulipchat.com/login/).
+```
 
 ## Workshops
 


### PR DESCRIPTION
# Description
Moves information about the napari workshop template (and how to include workshops to the list) to the top of the Workshops page.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Fixes or improves existing content
- [ ] Adds new content page(s)
- [ ] Fixes or improves workflow, documentation build or deployment

# References
Closes #88 

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added [alt text](https://webaim.org/techniques/alttext/) to new images included in this PR