### PR TITLE
Update headless-gui action in build (fix screenshots)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           name: Install napari-dev
           command: |
             . venv/bin/activate
-            python -m pip install -e "napari/[all]"
+            python -m pip install -e "napari/[pyside,dev]"
           environment:
             PIP_CONSTRAINT: napari/resources/constraints/constraints_py3.10_docs.txt
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           name: Install napari-dev
           command: |
             . venv/bin/activate
-            python -m pip install -e "napari/[pyside,dev]"
+            python -m pip install -e "napari/[all]"
           environment:
             PIP_CONSTRAINT: napari/resources/constraints/constraints_py3.10_docs.txt
       - run:

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -62,8 +62,9 @@ jobs:
           run:  make -C docs docs
           # setting these empty stops from running the default (tiling) window manager
           # the window manager is not necessary for docs builds at this time
-          linux-pkgs: ""
-          linux-setup: ""
+          linux-pkgs: " "
+          linux-setup: " "
+          linux-teardown: " "
 
 
       - name: Upload artifact

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install "napari/[all]"
+          python -m pip install "napari/[pyside,dev]"
           python -m pip install -r docs/requirements.txt
         env:
           PIP_CONSTRAINT: ${{ github.workspace }}/napari/resources/constraints/constraints_py3.10_docs.txt

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -60,6 +60,10 @@ jobs:
           PIP_CONSTRAINT: ${{ github.workspace }}/napari/resources/constraints/constraints_py3.10_docs.txt
         with:
           run:  make -C docs docs
+          # setting these empty stops from running the default (tiling) window manager
+          # the window manager is not necessary for docs builds at this time
+          linux-pkgs: ""
+          linux-setup: ""
 
 
       - name: Upload artifact

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -53,19 +53,18 @@ jobs:
           python -c 'import napari.layers; print(napari.layers.__doc__)'
 
       - name: Build Docs
-        uses: aganders3/headless-gui@configurable-xvfb
+        uses: aganders3/headless-gui@v2
         env:
           GOOGLE_CALENDAR_ID: ${{ secrets.GOOGLE_CALENDAR_ID }}
           GOOGLE_CALENDAR_API_KEY: ${{ secrets.GOOGLE_CALENDAR_API_KEY }}
           PIP_CONSTRAINT: ${{ github.workspace }}/napari/resources/constraints/constraints_py3.10_docs.txt
         with:
           run:  make -C docs docs
-          # setting these empty stops from running the default (tiling) window manager
-          # the window manager is not necessary for docs builds at this time
+          # skipping setup stops the action from running the default (tiling) window manager
+          # the window manager is not necessary for docs builds at this time and it was causing
+          # problems with screenshots (https://github.com/napari/docs/issues/285)
           linux-setup: "echo 'skip setup'"
           linux-teardown: "echo 'skip teardown'"
-          xvfb-screen-size: "1280x1024x24"
-
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -64,7 +64,7 @@ jobs:
           # the window manager is not necessary for docs builds at this time
           linux-setup: "echo 'skip setup'"
           linux-teardown: "echo 'skip teardown'"
-          xvfb-server-args: "-screen 0 640x480x8"
+          xvfb-screen-size: "1280x1024x24"
 
 
       - name: Upload artifact

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install "napari/[pyside,dev]"
+          python -m pip install "napari/[all]"
           python -m pip install -r docs/requirements.txt
         env:
           PIP_CONSTRAINT: ${{ github.workspace }}/napari/resources/constraints/constraints_py3.10_docs.txt

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -62,9 +62,8 @@ jobs:
           run:  make -C docs docs
           # setting these empty stops from running the default (tiling) window manager
           # the window manager is not necessary for docs builds at this time
-          linux-pkgs: " "
-          linux-setup: " "
-          linux-teardown: " "
+          linux-setup: "echo 'skip setup'"
+          linux-teardown: "echo 'skip teardown'"
 
 
       - name: Upload artifact

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -53,7 +53,7 @@ jobs:
           python -c 'import napari.layers; print(napari.layers.__doc__)'
 
       - name: Build Docs
-        uses: aganders3/headless-gui@v1
+        uses: aganders3/headless-gui@configurable-xvfb
         env:
           GOOGLE_CALENDAR_ID: ${{ secrets.GOOGLE_CALENDAR_ID }}
           GOOGLE_CALENDAR_API_KEY: ${{ secrets.GOOGLE_CALENDAR_API_KEY }}
@@ -64,6 +64,7 @@ jobs:
           # the window manager is not necessary for docs builds at this time
           linux-setup: "echo 'skip setup'"
           linux-teardown: "echo 'skip teardown'"
+          xvfb-server-args: "-screen 0 640x480x8"
 
 
       - name: Upload artifact

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -63,6 +63,11 @@ jobs:
           # the napari-docs repo is cloned into a docs/ folder, hence the
           # invocation below. Locally, you should simply run make docs
           run: make -C docs docs GALLERY_PATH=../examples/
