### PR TITLE
[Maintenance] Use permissions for labeler action (and set v4)

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -5,8 +5,11 @@ on:
 
 jobs:
   triage:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@main
+    - uses: actions/labeler@4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
# References and relevant issues
Analogous to:
https://github.com/napari/napari/pull/6289
See failing action: https://github.com/napari/docs/actions/runs/6385322990/job/17329817536?pr=246
(or on this PR—workflow only runs from main though, so this needs to be merged to fix)

# Description
Fixes failed labeler status.
