### PR TITLE
Installation: Add libmamba solver to conda Note

### DIFF
--- a/docs/tutorials/fundamentals/installation.md
+++ b/docs/tutorials/fundamentals/installation.md
@@ -129,18 +129,20 @@ For example, use {{ python_version_code }} to get Python {{ python_version }} an
 the current release.
 
 2. Switching to the new, faster [`libmamba` solver](https://conda.github.io/conda-libmamba-solver/libmamba-vs-classic/), 
-by updating your `conda` (>22.11) and installing the solver, as follows:
+by updating your `conda` (>22.11), if needed, and then installing and activating 
+the solver, as follows:
 ```
 conda update -n base conda
 conda install -n base conda-libmamba-solver
 conda config --set solver libmamba
 ```
-3. Installing [`mamba`](https://github.com/mamba-org/mamba) in your base
-environment with `conda install -n base -c conda-forge mamba`. Then you can use `mamba`
-by replacing `conda` with `mamba` in the installation instructions, for example:
+3. Alternately, consider installing [`mamba`](https://github.com/mamba-org/mamba)
+in your base environment with `conda install -n base -c conda-forge mamba`. 
+Then you can use `mamba` by replacing `conda` with `mamba` in the installation instructions, for example:
 ```
 mamba install napari
 ```
+
 ````
 
 

--- a/docs/tutorials/fundamentals/installation.md
+++ b/docs/tutorials/fundamentals/installation.md
@@ -122,14 +122,25 @@ conda install -c conda-forge "napari=*=*pyside2"
 In some cases, `conda`'s default solver can struggle to find out which packages need to be
 installed for napari. If it takes too long or you get the wrong version of napari
 (see below), consider:
-1. Overriding your default channels to use only `conda-forge` by adding `--override-channels`
-and specifying the napari and Python versions explicitly. For example, use {{ python_version_code }}
-to get Python {{ python_version }} and {{ napari_conda_version }} to specify the napari version as
-{{ napari_version }}, the current release.
+1. Overriding your default channels to use only `conda-forge` by adding
+`--override-channels` and specifying the napari and Python versions explicitly. 
+For example, use {{ python_version_code }} to get Python {{ python_version }} and
+{{ napari_conda_version }} to specify the napari version as {{ napari_version }}, 
+the current release.
 
-2. You can try installing [`mamba`](https://github.com/mamba-org/mamba) in your base
-environment with `conda install -n base -c conda-forge mamba` and use its faster solver
-by replacing `conda` for `mamba` in the above instructions.
+2. Switching to the new, faster [`libmamba` solver](https://conda.github.io/conda-libmamba-solver/libmamba-vs-classic/), 
+by updating your `conda` (>22.11) and installing the solver, as follows:
+```
+conda update -n base conda
+conda install -n base conda-libmamba-solver
+conda config --set solver libmamba
+```
+3. Installing [`mamba`](https://github.com/mamba-org/mamba) in your base
+environment with `conda install -n base -c conda-forge mamba`. Then you can use `mamba`
+by replacing `conda` with `mamba` in the installation instructions, for example:
+```
+mamba install napari
+```
 ````
 
 


### PR DESCRIPTION
# Description

Add mention of using regular conda but with the `libmamba` solver, as a way to resolve installation issues. See https://conda.github.io/conda-libmamba-solver/libmamba-vs-classic/
Currently, we suggest mamba. This works well, but breaks copy-paste of `conda install ...` and other instructions. Changing the solver gives much of the benefit, without needing to change the command.
See discussion at: https://github.com/napari/napari/issues/5509
 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Fixes or improves existing content
- [ ] Adds new content page(s)
- [ ] Fixes or improves workflow, documentation build or deployment

# References
closes https://github.com/napari/docs/issues/96

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added [alt text](https://webaim.org/techniques/alttext/) to new images included in this PR