### PR TITLE
Use docs constraints in circleci workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
           name: Install napari-dev
           command: |
             . venv/bin/activate
-            python -m pip install -e napari/".[pyside,dev]" -c "napari/resources/constraints/constraints_py3.10.txt"
+            python -m pip install -e napari/".[pyside,dev]" -c "napari/resources/constraints/constraints_py3.10_docs.txt"
       - run:
           name: Install python dependencies
           command: |


### PR DESCRIPTION
# Description
the circleci workflow use `napari/resources/constraints/constraints_py3.10.txt` instead of `napari/resources/constraints/constraints_py3.10_docs.txt` that causes the current failure of build docs, as the current build docs process requires pydantic in version 1.  
