### PR TITLE
Use tabs for the install as Python package guide

### DIFF
--- a/docs/tutorials/fundamentals/installation.md
+++ b/docs/tutorials/fundamentals/installation.md
@@ -78,7 +78,6 @@ If you want to install napari with PySide2 as the backend you need to install it
 ```sh
 conda install -c conda-forge napari pyside2
 ```
-````
 
 ````{note}
 In some cases, `conda`'s default solver can struggle to find out which packages need to be
@@ -111,7 +110,7 @@ mamba install napari
 
 :::::{tab-item} From PyPI using pip
 
-napari can be installed on most macOS (Intel x86), Linux, and Windows systems with Python
+napari can be installed from PyPI on most macOS (Intel x86), Linux, and Windows systems with Python
 {{ python_version_range }} using pip:
 
 ```sh
@@ -128,19 +127,16 @@ notation.)*
 
 *(See [Using constraints file](#using-constraints-files) for help installing older versions of napari)*
 
-````
-
 :::::
 
 :::::{tab-item} From the main branch on Github
 
-To install the latest version with yet to be released features from github via pip, call
+To install the latest version with yet to be released features from Github you can use pip:
 
 ```sh
 python -m pip install "git+https://github.com/napari/napari.git#egg=napari[all]"
 ```
-````
-
+:::::
 ::::::
 
 

--- a/docs/tutorials/fundamentals/installation.md
+++ b/docs/tutorials/fundamentals/installation.md
@@ -55,31 +55,9 @@ up a Python {{ python_version }} environment with `conda`:
 
 Choose one of the options below to install napari as a Python package.
 
-````{admonition} **1. From pip**
-:class: dropdown
+::::::{tab-set}
 
-napari can be installed on most macOS (Intel x86), Linux, and Windows systems with Python
-{{ python_version_range }} using pip:
-
-```sh
-python -m pip install "napari[all]"
-```
-You can then upgrade napari to a new version using:
-
-```sh
-python -m pip install "napari[all]" --upgrade
-```
-
-*(See [Choosing a different Qt backend](#choosing-a-different-qt-backend) below for an explanation of the `[all]`
-notation.)*
-
-*(See [Using constraints file](#using-constraints-files) for help installing older versions of napari)*
-
-````
-
-
-````{admonition} **2. From conda-forge**
-:class: dropdown
+:::::{tab-item} From conda-forge using conda
 
 If you prefer to manage packages with conda, napari is available on the
 conda-forge channel. We also recommend this path for users of arm64 macOS machines
@@ -129,9 +107,32 @@ mamba install napari
 
 ````
 
+:::::
 
-````{admonition} **3. From the main branch on Github**
-:class: dropdown
+:::::{tab-item} From PyPI using pip
+
+napari can be installed on most macOS (Intel x86), Linux, and Windows systems with Python
+{{ python_version_range }} using pip:
+
+```sh
+python -m pip install "napari[all]"
+```
+You can then upgrade napari to a new version using:
+
+```sh
+python -m pip install "napari[all]" --upgrade
+```
+
+*(See [Choosing a different Qt backend](#choosing-a-different-qt-backend) below for an explanation of the `[all]`
+notation.)*
+
+*(See [Using constraints file](#using-constraints-files) for help installing older versions of napari)*
+
+````
+
+:::::
+
+:::::{tab-item} From the main branch on Github
 
 To install the latest version with yet to be released features from github via pip, call
 
@@ -139,6 +140,9 @@ To install the latest version with yet to be released features from github via p
 python -m pip install "git+https://github.com/napari/napari.git#egg=napari[all]"
 ```
 ````
+
+::::::
+
 
 <!-- #region -->
 ### Checking it worked


### PR DESCRIPTION
# References and relevant issues
This came up at the docs workgroup and also:
https://github.com/napari/docs/pull/274#pullrequestreview-1740859412

# Description
Currently, the install docs have pip, conda and GitHub install instructions in series followed by the `checking that it worked`. No-one will use all three approaches.
In this PR instead Tabs are used for *each* of the approaches, to let the user choose an install strategy. 
This makes the install page simpler and cleaner, leading the user to the the next logical step.

What it looks like:
<img width="776" alt="image" src="https://github.com/napari/docs/assets/76622105/3c86bb63-07e0-44e9-83c5-6e777698f2db">
