### PR TITLE
Update deploy_docs.yml to use metadata to use proper napari version substitution

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -30,6 +30,8 @@ jobs:
           path: napari-repo
           ref: main
           repository: napari/napari
+          # ensure version metadata is proper
+          fetch-depth: 0
 
       - name: Copy examples to docs folder
         run: |


### PR DESCRIPTION
# Description

See https://github.com/napari/napari/issues/5509#issuecomment-1406238725
The docs live on napari.org don't match PR action downloaded docs when doing napari version substitution (https://github.com/napari/docs/pull/51)

Live, napari.org docs:
![](https://user-images.githubusercontent.com/76622105/215032279-e651309b-378e-4b16-adb7-78ce0cb3298e.png)


PR built docs, download zip:
![](https://user-images.githubusercontent.com/76622105/215052126-93ff21a3-73b1-4af6-b7b7-ae5efb5dfdf1.png)


This PR updates the deploy action with `fetch-depth: 0` that was added to the PR `build_docs` action. This should make the version metadata be correct (see https://github.com/pypa/setuptools_scm/issues/480)

<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new content, improvement, or fix! -->
<!-- If you can, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Fixes or improves existing content
- [ ] Adds new content page(s)
- [ ] Fixes or improves workflow, documentation build or deployment

# References

Adresses issue noted here https://github.com/napari/napari/issues/5509#issuecomment-1406238725

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added [alt text](https://webaim.org/techniques/alttext/) to new images included in this PR


I'm not sure how to test this or check that it's correct, because the issue is already fixed in PR builds.