### PR TITLE
change blob example to be self contained

### DIFF
--- a/docs/howtos/layers/labels.md
+++ b/docs/howtos/layers/labels.md
@@ -143,6 +143,8 @@ browse volumetric timeseries data and other high dimensional data.
 
 ```{code-cell} python
 :tags: [remove-output]
+import napari
+from skimage import data
 from scipy import ndimage as ndi
 
 blobs = data.binary_blobs(length=128, volume_fraction=0.1, n_dim=3)


### PR DESCRIPTION
# Description
Currently  for running the blob example, one need to import 2 other modules, they were indeed imported in the previous code, but I think it is better to have this example self-contained as this is a tutorial. Also, because the screenshot does not correspond to the output of running both examples one after the other. Thanks

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Fixes or improves existing content
- [x] Fixes or improves workflow, documentation build or deployment

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
