### PR TITLE
Add extra note for Windows and Make to avoid running `rm -rf C:\Users`

### DIFF
--- a/docs/developers/documentation/index.md
+++ b/docs/developers/documentation/index.md
@@ -407,6 +407,15 @@ help you edit your document and find the right spot!
 
 ## Building the documentation on Windows
 
+```{note}
+It is very important that you clone the `napari/docs` repository to a path that does not contain spaces.
+For example, `C:\Users\myusername\Documents\GitHub\napari-docs` is a valid path, but \
+`C:\Users\my username\Documents\GitHub\napari-docs` is not.
+If you clone the napari-docs repository to a directory following the default Windows path naming convention, e.g. \
+`C:\Users\my username\Documents\GitHub\napari-docs` (note the space), and run the `make` commands to build the napari docs, it may remove unintended files from your computer as it will essentially run the command `rm -rf C:\Users`.
+This is because the napari documentation is built using `make` which does not work on paths which contain spaces.
+```
+
 The documentation build requires some Linux specific commands, so some extra steps are required to build the documentation on Windows. There are multiple tools for this, but [Git Bash](https://gitforwindows.org/) or [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install) are recommended.
 
 ### Git Bash


### PR DESCRIPTION
# Description
We've added instructions to build the docs on Windows, but if you skip straight to that section and follow the guides for Git Bash, you could end up a bit frustrated.
The default Windows path naming for user profiles with spaces is like `C:\Users\First Last\...`, so if you cloned napari to a subdirectory of that and ran `make docs`, there is a chance that (as happened to me), the command `rm -rf C:\Users` is run by the makefile.
This is just because the handling of spaces is really weird in Make.

I've added a duplicate of the note nearer the top of the page about Make and spaces to reiterate this for Windows users, and I've tried to stress the severity of it.
I'm open to other thoughts here, but I'd really feel bad if someone went straight to the Windows build docs and ended up running `rm -rf C:\Users`.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Fixes or improves existing content