### PR TITLE
Update version switcher json

### DIFF
--- a/docs/_static/version_switcher.json
+++ b/docs/_static/version_switcher.json
@@ -5,9 +5,14 @@
 		"url": "https://napari.org/dev/"
 	},
 	{
-		"name": "stable",
-		"version": "0.4.16",
+		"name": "stable (0.4.17)",
+		"version": "0.4.17",
 		"url": "https://napari.org/stable/"
+	},
+	{
+		"name": "0.4.16",
+		"version": "0.4.16",
+		"url": "https://napari.org/0.4.16/"
 	},
 	{
 		"name": "0.4.15",

--- a/docs/_static/version_switcher.json
+++ b/docs/_static/version_switcher.json
@@ -8,7 +8,7 @@
 		"name": "stable",
 		"version": "0.4.16",
 		"url": "https://napari.org/stable/"
-	}
+	},
 	{
 		"name": "0.4.15",
 		"version": "0.4.15",


### PR DESCRIPTION
I have to say I don't understand why anything in the site version switcher is working currently given the status of the version switcher json... @melissawm Any thoughts? Is this version not uploaded to the deployed repo? At any rate, this makes it correct. (I added the version number to the "stable" name as I think it's handy.)

