### PR TITLE
Fix getting started in napari linking to the unittest getting started page

### DIFF
--- a/docs/tutorials/start_index.md
+++ b/docs/tutorials/start_index.md
@@ -22,7 +22,7 @@ How to do a clean install of napari and launch the viewer.
 :::
 
 :::{grid-item-card} Getting started
-:link: getting-started
+:link: getting_started
 :link-type: ref
 
 This tutorial will teach you all the different ways to launch napari.


### PR DESCRIPTION
Clicking the Getting started grid in the below image pointed to https://docs.python.org/3/library/unittest.mock-examples.html#getting-started.
![image](https://github.com/napari/docs/assets/21295664/6a799ff0-1672-40d5-b263-4276d43beb88)

I've changed the link, so it *should* now link to https://napari.org/dev/tutorials/fundamentals/getting_started.html, which I assume was the intention here.

