### PR TITLE
fix outdated dimension sliders documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -160,7 +160,7 @@ myst_enable_extensions = [
     'tasklist',
 ]
 
-myst_heading_anchors = 3
+myst_heading_anchors = 4
 
 version_string = '.'.join(str(x) for x in __version_tuple__[:3])
 python_version = '3.9'

--- a/docs/tutorials/fundamentals/viewer.md
+++ b/docs/tutorials/fundamentals/viewer.md
@@ -301,7 +301,7 @@ viewer.dims.current_step
 # to change the current position of this example to step 3
 viewer.dims.current_step = (3, 255, 255)
 ```
-Note that in this case two dimensions are displayed and thus the last two elements of the tuple have no effect.
+The length of the `current_step` tuple corresponds to the number of dimensions. Note that in this example, the last two dimensions are displayed (don't have a slider) and thus changing the last two elements of the tuple will have no effect until the axes order is changed.
 
 `viewer.dims.point` contains the position in world coordinates (i.e., including
 scale and translate transformations).

--- a/docs/tutorials/fundamentals/viewer.md
+++ b/docs/tutorials/fundamentals/viewer.md
@@ -295,15 +295,38 @@ nbscreenshot(viewer, alt_text="A 2d view of the moon on top of which is overlaid
 In this example there are three dimensions. In order to get or update the current position of the slider, use:
 
 ```python
-# to get the current position returned as tuple of length 3
+# To get the current position returned as tuple of length 3
 viewer.dims.current_step 
 
-# to change the current position of this example to step 3
+# To change the current position of this example to step 3
 viewer.dims.current_step = (3, 255, 255)
 ```
 The length of the `current_step` tuple corresponds to the number of dimensions. Note that in this example, the last two dimensions are displayed (don't have a slider) and thus changing the last two elements of the tuple will have no effect until the axes order is changed.
+The dimension order can be changed as follows:
 
-`viewer.dims.point` contains the position in world coordinates (i.e., including
+```python
+# To get the current dimension order as tuple of int
+viewer.dims.order
+
+# To change the current dimension order
+viewer.dims.order = (2, 1, 0)
+```
+In this case the third dimension will be controlled by the slider and the first and second dimension will be visible.
+Note that this has no effect on the order of `viewer.dims.current_step`. The first element still corresponds to the first dimension for example.
+
+The dimensions can also have labels. These can be set in the following manner:
+
+```python
+# To get the dimension labels
+viewer.dims.axis_labels
+
+# To set new axis labels
+viewer.dims.axis_labels = ("label_2", "label_1", "label_0")
+```
+
+Note that these are just examples. The only requirement is that the length of the tuple is the same as the number of dimensions.
+
+Lastly, `viewer.dims.point` contains the position in world coordinates (i.e., including
 scale and translate transformations).
 
 ### Scroll buttons

--- a/docs/tutorials/fundamentals/viewer.md
+++ b/docs/tutorials/fundamentals/viewer.md
@@ -260,7 +260,7 @@ One of the main strengths of **napari** is that it has been designed from the be
 
 Adding data with a dimensionality greater than 2D will cause dimension sliders to appear directly underneath the canvas and above the status bar. As many sliders as needed will appear to ensure the data can be fully browsed. For example, a 3D dataset needs one slider, a 4D dataset needs two sliders, and so on. The widths of the scroll bars of the dimension sliders are directly related to how many slices are in each dimension.
 To the left of each slider will be an integer indicating which dimension is being controlled by that slider. These integers are automatically updated when changing which dimensions are to be displayed. Alternately, the sliders can be labeled by double-clicking on the integer and editing the field. The labels can be retrieved programatically as follows:
-```{code-cel} python
+```{code-cell} python
 # To get the dimension labels
 viewer.dims.axis_labels
 ```
@@ -301,7 +301,7 @@ viewer.add_image(blobs, name='blobs', opacity=0.5, colormap='red')
 nbscreenshot(viewer, alt_text="A 2d view of the moon on top of which is overlaid a 3d volume containing blobs through which you can navigate using the dimension slider.")
 ```
 
-In this example there are three dimensions. In order to get or update the current position of the slider, use:
+In this example there are three dimensions. In order to get or update the current position of the sliders, use:
 
 ```{code-cell} python
 # To get the current position returned as tuple of length 3
