### PR TITLE
Add missed pinning dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,8 @@ jobs:
           command: |
             . venv/bin/activate
             python -m pip install -r requirements.txt
+          environment:
+            PIP_CONSTRAINTS: ../resources/constraints/constraints_py3.10_docs.txt
       - run:
           name: Build docs
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,9 +52,7 @@ jobs:
           name: Install python dependencies
           command: |
             . venv/bin/activate
-            python -m pip install -r requirements.txt
-          environment:
-            PIP_CONSTRAINTS: ../resources/constraints/constraints_py3.10_docs.txt
+            python -m pip install -r requirements.txt -c "napari/resources/constraints/constraints_py3.10_docs.txt"
       - run:
           name: Build docs
           command: |

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -38,6 +38,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install "napari/[all]" -c "napari/resources/constraints/constraints_py3.10_docs.txt"
+          python -m pip install -r requirements.txt -c "napari/resources/constraints/constraints_py3.10_docs.txt"
 
       - name: Testing
         run: |


### PR DESCRIPTION
# Description
Closes #259
using the constraints file pins back sphinx_tags to 0.2.1 which is compatible with sphinx<5
