### PR TITLE
Docs for adding LayerData tuple to viewer

### DIFF
--- a/docs/plugins/_layer_data_guide.md
+++ b/docs/plugins/_layer_data_guide.md
@@ -118,3 +118,14 @@ Out[7]:
     'image'
 )
 ```
+
+### Adding to the viewer
+
+To add a `LayerData` tuple to the napari viewer, use :meth:`Layer.create`:
+
+```python
+>>> image_layer_data = (data, {'name': 'My Image', 'colormap': 'red'}, 'image')
+>>> viewer = napari.current_viewer()
+>>> viewer.add_layer(napari.layers.Layer.create(*image_layer_data))
+```
+The only attribute that can't be passed to `napari.layers.Layer.create` that is otherwise valid for a `LayerData` tuple is 'channel_axis'.


### PR DESCRIPTION
# Description
This adds some short docs for adding a LayerData tuple to the napari viewer. Replaces https://github.com/napari/napari/pull/4711.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Fixes or improves existing content
- [ ] Adds new content page(s)
- [ ] Fixes or improves workflow, documentation build or deployment

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added [alt text](https://webaim.org/techniques/alttext/) to new images included in this PR