@@ -312,7 +312,7 @@ And to change the current position of the sliders use:
 # To change the current position of this example to step 3
 viewer.dims.current_step = (3, 255, 255)
 ```
-The length of the `current_step` tuple corresponds to the number of dimensions. Note that in this example, the last two dimensions are displayed (don't have a slider) and thus changing the last two elements of the tuple will have no effect [until the axes order is changed](#roll-dimensions).
+The length of the `current_step` tuple corresponds to the number of dimensions. Note that in this example, the last two dimensions are *displayed* (don't have a slider) and thus changing the last two elements of the tuple will have no effect [until the axes order is changed](#roll-dimensions).
 
 Lastly, `viewer.dims.point` contains the position in world coordinates (i.e., including
 scale and translate transformations).

--- a/docs/tutorials/fundamentals/viewer.md
+++ b/docs/tutorials/fundamentals/viewer.md
@@ -259,6 +259,7 @@ viewer.layers.pop(i)
 One of the main strengths of **napari** is that it has been designed from the beginning to handle n-dimensional data. While much consumer photography is 2D and `RGB`, scientific image data can often be volumetric (i.e. 3D), volumetric timeseries (i.e. 4D), or even higher dimensional. **napari** places no limits on the dimensionality of its input data for all its layer types.
 
 Adding data with a dimensionality greater than 2D will cause dimension sliders to appear directly underneath the canvas and above the status bar. As many sliders as needed will appear to ensure the data can be fully browsed. For example, a 3D dataset needs one slider, a 4D dataset needs two sliders, and so on. The widths of the scroll bars of the dimension sliders are directly related to how many slices are in each dimension.
+To the left of each slider will be an integer indicating which dimension is being controlled by that slider. These integers are automatically updated when changing which dimensions are to be displayed.
 
 It is also possible to mix data of different shapes and dimensionality in different layers. If a 2D and 4D dataset are both added to the viewer then the sliders will affect only the 4D dataset, the 2D dataset will remain the
 same. Effectively, the two datasets are broadcast together using [NumPy broadcasting rules](https://numpy.org/doc/stable/user/basics.broadcasting.html).
@@ -291,14 +292,16 @@ viewer.add_image(blobs, name='blobs', opacity=0.5, colormap='red')
 nbscreenshot(viewer, alt_text="A 2d view of the moon on top of which is overlaid a 3d volume containing blobs through which you can navigate using the dimension slider.")
 ```
 
-In order to get or update the current position of the slider, use:
+In this example there are three dimensions. In order to get or update the current position of the slider, use:
 
 ```python
-# to get the current position
-viewer.dims.current_step
-# to change the current position
-viewer.dims.current_step = 3
+# to get the current position returned as tuple of length 3
+viewer.dims.current_step 
+
+# to change the current position of this example to step 3
+viewer.dims.current_step = (3, 255, 255)
 ```
+Note that in this case two dimensions are displayed and thus the last two elements of the tuple have no effect.
 
 `viewer.dims.point` contains the position in world coordinates (i.e., including
 scale and translate transformations).

--- a/docs/tutorials/fundamentals/viewer.md
+++ b/docs/tutorials/fundamentals/viewer.md
@@ -259,7 +259,16 @@ viewer.layers.pop(i)
 One of the main strengths of **napari** is that it has been designed from the beginning to handle n-dimensional data. While much consumer photography is 2D and `RGB`, scientific image data can often be volumetric (i.e. 3D), volumetric timeseries (i.e. 4D), or even higher dimensional. **napari** places no limits on the dimensionality of its input data for all its layer types.
 
 Adding data with a dimensionality greater than 2D will cause dimension sliders to appear directly underneath the canvas and above the status bar. As many sliders as needed will appear to ensure the data can be fully browsed. For example, a 3D dataset needs one slider, a 4D dataset needs two sliders, and so on. The widths of the scroll bars of the dimension sliders are directly related to how many slices are in each dimension.
