### PR TITLE
fix napari repo path to constraints

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -58,7 +58,7 @@ jobs:
         env:
           GOOGLE_CALENDAR_ID: ${{ secrets.GOOGLE_CALENDAR_ID }}
           GOOGLE_CALENDAR_API_KEY: ${{ secrets.GOOGLE_CALENDAR_API_KEY }}
-          PIP_CONSTRAINT: ${{ github.workspace }}/napari/resources/constraints/constraints_py3.10_docs.txt
+          PIP_CONSTRAINT: ${{ github.workspace }}/napari-repo/resources/constraints/constraints_py3.10_docs.txt
         with:
           # the napari-docs repo is cloned into a docs/ folder, hence the
           # invocation below. Locally, you should simply run make docs


### PR DESCRIPTION
# References and relevant issues
Fix failing deployment:
https://github.com/napari/docs/actions/runs/7093394130/job/19306680514
caused by https://github.com/napari/docs/pull/287

# Description
In the deploy workflow, napari is cloned into napari-repo:
`path: napari-repo  # place in a named directory`
fixing that here so that the constraints path in the ENV variable is also using napari-repo and not napari.
Obviously overlooked this difference when reviewing https://github.com/napari/docs/pull/287
Yet another reason to use just one workflow, https://github.com/napari/docs/issues/284