### PR TITLE
Move contributing resources to top-level navbar

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -112,33 +112,34 @@ subtrees:
       - file: community/governance
       - file: community/working_groups
       - file: community/meeting_schedule
-      - file: developers/index
+      - file: community/licensing
+  - file: developers/index
+    subtrees:
+    - entries:
+      - file: developers/contributing
+      - file: naps/index
+        subtrees:
+        - maxdepth: 1
+          entries:
+          - file: naps/0-nap-process
+          - file: naps/1-institutional-funding-partners
+          - file: naps/2-conda-based-packaging
+          - file: naps/3-spaces
+          - file: naps/4-async-slicing
+          - file: naps/5-new-logo
+          - file: naps/6-contributable-menus
+          - file: naps/7-key-binding-dispatch
+      - file: developers/documentation/index
         subtrees:
         - entries:
-          - file: developers/contributing
-          - file: naps/index
-            subtrees:
-            - maxdepth: 1
-              entries:
-              - file: naps/0-nap-process
-              - file: naps/1-institutional-funding-partners
-              - file: naps/2-conda-based-packaging
-              - file: naps/3-spaces
-              - file: naps/4-async-slicing
-              - file: naps/5-new-logo
-              - file: naps/6-contributable-menus
-              - file: naps/7-key-binding-dispatch
-          - file: developers/documentation/index
-            subtrees:
-            - entries:
-              - file: developers/documentation/docs_template
-          - file: developers/translations
-          - file: developers/core_dev_guide
-          - file: developers/release
-          - file: developers/testing
-          - file: developers/profiling
-          - file: developers/benchmarks
-          - file: developers/packaging
+          - file: developers/documentation/docs_template
+      - file: developers/translations
+      - file: developers/core_dev_guide
+      - file: developers/release
+      - file: developers/testing
+      - file: developers/profiling
+      - file: developers/benchmarks
+      - file: developers/packaging
       - file: release/index
         subtrees:
         - entries:
@@ -191,7 +192,6 @@ subtrees:
           - file: roadmaps/0_4
           - file: roadmaps/0_3_retrospective
           - file: roadmaps/0_3
-      - file: community/licensing
   - file: api/index
     subtrees:
     - titlesonly: True

--- a/docs/developers/index.md
+++ b/docs/developers/index.md
@@ -1,7 +1,6 @@
 # Contributing
 
-Here you can find resources about the contributing workflow, governance of the
-project and the onboarding of new contributors.
+Here you can find resources about the contributing workflow for both code to napari core and documentation of the project, as well as information for onboarding of new core developers.
 
 ## For contributors
 

--- a/docs/developers/index.md
+++ b/docs/developers/index.md
@@ -1,4 +1,4 @@
-# Contributing resources
+# Contributing
 
 Here you can find resources about the contributing workflow, governance of the
 project and the onboarding of new contributors.


### PR DESCRIPTION
# Description
This PR moves the "Contributing" toctree to the top level navbar.

This has been discussed before, but we don't have an issue for it.

cc @jni @psobolewskiPhD 

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Fixes or improves existing content
- [ ] Adds new content page(s)
- [ ] Fixes or improves workflow, documentation build or deployment

# References
--

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added [alt text](https://webaim.org/techniques/alttext/) to new images included in this PR