### PR TITLE
Update README to display CZI logo for dark and light GitHub themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,4 +37,7 @@ the bug report template. If you think something isn't working, don't hesitate to
 
 ## institutional and funding partners
 
-![Chan Zuckerberg Initiative logo](https://chanzuckerberg.com/wp-content/themes/czi/img/logo.svg)
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://chanzuckerberg.com/wp-content/themes/czi/img/logo-white.svg">
+  <img alt="CZI logo" src="https://chanzuckerberg.com/wp-content/themes/czi/img/logo.svg">
+</picture>


### PR DESCRIPTION
# Description
- Currently the CZI logo in the README is not clear with the GitHub dark theme.
  ![image](https://github.com/napari/docs/assets/871137/795bdd1b-ed57-40ba-9b8a-e45f9fd1d3bc)

- [x] Updated the README with HTML to display the CZI logo based on the GitHub theme. The GitHub documentation linked below describes this feature.
  - [x] Light theme
    ![image](https://github.com/napari/docs/assets/871137/6d3df65a-46b6-4e98-a3a0-b79c798fe927)

  - [x] Dark theme
    ![image](https://github.com/napari/docs/assets/871137/4903e0f6-c5f1-4774-98f5-ab54bcb859bf)

## Type of change
- [x] Fixes or improves existing content

# References
- [GitHub Docs - Specifying the theme an image is shown to](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#specifying-the-theme-an-image-is-shown-to)
- Identical fix in the `napari/napari` repo: https://github.com/napari/napari/pull/5800

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] n/a I have commented my code, particularly in hard-to-understand areas
- [x] I have added [alt text](https://webaim.org/techniques/alttext/) to new images included in this PR