### PR TITLE
[NAP-8] delete :orphan:

### DIFF
--- a/docs/naps/8-telemetry.md
+++ b/docs/naps/8-telemetry.md
@@ -1,6 +1,4 @@
-:orphan: 
-  
- (nap-8)= 
+(nap-8)= 
   
  # NAP-8 — Telemetry
   


### PR DESCRIPTION
# References and relevant issues
First noted here:
https://github.com/napari/napari/pull/6384#discussion_r1385853123


# Description
There is an orphan `:orphan:` tag at the top of NAP-8. Pretty sure it's not doing anything--the other naps don't have it. This deletes it.

