### PR TITLE
Change `CIRCLECI_TOKEN` to `GITHUB_TOKEN` in `circleci.yml`  workflow file. 

### DIFF
--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: GitHub Action step
         uses: larsoner/circleci-artifacts-redirector-action@master
         with:
-          repo-token: ${{ secrets.CIRCLECI_TOKEN }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
           artifact-path: 0/docs/_build/index.html
           circleci-jobs: build-docs
           job-title: Check the rendered docs here!


### PR DESCRIPTION
# Description

Close #107
Switches to use the default GITHUB_TOKEN rather than making adding a new CIRCLECI_TOKEN
This makes the workflow match the README of the action:
[larsoner/circleci-artifacts-redirector-action](https://github.com/larsoner/circleci-artifacts-redirector-action)
This is also used commonly in other repos, see for example numpy/numpy:
[numpy/numpy@1426570/.github/workflows/circleci.yml#L18](https://github.com/numpy/numpy/blob/14265704f6fb3b77ca2739329d35ff49293d26df/.github/workflows/circleci.yml#L18)

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Fixes or improves existing content

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added [alt text](https://webaim.org/techniques/alttext/) to new images included in this PR