### PR TITLE
Run PR depenecy check on every comment added to PR

### DIFF
--- a/.github/workflows/pr_dependencies.yml
+++ b/.github/workflows/pr_dependencies.yml
@@ -1,7 +1,9 @@
 # https://github.com/marketplace/actions/pr-dependency-check
 name: "PR Dependency Check"
 on:
-  - pull_request
+  pull_request:
+  issue_comment:
+    types: [ created ]
 
 jobs:
   check_dependencies:

--- a/.github/workflows/pr_dependencies.yml
+++ b/.github/workflows/pr_dependencies.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   check_dependencies:
     runs-on: ubuntu-latest
+    if: (github.event.issue.pull_request != '' && contains(github.event.comment.body, 'dependency')) || github.event_name == 'pull_request'
     name: Check Dependencies
     steps:
     - uses: gregsdennis/dependencies-action@main

--- a/.github/workflows/pr_dependencies.yml
+++ b/.github/workflows/pr_dependencies.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   check_dependencies:
     runs-on: ubuntu-latest
-    if: (github.event.issue.pull_request != '' && contains(github.event.comment.body, 'dependency')) || github.event_name == 'pull_request'
+    if: (github.event.issue.pull_request != '' && contains(github.event.comment.body, 'merge')) || github.event_name == 'pull_request'
     name: Check Dependencies
     steps:
     - uses: gregsdennis/dependencies-action@main


### PR DESCRIPTION
# Description

For the current state, the core dev needs to restart the dependency check, or a dummy commit needs to be done. 

As the PR dependency check is cheap, I think it is worth triggering it on every comment, so if a user write comment containing `merge` the check will be restarted

## Type of change
- [x] Fixes or improves workflow, documentation build or deployment

# References

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_comment-use-issue_comment

