### PR TITLE
Update to use napari-sphinx-theme 0.3.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
             cd docs
             xvfb-run --auto-servernum make docs
           environment:
-            PIP_CONSTRAINT: ../napari/resources/constraints/constraints_py3.10_docs.txt
+            PIP_CONSTRAINT: "" # ../napari/resources/constraints/constraints_py3.10_docs.txt
       - store_artifacts:
           path: docs/docs/_build/
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
             cd docs
             xvfb-run --auto-servernum make docs
           environment:
-            PIP_CONSTRAINT: "" # ../napari/resources/constraints/constraints_py3.10_docs.txt
+            PIP_CONSTRAINT: ../napari/resources/constraints/constraints_py3.10_docs.txt
       - store_artifacts:
           path: docs/docs/_build/
       - persist_to_workspace:

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -43,7 +43,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install "napari/[all]"
-          python -m pip install -r docs/requirements.txt
         env:
           PIP_CONSTRAINT: ${{ github.workspace }}/napari/resources/constraints/constraints_py3.10_docs.txt
 

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -57,7 +57,7 @@ jobs:
         env:
           GOOGLE_CALENDAR_ID: ${{ secrets.GOOGLE_CALENDAR_ID }}
           GOOGLE_CALENDAR_API_KEY: ${{ secrets.GOOGLE_CALENDAR_API_KEY }}
-          PIP_CONSTRAINT: ${{ github.workspace }}/napari/resources/constraints/constraints_py3.10_docs.txt
+          PIP_CONSTRAINT: "" # ${{ github.workspace }}/napari/resources/constraints/constraints_py3.10_docs.txt
         with:
           run:  make -C docs docs
           # skipping setup stops the action from running the default (tiling) window manager

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -56,7 +56,7 @@ jobs:
         env:
           GOOGLE_CALENDAR_ID: ${{ secrets.GOOGLE_CALENDAR_ID }}
           GOOGLE_CALENDAR_API_KEY: ${{ secrets.GOOGLE_CALENDAR_API_KEY }}
-          PIP_CONSTRAINT: "" # ${{ github.workspace }}/napari/resources/constraints/constraints_py3.10_docs.txt
+          PIP_CONSTRAINT: ${{ github.workspace }}/napari/resources/constraints/constraints_py3.10_docs.txt
         with:
           run:  make -C docs docs
           # skipping setup stops the action from running the default (tiling) window manager

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -47,7 +47,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install "napari-repo/[all]"  -c "napari-repo/resources/constraints/constraints_py3.10_docs.txt"
-          python -m pip install -r docs/requirements.txt -c "napari-repo/resources/constraints/constraints_py3.10_docs.txt"
+          python -m pip install -r docs/requirements.txt 
+        # -c "napari-repo/resources/constraints/constraints_py3.10_docs.txt"
       - name: Testing
         run: |
           python -c 'import napari; print(napari.__version__)'
@@ -58,7 +59,7 @@ jobs:
         env:
           GOOGLE_CALENDAR_ID: ${{ secrets.GOOGLE_CALENDAR_ID }}
           GOOGLE_CALENDAR_API_KEY: ${{ secrets.GOOGLE_CALENDAR_API_KEY }}
-          PIP_CONSTRAINT: ${{ github.workspace }}/napari-repo/resources/constraints/constraints_py3.10_docs.txt
+          PIP_CONSTRAINT: "" # ${{ github.workspace }}/napari-repo/resources/constraints/constraints_py3.10_docs.txt
         with:
           # the napari-docs repo is cloned into a docs/ folder, hence the
           # invocation below. Locally, you should simply run make docs

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -47,7 +47,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install "napari-repo/[all]"  -c "napari-repo/resources/constraints/constraints_py3.10_docs.txt"
-          python -m pip install -r docs/requirements.txt 
         # -c "napari-repo/resources/constraints/constraints_py3.10_docs.txt"
       - name: Testing
         run: |

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -47,7 +47,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install "napari-repo/[all]"  -c "napari-repo/resources/constraints/constraints_py3.10_docs.txt"
-        # -c "napari-repo/resources/constraints/constraints_py3.10_docs.txt"
       - name: Testing
         run: |
           python -c 'import napari; print(napari.__version__)'
