### PR TITLE
Fix version switcher URL for the latest docs version

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -98,7 +98,7 @@ html_theme_options = {
     "navbar_start": ["navbar-project"],
     "navbar_end": ["version-switcher", "navbar-icon-links"],
     "switcher": {
-        "json_url": "https://napari.org/version_switcher.json",
+        "json_url": json_url,
         "version_match": version_match,
     },
 }


### PR DESCRIPTION
# Description

Fixes the link to the version switcher json file for the latest version of the docs. 

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Fixes or improves existing content
- [ ] Adds new content page(s)
- [x] Fixes or improves workflow, documentation build or deployment

# References
No issue, but flagged by @kandarpksk - thanks!

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added [alt text](https://webaim.org/techniques/alttext/) to new images included in this PR