### PR TITLE
Update URL of version switcher

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -83,7 +83,7 @@ tags_extension = ["md", "rst"]
 html_theme = 'napari'
 
 # Define the json_url for our version switcher.
-json_url = "https://napari.org/version_switcher.json"
+json_url = "https://napari.org/dev/_static/version_switcher.json"
 
 if version == "dev":
     version_match = "latest"


### PR DESCRIPTION
# Description
Updates URL of version switcher to use https://napari.org/dev/_static/version_switcher.json

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Fixes or improves existing content
- [ ] Adds new content page(s)
- [x] Fixes or improves workflow, documentation build or deployment

# References
This is a follow-up on #109.

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added [alt text](https://webaim.org/techniques/alttext/) to new images included in this PR