### PR TITLE
[Maintenance] Lift sphinx pin to <6

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx<5
+sphinx<6
 sphinx-autobuild
 sphinx-tabs
 sphinx-tags

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-sphinx<5
+sphinx<6
 sphinx-autobuild
 sphinx-tabs
 sphinx-tags


### PR DESCRIPTION
# References and relevant issues
Closes https://github.com/napari/docs/issues/259

Depends on https://github.com/napari/napari-sphinx-theme/pull/133
See also https://github.com/napari/docs/pull/256#issuecomment-1786315010

# Description

Lifts the sphinx pin to <6 for compatibility with `sphinx_tags`