-To the left of each slider will be an integer indicating which dimension is being controlled by that slider. These integers are automatically updated when changing which dimensions are to be displayed.
+To the left of each slider will be an integer indicating which dimension is being controlled by that slider. These integers are automatically updated when changing which dimensions are to be displayed. Alternately, the sliders can be labeled by double-clicking on the integer and editing the field. The labels can be retrieved programatically as follows:
+```{code-cel} python
+# To get the dimension labels
+viewer.dims.axis_labels
+```
+You can also set the axis labels programatically as follows:
+```{code-cell} python
+# To set new axis labels
+viewer.dims.axis_labels = ("label_1", "label_2")
+``` 
 
 It is also possible to mix data of different shapes and dimensionality in different layers. If a 2D and 4D dataset are both added to the viewer then the sliders will affect only the 4D dataset, the 2D dataset will remain the
 same. Effectively, the two datasets are broadcast together using [NumPy broadcasting rules](https://numpy.org/doc/stable/user/basics.broadcasting.html).
@@ -294,37 +303,16 @@ nbscreenshot(viewer, alt_text="A 2d view of the moon on top of which is overlaid
 
 In this example there are three dimensions. In order to get or update the current position of the slider, use:
 
-```python
+```{code-cell} python
 # To get the current position returned as tuple of length 3
 viewer.dims.current_step 
-
+```
+And to change the current position of the sliders use:
+```{code-cell} python
 # To change the current position of this example to step 3
 viewer.dims.current_step = (3, 255, 255)
 ```
-The length of the `current_step` tuple corresponds to the number of dimensions. Note that in this example, the last two dimensions are displayed (don't have a slider) and thus changing the last two elements of the tuple will have no effect until the axes order is changed.
-The dimension order can be changed as follows:
-
-```python
-# To get the current dimension order as tuple of int
-viewer.dims.order
-
-# To change the current dimension order
-viewer.dims.order = (2, 1, 0)
-```
-In this case the third dimension will be controlled by the slider and the first and second dimension will be visible.
-Note that this has no effect on the order of `viewer.dims.current_step`. The first element still corresponds to the first dimension for example.
-
-The dimensions can also have labels. These can be set in the following manner:
-
-```python
-# To get the dimension labels
-viewer.dims.axis_labels
-
-# To set new axis labels
-viewer.dims.axis_labels = ("label_2", "label_1", "label_0")
-```
-
-Note that these are just examples. The only requirement is that the length of the tuple is the same as the number of dimensions.
+The length of the `current_step` tuple corresponds to the number of dimensions. Note that in this example, the last two dimensions are displayed (don't have a slider) and thus changing the last two elements of the tuple will have no effect [until the axes order is changed](#roll-dimensions).
 
 Lastly, `viewer.dims.point` contains the position in world coordinates (i.e., including
 scale and translate transformations).
@@ -422,6 +410,18 @@ viewer.camera.perspective = 45
 #### Roll dimensions
 
 The third button rolls the dimensions that are currently displayed in the viewer. For example if you have a `ZYX` volume and are looking at the `YX` slice, this will then show you the `ZY` slice. You can also right-click this button to re-order the dimensions by drag-and-drop.
+
+The dimension order can also be changed programatically as follows:
+
+```{code-cell} python
+# To get the current dimension order as tuple of int
+viewer.dims.order
+
+# To change the current dimension order
+viewer.dims.order = (2, 1, 0)
+```
+In this case the third dimension will be controlled by the slider and the first and second dimension will be visible.
+Note that this has no effect on the order of `viewer.dims.current_step`. The first element still corresponds to the first dimension for example. These are just examples; the only requirement is that the length of the tuple is the same as the number of dimensions.
 
 #### Transpose dimensions
 

--- a/docs/tutorials/fundamentals/viewer.md
+++ b/docs/tutorials/fundamentals/viewer.md
@@ -411,12 +411,14 @@ viewer.camera.perspective = 45
 
 The third button rolls the dimensions that are currently displayed in the viewer. For example if you have a `ZYX` volume and are looking at the `YX` slice, this will then show you the `ZY` slice. You can also right-click this button to re-order the dimensions by drag-and-drop.
 
-The dimension order can also be changed programatically as follows:
+The dimension order can also be checked programatically as follows:
 
 ```{code-cell} python
 # To get the current dimension order as tuple of int
 viewer.dims.order
-
+```
+And then, changed programatically as follows:
+```{code-cell} python
 # To change the current dimension order
 viewer.dims.order = (2, 1, 0)
 ```


### PR DESCRIPTION
# References and relevant issues
Closes #240 

# Description
This PR updates the documentation under the section `Dimension Sliders`. Here it was still shown that `current step` would return
a single integer and could be set by assigning a single integer. I have checked whether this was also the case elsewhere in the documentation, but that is not the case.
