### PR TITLE
Add env constraint to 'deploy_docs' workflow

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -48,7 +48,6 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install "napari-repo/[all]"  -c "napari-repo/resources/constraints/constraints_py3.10_docs.txt"
           python -m pip install -r docs/requirements.txt -c "napari-repo/resources/constraints/constraints_py3.10_docs.txt"
-          
       - name: Testing
         run: |
           python -c 'import napari; print(napari.__version__)'
@@ -59,6 +58,7 @@ jobs:
         env:
           GOOGLE_CALENDAR_ID: ${{ secrets.GOOGLE_CALENDAR_ID }}
           GOOGLE_CALENDAR_API_KEY: ${{ secrets.GOOGLE_CALENDAR_API_KEY }}
+          PIP_CONSTRAINT: ${{ github.workspace }}/napari/resources/constraints/constraints_py3.10_docs.txt
         with:
           # the napari-docs repo is cloned into a docs/ folder, hence the
           # invocation below. Locally, you should simply run make docs


### PR DESCRIPTION
# References and relevant issues
Possible f i x es #283

# Description
Add constraints as env variable to the build step of 'deploy_docs' workflow, matching the 'build_docs' workflow.

(no further improvement of these workflows attempted in this PR, they can be done later, see #284)
