### PR TITLE
Update version_switcher.json FOR 0.4.18

### DIFF
--- a/docs/_static/version_switcher.json
+++ b/docs/_static/version_switcher.json
@@ -5,9 +5,14 @@
 		"url": "https://napari.org/dev/"
 	},
 	{
-		"name": "stable (0.4.17)",
-		"version": "0.4.17",
+		"name": "stable (0.4.18)",
+		"version": "0.4.18",
 		"url": "https://napari.org/stable/"
+	},
+	{
+		"name": "0.4.17",
+		"version": "0.4.17",
+		"url": "https://napari.org/0.4.17/"
 	},
 	{
 		"name": "0.4.16",


### PR DESCRIPTION
# Description

Adds 0.4.18 to the dev version switcher.
This won't fix anything per se right now, but could matter if we deploy again?

## Type of change
- [x] Fixes or improves existing content

# References
https://github.com/napari/napari.github.io/pull/384

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
