### PR TITLE
Add npe2 and magicgui to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ napari-sphinx-theme
 matplotlib
 lxml
 imageio-ffmpeg
+npe2

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ matplotlib
 lxml
 imageio-ffmpeg
 npe2
+magicgui


### PR DESCRIPTION
# Description
Add npe2 and magicgui to the requirements file.

If found that when running `make prep-docs` it needs `npe2` and `magicgui`, so add to requirements.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Fixes or improves existing content
- [ ] Adds new content page(s)
- [x] Fixes or improves workflow, documentation build or deployment

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added [alt text](https://webaim.org/techniques/alttext/) to new images included in this PR