### PR TITLE
Update docs to suggest python 3.10 install

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -163,7 +163,7 @@ myst_enable_extensions = [
 myst_heading_anchors = 4
 
 version_string = '.'.join(str(x) for x in __version_tuple__[:3])
-python_version = '3.9'
+python_version = '3.10'
 python_version_range = '3.8–3.10'
 
 myst_substitutions = {


### PR DESCRIPTION
# References and relevant issues
In discussion about python version support, Matthias mentioned that more napari downloads are 3.9 than 3.10
https://github.com/napari/napari/pull/5768#issuecomment-1742691809

# Description
This PR updates the `python_version` variable in conf.py to `3.10` that is used for the myst substitution used in installation docs and contributing (developer env) guide.

