### PR TITLE
Add roadmap board link to Roadmaps page

### DIFF
--- a/docs/developers/contributing.md
+++ b/docs/developers/contributing.md
@@ -5,6 +5,8 @@ We welcome your contributions! Please see the provided steps below and never hes
 
 If you are a new user, we recommend checking out the detailed [Github Docs](https://docs.github.com/en).
 
+You can see the general direction for napari development and possible work plans in our current [Roadmap](../roadmaps/index.md).
+
 (dev-installation)=
 ## Setting up a development installation
 

--- a/docs/developers/index.md
+++ b/docs/developers/index.md
@@ -3,6 +3,8 @@
 Here you can find resources about the contributing workflow, governance of the
 project and the onboarding of new contributors.
 
+You can see the general direction for napari development and possible work plans in our current [Roadmap](../roadmaps/index.md).
+
 ## For contributors
 
 - [Contributing guide](./contributing)

--- a/docs/roadmaps/index.md
+++ b/docs/roadmaps/index.md
@@ -1,3 +1,13 @@
 # Roadmaps
 
-Past and future roadmaps for the `napari` project.
+The current `napari` roadmap can be seen in the following GitHub board: [napari global roadmap](https://github.com/orgs/napari/projects/24/views/2?pane=info)
+
+This roadmap captures the current priorities of the napari core developer team. It is revisited every six months.
+
+---
+
+You can see past roadmaps below.
+
+- [](0_4.md)
+- [](0_3_retrospective.md)
+- [](0_3.md)


### PR DESCRIPTION
# Description

Adds link to GitHub board containing the napari roadmap to Roadmap page.

EDIT: [Rendered page is here](https://output.circle-artifacts.com/output/job/31a35d46-3a9c-414e-ad63-7f7a8a988b93/artifacts/0/docs/_build/roadmaps/index.html)

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Fixes or improves existing content
- [ ] Adds new content page(s)
- [ ] Fixes or improves workflow, documentation build or deployment

# References
Closes #182 

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added [alt text](https://webaim.org/techniques/alttext/) to new images included in this PR