### PR TITLE
Unversioned pages: overwrite home and developer docs on stable with dev version

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -15,9 +15,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+
   build-and-deploy:
     name: Build & Deploy
     runs-on: ubuntu-latest
+
     steps:
       - name: Clone docs repo
         uses: actions/checkout@v3
@@ -72,3 +74,43 @@ jobs:
           publish_branch: gh-pages
           destination_dir: dev
           cname: napari.org
+
+      - name: Copy permanent files locally
+        run: |
+          mkdir permanent
+          cp -R docs/docs/_build/developers permanent
+          cp docs/docs/_build/index.html permanent
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@master
+        with:
+          name: permanent_docs
+          path: permanent
+
+  copy-files:
+
+    needs: build-and-deploy
+    name: Copy permanent files
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        source_files: [index.html, developers]
+
+    steps:
+
+    - name: Download artifact
+      uses: actions/download-artifact@master
+      with:
+        name: permanent_docs
+
+    - name: Copy permanent files to napari.github.io/stable
+      uses: dmnemec/copy_file_to_another_repo_action@main
+      env:
+        API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+      with:
+        source_file: ${{ matrix.source_files }}
+        destination_repo: 'napari/napari.github.io'
+        destination_folder: 'stable'
+        destination_branch: 'gh-pages'
+        user_email: 'melissawm@gmail.com'
+        user_name: 'melissawm'


### PR DESCRIPTION
# Description
Creates pages that are always synced to latest by copying over index.html and the contents of the developers/ folder over their stable version.

There are maybe easier versions of this, happy to change strategy in that case 😄 

I've tested this successfully on my fork at melissawm/napari.github.io 

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Fixes or improves existing content
- [ ] Adds new content page(s)
- [x] Fixes or improves workflow, documentation build or deployment

# References
Fixes #86 

## Final checklist:
- [?] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added [alt text](https://webaim.org/techniques/alttext/) to new images included in this PR