### PR TITLE
Add matplotlib image scraper for gallery

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -220,7 +220,7 @@ sphinx_gallery_conf = {
     'download_all_examples': False,
     'min_reported_time': 10,
     'only_warn_on_example_error': True,
-    'image_scrapers': (qtgallery.qtscraper,),
+    'image_scrapers': ("matplotlib", qtgallery.qtscraper,),
     'reset_modules': (reset_napari_theme,),
     'reference_url': {'napari': None},
     'within_subsection_order': ExampleTitleSortKey,


### PR DESCRIPTION
# Description
As described in #129, adding this scraper allows the use of matplotlib to create plots, etc. in gallery examples.

## Type of change
- [x] Fixes or improves workflow, documentation build or deployment

# References
closes #129 

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [alt text](https://webaim.org/techniques/alttext/) to new images included in this PR