### PR TITLE
[Maintenance] fix path to requirements.txt in deploy_docs workflow

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install "napari-repo/[all]"  -c "napari-repo/resources/constraints/constraints_py3.10_docs.txt"
-          python -m pip install -r requirements.txt -c "napari-repo/resources/constraints/constraints_py3.10_docs.txt"
+          python -m pip install -r docs/requirements.txt -c "napari-repo/resources/constraints/constraints_py3.10_docs.txt"
           
       - name: Testing
         run: |


### PR DESCRIPTION
# References and relevant issues
Deployment of docs action is still failing:
https://github.com/napari/docs/actions/runs/6730870120/job/18294402924

This is because when I added the pip install with constraints I didn't realize the directory structure was different in this workflow.

# Description
Fixes the path based on the cloning scheme.
