### PR TITLE
Try to use herbstluftwm in CircleCI to fix gallery

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,9 +52,12 @@ jobs:
           name: Build docs
           command: |
             . venv/bin/activate
-            herbstluftwm &
+            export DISPLAY=:99.0
+            /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render
+            sleep 3
+            "herbstluftwm &"
             sleep 1
-            xvfb-run --auto-servernum make docs GALLERY_PATH=../napari/examples/
+            make docs GALLERY_PATH=../napari/examples/
       - store_artifacts:
           path: docs/_build/
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,8 @@ jobs:
           name: Build docs
           command: |
             . venv/bin/activate
-            herbstluftwm
+            herbstluftwm &
+            sleep 1
             xvfb-run --auto-servernum make docs GALLERY_PATH=../napari/examples/
       - store_artifacts:
           path: docs/_build/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
       - checkout
       - run:
           name: Install qt libs + xvfb
-          command: sudo apt-get update && sudo apt-get install -y xvfb libegl1 libdbus-1-3 libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0 x11-utils
+          command: sudo apt-get update && sudo apt-get install -y xvfb herbstluftwm libegl1 libdbus-1-3 libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0 x11-utils
 
       - run:
           name: Install python dependencies
@@ -40,7 +40,6 @@ jobs:
             python -m venv venv
             . venv/bin/activate
             python -m pip install --upgrade pip
-            python -m pip install -r requirements.txt
       - run:
           name: Clone main repo
           command: git clone git@github.com:napari/napari.git napari
@@ -53,7 +52,8 @@ jobs:
           name: Build docs
           command: |
             . venv/bin/activate
-            xvfb-run --auto-servernum make docs-build GALLERY_PATH=../napari/examples/
+            herbstluftwm
+            xvfb-run --auto-servernum make docs GALLERY_PATH=../napari/examples/
       - store_artifacts:
           path: docs/_build/
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
             export DISPLAY=:99.0
             /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render
             sleep 3
-            "herbstluftwm &"
+            /usr/bin/herbstluftwm &
             sleep 1
             make docs GALLERY_PATH=../napari/examples/
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
       - checkout
       - run:
           name: Install qt libs + xvfb
-          command: sudo apt-get update && sudo apt-get install -y xvfb herbstluftwm libegl1 libdbus-1-3 libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0 x11-utils
+          command: sudo apt-get update && sudo apt-get install -y xvfb herbstluftwm x11-xserver-utils libegl1 libdbus-1-3 libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0 x11-utils
 
       - run:
           name: Install python dependencies


### PR DESCRIPTION
# Description
In CircleCI previews, the Gallery is broken. The errors appear to be related to pyside.
The normal build on Github works, but it uses a different xvfb setup and herbstluftwm.
Some googling suggests that maybe herbstluftwm is the key, so trying here.

## Type of change
- [x] Fixes or improves existing content

# References
Closes https://github.com/napari/docs/issues/174

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
