### PR TITLE
[Maint] use concurrency to cancel in-progress build_docs 

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -8,6 +8,10 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-upload:
     name: Build & Upload Artifact


### PR DESCRIPTION
# References and relevant issues
Closes https://github.com/napari/docs/issues/172

# Description
Adds a concurrency group to the build_docs action, so that in progress workflows are canceled 

