### PR TITLE
Update napari-workshops.md

### DIFF
--- a/docs/further-resources/napari-workshops.md
+++ b/docs/further-resources/napari-workshops.md
@@ -21,6 +21,7 @@ or contact the core developers on [zulip chat](https://napari.zulipchat.com/logi
 ## Workshops
 
 *Workshops are listed from newest to oldest.*
+* September 2023, [plugin design](https://chanzuckerberg.github.io/napari-plugin-accel-workshops/workshops/design23.html) and [software development workshop](https://chanzuckerberg.github.io/napari-plugin-accel-workshops/workshops/softwaredev.html) for [napari plugin grantees](https://chanzuckerberg.com/rfa/napari-plugin-grants/).
 * November 2022, napari foundation grant onboarding
   * [Getting started with napari plugin development slide deck](https://docs.google.com/presentation/d/15lrFRLPm9bfmU4hgcVwoduIJr5bqhoHo7ZeWLO6H_Us/edit?usp=sharing)
   * [Watch it here](https://drive.google.com/file/d/1IYDV-GTGEYh5j_tvBaWYEZ_tQXTqmJkr/view?usp=share_link)


### PR DESCRIPTION
Adding links to 2 workshops hosted in September geared towards plugin developers

# References and relevant issues
None

# Description
Adding 2 workshops geared towards plugin developers to the napari workshops page
