### PR TITLE
[Maintenance] Update CIrcleCI redirector circleci.yml to fix artifact path

### DIFF
--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -19,6 +19,6 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           api-token: ${{ secrets.CIRCLECI_TOKEN }}
-          artifact-path: 0/docs/_build/index.html
+          artifact-path: docs/docs/_build/index.html
           circleci-jobs: build-docs
           job-title: Check the rendered docs here!

--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -19,6 +19,6 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           api-token: ${{ secrets.CIRCLECI_TOKEN }}
-          artifact-path: docs/docs/_build/index.html
+          artifact-path: 0/docs/docs/_build/index.html
           circleci-jobs: build-docs
           job-title: Check the rendered docs here!


### PR DESCRIPTION
# References and relevant issues
The CircleCI redirector is not re-directing properly even when build succeeds, see:
https://github.com/napari/docs/pull/273#issuecomment-1819932043

# Description

In https://github.com/napari/docs/pull/266 the artifact path got changed. This fixes the redirector action to use the new path.
