### PR TITLE
Fix titles on Getting Started section of user guide

### DIFF
--- a/docs/tutorials/fundamentals/getting_started.md
+++ b/docs/tutorials/fundamentals/getting_started.md
@@ -1,7 +1,5 @@
 (getting_started)=
-# Getting started
-
-Welcome to the getting started with **napari** tutorial!
+# How to launch napari
 
 This tutorial assumes you have already installed napari.
 For help with installation see our [installation tutorial](./installation).

--- a/docs/tutorials/fundamentals/installation.md
+++ b/docs/tutorials/fundamentals/installation.md
@@ -15,7 +15,7 @@ jupyter:
 
 (installation)=
 
-# Installing
+# How to install napari
 
 Welcome to the **napari** installation guide!
 

--- a/docs/tutorials/start_index.md
+++ b/docs/tutorials/start_index.md
@@ -5,7 +5,7 @@ napari. For more detailed use-cases, check out the [napari tutorials](./index)
 or [How-to guides](../howtos/index).
 
 ::::{grid}
-:::{grid-item-card} napari quick start
+:::{grid-item-card} Quick start
 :link: napari-quick-start
 :link-type: ref
 
@@ -21,7 +21,7 @@ A quick glance of what napari does aimed at first-timers.
 How to do a clean install of napari and launch the viewer.
 :::
 
-:::{grid-item-card} Getting started
+:::{grid-item-card} How to launch napari
 :link: getting_started
 :link-type: ref
 
@@ -30,7 +30,7 @@ This tutorial will teach you all the different ways to launch napari.
 ::::
 
 ::::{grid}
-:::{grid-item-card} napari viewer tutorial
+:::{grid-item-card} Viewer tutorial
 :link: viewer-tutorial
 :link-type: ref
 


### PR DESCRIPTION
# Description
Makes contents a bit clearer, and matches the tiles in the Getting started index page.

h/t @seankmartin who called this out 😄 

Old page:
![Screenshot_20230814_141217](https://github.com/napari/docs/assets/3949932/0d5b3014-a901-4a3a-8ff4-a3417248c83b)

New page:
![Screenshot_20230814_141249](https://github.com/napari/docs/assets/3949932/6bde0fb4-f2b4-4d42-bfdd-d6854eda712f)


## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Fixes or improves existing content
- [ ] Adds new content page(s)
- [ ] Fixes or improves workflow, documentation build or deployment

# References
--

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added [alt text](https://webaim.org/techniques/alttext/) to new images included in this PR