+          # setting these empty stops from running the default (tiling) window manager
+          # the window manager is not necessary for docs builds at this time
+          linux-pkgs: " "
+          linux-setup: " "
+          linux-teardown: " "
 
       - name: Deploy Docs
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -47,21 +47,27 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install "napari-repo/[all]"  -c "napari-repo/resources/constraints/constraints_py3.10_docs.txt"
-
+          python -m pip install -r docs/requirements.txt -c "napari-repo/resources/constraints/constraints_py3.10_docs.txt"
       - name: Testing
         run: |
           python -c 'import napari; print(napari.__version__)'
           python -c 'import napari.layers; print(napari.layers.__doc__)'
 
       - name: Build Docs
-        uses: aganders3/headless-gui@v1
+        uses: aganders3/headless-gui@v2
         env:
           GOOGLE_CALENDAR_ID: ${{ secrets.GOOGLE_CALENDAR_ID }}
           GOOGLE_CALENDAR_API_KEY: ${{ secrets.GOOGLE_CALENDAR_API_KEY }}
+          PIP_CONSTRAINT: ${{ github.workspace }}/napari-repo/resources/constraints/constraints_py3.10_docs.txt
         with:
           # the napari-docs repo is cloned into a docs/ folder, hence the
           # invocation below. Locally, you should simply run make docs
           run: make -C docs docs GALLERY_PATH=../examples/
+          # skipping setup stops the action from running the default (tiling) window manager
+          # the window manager is not necessary for docs builds at this time and it was causing
+          # problems with screenshots (https://github.com/napari/docs/issues/285)
+          linux-setup: "echo 'skip setup'"
+          linux-teardown: "echo 'skip teardown'"
 
       - name: Deploy Docs
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install "napari-repo/[all]"  -c "napari-repo/resources/constraints/constraints_py3.10_docs.txt"
+          python -m pip install "napari-repo/[pyside,dev]"  -c "napari-repo/resources/constraints/constraints_py3.10_docs.txt"
           python -m pip install -r docs/requirements.txt -c "napari-repo/resources/constraints/constraints_py3.10_docs.txt"
       - name: Testing
         run: |

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -65,9 +65,8 @@ jobs:
           run: make -C docs docs GALLERY_PATH=../examples/
           # setting these empty stops from running the default (tiling) window manager
           # the window manager is not necessary for docs builds at this time
-          linux-pkgs: " "
-          linux-setup: " "
-          linux-teardown: " "
+          linux-setup: "echo 'skip setup'"
+          linux-teardown: "echo 'skip teardown'"
 
       - name: Deploy Docs
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -46,28 +46,22 @@ jobs:
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install "napari-repo/[pyside,dev]"  -c "napari-repo/resources/constraints/constraints_py3.10_docs.txt"
-          python -m pip install -r docs/requirements.txt -c "napari-repo/resources/constraints/constraints_py3.10_docs.txt"
+          python -m pip install "napari-repo/[all]"  -c "napari-repo/resources/constraints/constraints_py3.10_docs.txt"
+
       - name: Testing
         run: |
           python -c 'import napari; print(napari.__version__)'
           python -c 'import napari.layers; print(napari.layers.__doc__)'
 
       - name: Build Docs
-        uses: aganders3/headless-gui@configurable-xvfb
+        uses: aganders3/headless-gui@v1
         env:
           GOOGLE_CALENDAR_ID: ${{ secrets.GOOGLE_CALENDAR_ID }}
           GOOGLE_CALENDAR_API_KEY: ${{ secrets.GOOGLE_CALENDAR_API_KEY }}
-          PIP_CONSTRAINT: ${{ github.workspace }}/napari-repo/resources/constraints/constraints_py3.10_docs.txt
         with:
           # the napari-docs repo is cloned into a docs/ folder, hence the
           # invocation below. Locally, you should simply run make docs
           run: make -C docs docs GALLERY_PATH=../examples/
-          # setting these empty stops from running the default (tiling) window manager
-          # the window manager is not necessary for docs builds at this time
-          linux-setup: "echo 'skip setup'"
-          linux-teardown: "echo 'skip teardown'"
-          xvfb-server-args: "-screen 0 640x480x8"
 
       - name: Deploy Docs
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -54,7 +54,7 @@ jobs:
           python -c 'import napari.layers; print(napari.layers.__doc__)'
 
       - name: Build Docs
-        uses: aganders3/headless-gui@v1
+        uses: aganders3/headless-gui@configurable-xvfb
         env:
           GOOGLE_CALENDAR_ID: ${{ secrets.GOOGLE_CALENDAR_ID }}
           GOOGLE_CALENDAR_API_KEY: ${{ secrets.GOOGLE_CALENDAR_API_KEY }}
@@ -67,6 +67,7 @@ jobs:
           # the window manager is not necessary for docs builds at this time
           linux-setup: "echo 'skip setup'"
           linux-teardown: "echo 'skip teardown'"
+          xvfb-server-args: "-screen 0 640x480x8"
 
       - name: Deploy Docs
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
# References and relevant issues
~~Hopefully f i x e s~~ Pretty sure now this fixes both #283 and #285 

# Description
This configures the [headless-gui](https://github.com/aganders3/headless-gui) action to not run the tiling window manager it uses by default. My thinking is the tiling behavior in the window manager is causing issues with certain screenshots. See https://github.com/napari/docs/issues/283#issuecomment-1841621067 for more details.

This also updates the action to a new version with a more common default screen size. This change in bit-depth fixes the messed up magicgui screenshot.

Edit: I'm still not _totally_ clear why the stable docs would look okay but I think this is worth trying.