### PR TITLE
[maintenance] Fix missing v in labeler action version

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,6 +10,6 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@4
+    - uses: actions/labeler@v4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
# References and relevant issues
https://github.com/napari/docs/pull/247

The action is still failing:
https://github.com/napari/docs/actions/runs/6387008928/job/17334664506?pr=246

# Description
I missed the `v` in the version in the previous PR!
Derp!