### PR TITLE
Add instructions on how to use docs-xvfb

### DIFF
--- a/docs/developers/documentation/index.md
+++ b/docs/developers/documentation/index.md
@@ -203,9 +203,9 @@ your pull request.
 
 ### 3.1. Building locally
 
-To build the documentation locally, run `make docs` from the root of your local
-clone of the `napari/docs` repository (assuming you've installed the
-[docs prerequisites](#prerequisites)).
+To build the documentation locally from scratch, run `make docs` from the root
+of your local clone of the `napari/docs` repository (assuming you've installed
+the [docs prerequisites](#prerequisites)).
 
 ```bash
 make docs
@@ -258,7 +258,7 @@ There's another `make` task you can use for live previews while editing docs:
 ```shell
 $ make html-live
 # or for faster reloads:
-# make html-live SPHINXOPTS="-j4"
+$ make html-live SPHINXOPTS="-j4"
 ```
 
 The first run will take a bit longer and a few napari instances will pop up
@@ -269,6 +269,19 @@ no need for further action! Edit the documents at will, and the browser will
 auto-reload.
 Once you are done with the live previews, you can exit via <kbd>Ctrl</kbd>+<kbd>C</kbd>
 on your terminal.
+````
+
+````{tip}
+If you have [xvfb](https://www.x.org/releases/X11R7.6/doc/man/man1/Xvfb.1.xhtml)
+installed on your system, you can also run a "headless GUI" build by using the
+`docs-xvfb` command:
+
+```shell
+$ make docs-xvfb
+```
+
+This will prevent all but the first napari window to be shown during the docs
+build.
 ````
 
 ### 3.2. Use the CI artifacts

--- a/docs/developers/documentation/index.md
+++ b/docs/developers/documentation/index.md
@@ -280,7 +280,7 @@ installed on your system, you can also run a "headless GUI" build by using the
 $ make docs-xvfb
 ```
 
-This will prevent all but the first napari window to be shown during the docs
+This will prevent all but the first napari window from being shown during the docs
 build.
 ````
 


### PR DESCRIPTION
# Description
Adds a note on how to use docs-xvfb for faster/less annoying docs builds :)

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Fixes or improves existing content
- [ ] Adds new content page(s)
- [ ] Fixes or improves workflow, documentation build or deployment

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added [alt text](https://webaim.org/techniques/alttext/) to new images included in this PR