@@ -58,7 +57,7 @@ jobs:
         env:
           GOOGLE_CALENDAR_ID: ${{ secrets.GOOGLE_CALENDAR_ID }}
           GOOGLE_CALENDAR_API_KEY: ${{ secrets.GOOGLE_CALENDAR_API_KEY }}
-          PIP_CONSTRAINT: "" # ${{ github.workspace }}/napari-repo/resources/constraints/constraints_py3.10_docs.txt
+          PIP_CONSTRAINT: ${{ github.workspace }}/napari-repo/resources/constraints/constraints_py3.10_docs.txt
         with:
           # the napari-docs repo is cloned into a docs/ folder, hence the
           # invocation below. Locally, you should simply run make docs

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,4 +1,4 @@
-{% extends "!layout.html" %}
+{% extends "!napari-layout.html" %}
 {% block extrahead %}
     <script async defer data-domain="napari.org" src="https://plausible.io/js/plausible.js"></script>
     {{ super() }}

--- a/docs/_templates/sbt-sidebar-nav.html
+++ b/docs/_templates/sbt-sidebar-nav.html
@@ -1,3 +1,0 @@
-<nav class="bd-links" id="bd-docs-nav" aria-label="Main navigation">
-    {{ generate_nav_html(include_item_names=True, with_home_page=theme_home_page_in_toc) }}
-</nav>

--- a/docs/_templates/sidebar-nav-bs.html
+++ b/docs/_templates/sidebar-nav-bs.html
@@ -1,0 +1,4 @@
+<nav class="bd-docs-nav bd-links"
+     aria-label="{{ _('Section Navigation') }}">
+  <div class="bd-toc-item navbar-nav">{{ sidebar_nav_html }}</div>
+</nav>

--- a/docs/community/meeting_schedule.md
+++ b/docs/community/meeting_schedule.md
@@ -8,6 +8,18 @@ If you are using napari or interested in how napari could be used in your work, 
 
 <div id='timezone'></div>
 
+<div id="myModal" class="modal">
+  <!-- Modal content -->
+  <div class="modal-content">
+    <div class="modal-header">
+      <span class="close">&times;</span>
+      <h3>Event details</h3>
+    </div>
+    <div id="details" class="modal-body">
+    </div>
+  </div>
+</div>
+
 <script src='https://cdn.jsdelivr.net/npm/fullcalendar@6.1.9/index.global.min.js'></script>
 <script src="https://cdn.jsdelivr.net/npm/@fullcalendar/google-calendar@6.1.9/index.global.min.js"></script>
 <script>
@@ -31,10 +43,17 @@ If you are using napari or interested in how napari could be used in your work, 
       eventClick: function (info) {
         info.jsEvent.preventDefault();
         var eventObj = info.event;
-        alert(
-          'Event: ' + eventObj.title + '\n\n'
-          + 'Description: ' + eventObj.extendedProps.description + '\n\n'
-          + 'URL: ' + eventObj.url);
+        // Get the <span> element that closes the modal
+        var span = document.getElementsByClassName("close")[0];
+        // Get the modal
+        var modal = document.getElementById("myModal");
+        modal.style.display = "block";
+        var eventTitle = eventObj.title.charAt(0).toUpperCase() + eventObj.title.slice(1);
+        document.getElementById("details").innerHTML = '<b>' + eventTitle + '</b>' + '<br>' + eventObj.extendedProps.description;
+        //When the user clicks on <span> (x), close the modal
+        span.onclick = function() {
+          modal.style.display = "none";
+        }
       },
       eventDisplay: 'block',
     });

--- a/docs/community/meeting_schedule.md
+++ b/docs/community/meeting_schedule.md
@@ -24,7 +24,7 @@ If you are using napari or interested in how napari could be used in your work, 
         center: "title",
         right: "dayGridMonth,listWeek",
       },
