### PR TITLE
Pin npe2 version to match installed one

### DIFF
--- a/docs/_scripts/prep_docs.py
+++ b/docs/_scripts/prep_docs.py
@@ -23,7 +23,7 @@ def prep_npe2():
     check_call(f"rm -rf {NPE}".split())
     check_call(f"git clone https://github.com/napari/npe2 {NPE}".split())
     if not parse(npe2_version).is_devrelease:
-        check_call(f"git checkout tags/v{npe2_version}".split(), cwd="npe2")
+        check_call(f"git checkout tags/v{npe2_version}".split(), cwd=NPE)
     check_call([sys.executable, f"{NPE}/_docs/render.py", DOCS / 'plugins'])
     check_call(f"rm -rf {NPE}".split())
 

--- a/docs/_scripts/prep_docs.py
+++ b/docs/_scripts/prep_docs.py
@@ -7,6 +7,8 @@ import sys
 from pathlib import Path
 from importlib.metadata import version
 
+from packaging.version import parse
+
 DOCS = Path(__file__).parent.parent.absolute()
 NPE = DOCS.parent.absolute() / 'npe2'
 
@@ -20,7 +22,8 @@ def prep_npe2():
 
     check_call(f"rm -rf {NPE}".split())
     check_call(f"git clone https://github.com/napari/npe2 {NPE}".split())
-    check_call(f"git checkout tags/v{npe2_version}".split(), cwd="npe2")
+    if not parse(npe2_version).is_devrelease:
+        check_call(f"git checkout tags/v{npe2_version}".split(), cwd="npe2")
     check_call([sys.executable, f"{NPE}/_docs/render.py", DOCS / 'plugins'])
     check_call(f"rm -rf {NPE}".split())
 

--- a/docs/_scripts/prep_docs.py
+++ b/docs/_scripts/prep_docs.py
@@ -5,16 +5,22 @@ from which this script will be called.
 """
 import sys
 from pathlib import Path
+from importlib.metadata import version
 
 DOCS = Path(__file__).parent.parent.absolute()
 NPE = DOCS.parent.absolute() / 'npe2'
 
 def prep_npe2():
     #   some plugin docs live in npe2 for testing purposes
+    if NPE.exists():
+        return
     from subprocess import check_call
+
+    npe2_version = version("npe2")
 
     check_call(f"rm -rf {NPE}".split())
     check_call(f"git clone https://github.com/napari/npe2 {NPE}".split())
+    check_call(f"git checkout tags/v{npe2_version}".split(), cwd="npe2")
     check_call([sys.executable, f"{NPE}/_docs/render.py", DOCS / 'plugins'])
     check_call(f"rm -rf {NPE}".split())
 


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new content, improvement, or fix! -->
<!-- If you can, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->
<!-- You can also see a preview of the documentation changes you are submitting by clicking on "Details" to the right of the "Check the rendered docs here!" check on your PR.-->

The https://github.com/napari/npe2/pull/294 breaks the docs building as we use the most recent npe2 repository, not matching npe2 version. In this PR I add `git checkout call` to have the npe2 repository cloned in a version matching the installed npe2 version. 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Fixes or improves existing content
- [ ] Adds new content page(s)
- [ ] Fixes or improves workflow, documentation build or deployment

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added [alt text](https://webaim.org/techniques/alttext/) to new images included in this PR