### PR TITLE
[Maint] Use pyqt for CircleCI docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
           name: Install napari-dev
           command: |
             . venv/bin/activate
-            python -m pip install -e napari/".[pyside,dev]" -c "napari/resources/constraints/constraints_py3.10.txt"
+            python -m pip install -e napari/".[pyqt,dev]" -c "napari/resources/constraints/constraints_py3.10.txt"
       - run:
           name: Build docs
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,8 +52,7 @@ jobs:
           name: Build docs
           command: |
             . venv/bin/activate
-            python -m pip install -r requirements.txt
-            xvfb-run --auto-servernum make docs-build GALLERY_PATH=../napari/examples/
+            xvfb-run --auto-servernum make docs GALLERY_PATH=../napari/examples/
       - store_artifacts:
           path: docs/_build/
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,6 @@ jobs:
             python -m venv venv
             . venv/bin/activate
             python -m pip install --upgrade pip
-            python -m pip install -r requirements.txt
       - run:
           name: Clone main repo
           command: git clone git@github.com:napari/napari.git napari
@@ -53,6 +52,7 @@ jobs:
           name: Build docs
           command: |
             . venv/bin/activate
+            python -m pip install -r requirements.txt
             xvfb-run --auto-servernum make docs-build GALLERY_PATH=../napari/examples/
       - store_artifacts:
           path: docs/_build/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
           name: Install napari-dev
           command: |
             . venv/bin/activate
-            python -m pip install -e napari/".[pyqt,dev]" -c "napari/resources/constraints/constraints_py3.10.txt"
+            python -m pip install -e napari/".[pyqt,dev]" -c "napari/resources/constraints/constraints_py3.9.txt"
       - run:
           name: Build docs
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
           name: Install napari-dev
           command: |
             . venv/bin/activate
-            python -m pip install -e napari/".[pyqt,dev]" -c "napari/resources/constraints/constraints_py3.9.txt"
+            python -m pip install "napari/[all]" -c "napari/resources/constraints/constraints_py3.10.txt"
       - run:
           name: Build docs
           command: |


### PR DESCRIPTION
# Description

In CircleCI previews, the Gallery is broken. The errors appear to be related to pyside.
The regular artifact (.zip) is fine, but it's built using pyqt, so here I change CircleCI to also use pyqt as a possible fix.



## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Fixes or improves existing content
- [ ] Adds new content page(s)
- [x] Fixes or improves workflow, documentation build or deployment

# References


## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added [alt text](https://webaim.org/techniques/alttext/) to new images included in this PR