### PR TITLE
Remove sub-sub section heading from rendering guide

### DIFF
--- a/docs/guides/rendering.md
+++ b/docs/guides/rendering.md
@@ -27,8 +27,6 @@ it will call {meth}`~napari.layers.Image.on_chunk_loaded` with
 the loaded data. The next frame {class}`~napari.layers.Image`
 can display the new data.
 
-### Time-series data
-
 Without `NAPARI_ASYNC` napari will block when switching slices. Napari
 will hang until the new slice has loaded. If the slice loads slowly enough
 you might see the "spinning wheel of death" on a Mac indicating the process

--- a/docs/guides/rendering.md
+++ b/docs/guides/rendering.md
@@ -55,7 +55,7 @@ improvement, but working with slow-loading data is still slow. Most large
 image viewers improve on this experience with chunks or tiles. With chunks
 or tiles when the image is panned the existing tiles are translated and
 re-used. Then the viewer only needs to fetch tiles which newly slid onto
-the screen. This style of rendering what our `NAPARI_OCTREE` flag
+the screen. This style of rendering is what the `NAPARI_OCTREE` flag
 enables.
 
 ## NAPARI_OCTREE


### PR DESCRIPTION
# Description
The block of text under this heading doesn't refer to time-series data. While it's applicable to time-series data, it's also applicable to 3D volume data, so it seemed easiest just to remove the heading.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Fixes or improves existing content

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

## Final checklist:
- [ ] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added [alt text](https://webaim.org/techniques/alttext/) to new images included in this PR