-      googleCalendarApiKey: api_key,
+      googleCalendarApiKey: '{API_KEY}',
       events: {
           googleCalendarId: 'c_35r93ec6vtp8smhm7dv5uot0v4@group.calendar.google.com',
       },

--- a/docs/community/meeting_schedule.md
+++ b/docs/community/meeting_schedule.md
@@ -2,11 +2,42 @@
 
 We hold regular meetings, the timings of which are available on our [public calendar](https://calendar.google.com/calendar/embed?src=c_35r93ec6vtp8smhm7dv5uot0v4%40group.calendar.google.com).
 
-```{calendar}
----
-show-filters: true
-calendar-id: c_35r93ec6vtp8smhm7dv5uot0v4@group.calendar.google.com
----
-```
-
 If you are using napari or interested in how napari could be used in your work, please join one of our regular community meetings. If you're interested in diving deep on particular topic you could join the closest working group meeting. We currently have four working groups 'Bundled Application', 'Plugins', 'Architecture', and 'Documentation' that meet on a semi-regular candence. You can learn more about our working groups and community meetings in the corresponding discussion streams on the [napari Zulip](https://napari.zulipchat.com/login/).
+
+<div id='community_calendar'></div>
+
+<div id='timezone'></div>
+
+<script src='https://cdn.jsdelivr.net/npm/fullcalendar@6.1.9/index.global.min.js'></script>
+<script src="https://cdn.jsdelivr.net/npm/@fullcalendar/google-calendar@6.1.9/index.global.min.js"></script>
+<script>
+  document.getElementById('timezone').innerHTML = "All times shown in "+Intl.DateTimeFormat().resolvedOptions().timeZone+".";
+  document.addEventListener('DOMContentLoaded', function () {
+    var community_calendar = document.getElementById('community_calendar');
+    var calendar = new FullCalendar.Calendar(community_calendar,
+    {
+      height: 650,
+      timeZone: 'local',
+      initialView: 'dayGridMonth',
+      headerToolbar: {
+        left: "prev,next today",
+        center: "title",
+        right: "dayGridMonth,listWeek",
+      },
+      googleCalendarApiKey: api_key,
+      events: {
+          googleCalendarId: 'c_35r93ec6vtp8smhm7dv5uot0v4@group.calendar.google.com',
+      },
+      eventClick: function (info) {
+        info.jsEvent.preventDefault();
+        var eventObj = info.event;
+        alert(
+          'Event: ' + eventObj.title + '\n\n'
+          + 'Description: ' + eventObj.extendedProps.description + '\n\n'
+          + 'URL: ' + eventObj.url);
+      },
+      eventDisplay: 'block',
+    });
+    calendar.render();
+  });
+</script>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -105,6 +105,7 @@ html_theme_options = {
         "version_match": version_match,
     },
     "navbar_persistent": [],
+    "header_links_before_dropdown": 6,
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -104,6 +104,7 @@ html_theme_options = {
         "json_url": json_url,
         "version_match": version_match,
     },
+    "navbar_persistent": [],
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -106,6 +106,7 @@ html_theme_options = {
     },
     "navbar_persistent": [],
     "header_links_before_dropdown": 6,
+    "secondary_sidebar_items": ["page-toc"],
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -99,7 +99,7 @@ html_theme_options = {
         {"name": "napari hub", "url": "https://napari-hub.org"}
     ],
     "github_url": "https://github.com/napari/napari",
-    "navbar_start": ["navbar-project"],
+    "navbar_start": ["navbar-logo", "navbar-project"],
     "navbar_end": ["version-switcher", "navbar-icon-links"],
     "switcher": {
         "json_url": json_url,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,7 @@
 # sys.path.insert(0, os.path.abspath('.'))
 
 import re
+import os
 from importlib import import_module
 from pathlib import Path
 from urllib.parse import urlparse, urlunparse
@@ -267,15 +268,31 @@ sphinx_gallery_conf = {
     'within_subsection_order': ExampleTitleSortKey,
 }
 
+GOOGLE_CALENDAR_API_KEY = os.environ.get('GOOGLE_CALENDAR_API_KEY', '')
+
+
+def add_google_calendar_secrets(app, docname, source):
+    """Add google calendar api key to meeting schedule page.
+
+    The source argument is a list whose single element is the contents of the
+    source file. You can process the contents and replace this item to implement
+    source-level transformations.
+    """
+    if docname == 'community/meeting_schedule':
+        source[0] = source[0].replace('{API_KEY}', GOOGLE_CALENDAR_API_KEY)
+
 
 def setup(app):
-    """Ignore .ipynb files.
+    """Set up docs build.
 
-    Prevents sphinx from complaining about multiple files found for document
-    when generating the gallery.
+    * Ignores .ipynb files to prevent sphinx from complaining about multiple
+      files found for document when generating the gallery
+    * Rewrites github anchors to be comparable
+    * Adds google calendar api key to meetings schedule page
 
     """
     app.registry.source_suffix.pop(".ipynb", None)
+    app.connect('source-read', add_google_calendar_secrets)
     app.connect('linkcheck-process-uri', rewrite_github_anchor)
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -83,7 +83,7 @@ tags_extension = ["md", "rst"]
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'napari'
+html_theme = 'napari_sphinx_theme'
 
 # Define the json_url for our version switcher.
 json_url = "https://napari.org/dev/_static/version_switcher.json"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -107,6 +107,8 @@ html_theme_options = {
     "navbar_persistent": [],
     "header_links_before_dropdown": 6,
     "secondary_sidebar_items": ["page-toc"],
+    "pygment_light_style": "napari",
+    "pygment_dark_style": "napari",
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ sphinx-copybutton
 sphinx-gallery
 sphinx_autodoc_typehints==1.12.0
 myst-nb
-napari-sphinx-theme>=0.3.0
+#napari-sphinx-theme>=0.3.0
 matplotlib
 lxml
 imageio-ffmpeg

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ sphinx-gallery
 sphinx_autodoc_typehints==1.12.0
 myst-nb
 #napari-sphinx-theme>=0.3.0
+napari-sphinx-theme @ git+https://github.com/melissawm/napari-sphinx-theme.git@new-theme
 matplotlib
 lxml
 imageio-ffmpeg

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ sphinx-copybutton
 sphinx-gallery
 sphinx_autodoc_typehints==1.12.0
 myst-nb
-napari-sphinx-theme
+#napari-sphinx-theme
 matplotlib
 lxml
 imageio-ffmpeg

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-sphinx<5
+sphinx<6
 sphinx-autobuild
 sphinx-tabs
 sphinx-tags

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ sphinx-copybutton
 sphinx-gallery
 sphinx_autodoc_typehints==1.12.0
 myst-nb
-#napari-sphinx-theme
+napari-sphinx-theme>=0.3.0
 matplotlib
 lxml
 imageio-ffmpeg

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,7 @@ sphinx-copybutton
 sphinx-gallery
 sphinx_autodoc_typehints==1.12.0
 myst-nb
-#napari-sphinx-theme>=0.3.0
-napari-sphinx-theme @ git+https://github.com/melissawm/napari-sphinx-theme.git@new-theme
+napari-sphinx-theme>=0.3.0
 matplotlib
 lxml
 imageio-ffmpeg

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ sphinx-copybutton
 sphinx-gallery
 sphinx_autodoc_typehints==1.12.0
 myst-nb
-napari-sphinx-theme>=0.3.0
+napari-sphinx-theme>=0.3.0.dev0
 matplotlib
 lxml
 imageio-ffmpeg


### PR DESCRIPTION
Prepares the docs repo to use the new napari-sphinx-theme, 0.3.0, which depends on pydata-sphinx-theme rather than forking it.

# References and relevant issues

Addresses napari/napari-sphinx-theme#113
Depends on napari/napari-sphinx-theme#134
