### PR TITLE
Add documentation how to avoid fickering windows when running test locally

### DIFF
--- a/docs/developers/testing.md
+++ b/docs/developers/testing.md
@@ -69,10 +69,12 @@ tox list
 
 ### Running tests without pop-up windows
 
-Part of tests are opening and closing windows. This can be annoying if you are doing something when wait on the test end. 
+Some tests create visible napari viewers, which pop up on your monitor then quickly disappear.
+This can be annoying if you are trying to use your computer while the tests are running.
 There are two ways to avoid this:
 
-1. Use the `QT_QPA_PLATFORM=offscreen` environment variable. This instruct QT to use `offscreen` rendering method.
+1. Use the `QT_QPA_PLATFORM=offscreen` environment variable.
+This tells Qt to render windows "offscreen", which is slower but will avoid the pop-ups.
    ```shell
    QT_QPA_PLATFORM=offscreen pytest napari
    ```
@@ -81,7 +83,8 @@ There are two ways to avoid this:
    QT_QPA_PLATFORM=offscreen tox -e py310-linux-pyqt5
    ```
    
-2. Linux only (windows with WSL should work also): use the `xvfb-run` command. This will run the test in a virtual X server. 
+2. If you are using Linux or WSL, you can use the `xvfb-run` command.
+   This will run the tests in a virtual X server. 
    ```sh
    xvfb-run pytest napari
    ```
@@ -90,7 +93,7 @@ There are two ways to avoid this:
    xvfb-run tox -e py310-linux-pyqt5
    ```
    
-where tox environment selector `py310-linux-pyqt5` need to fit your os and python version.
+where the tox environment selector `py310-linux-pyqt5` must match your OS and Python version.
 
 ### Tips for speeding up local testing
 

--- a/docs/developers/testing.md
+++ b/docs/developers/testing.md
@@ -67,7 +67,7 @@ To get list of all available environments run:
 tox list
 ```
 
-### Running tests without jumping windows
+### Running tests without pop-up windows
 
 Part of tests are opening and closing windows. This can be annoying if you are doing something when wait on the test end. 
 There are two ways to avoid this:

--- a/docs/developers/testing.md
+++ b/docs/developers/testing.md
@@ -53,6 +53,45 @@ If you'd like to include them in local tests, set the environment variable "CI":
 CI=1 pytest
 ```
 
+It is also possible to run test using `tox`. This is the same way as it is done in CI.
+The main difference is that tox will create a virtual environment for each test environment, so it will take more time
+but it will be more similar to the CI environment.
+
+```sh
+tox -e py310-linux-pyqt5
+```
+
+To get list of all available environments run:
+
+```sh
+tox list
+```
+
+### Running tests without jumping windows
+
+Part of tests are opening and closing windows. This can be annoying if you are doing something when wait on the test end. 
+There are two ways to avoid this:
+
+1. Use the `QT_QPA_PLATFORM=offscreen` environment variable. This instruct QT to use `offscreen` rendering method.
+   ```shell
+   QT_QPA_PLATFORM=offscreen pytest napari
+   ```
+   or 
+   ```shell
+   QT_QPA_PLATFORM=offscreen tox -e py310-linux-pyqt5
+   ```
+   
+2. Linux only (windows with WSL should work also): use the `xvfb-run` command. This will run the test in a virtual X server. 
+   ```sh
+   xvfb-run pytest napari
+   ```
+   or
+   ```sh
+   xvfb-run tox -e py310-linux-pyqt5
+   ```
+   
+where tox environment selector `py310-linux-pyqt5` need to fit your os and python version.
+
 ### Tips for speeding up local testing
 
 Very often when developing new code, you don't need or want to run the entire test suite (which can take many minutes to finish).  With `pytest`, it's easy to run a subset of your tests:


### PR DESCRIPTION
# Description

Improve testing documentation by adding information on disabling showing widgets during napari tests. 

Based on my observation `offscreen` method may be slower, in the way that impact CI time, but it is better than distracting popups when tests are running in the background. 

depends on https://github.com/napari/napari/pull/6110

## Type of change
- [x] Fixes or improves existing content
