### PR TITLE
Exclude inherited tqdm members from documentation

### DIFF
--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -5,7 +5,9 @@
 .. autoclass:: {{ objname }}
    :members:
    :show-inheritance:
-   :inherited-members:
+   {% if objname != "progress" %}
+      :inherited-members:
+   {% endif %}
 
    {% block methods %}
 


### PR DESCRIPTION
# References and relevant issues
Addresses #111 - reduces current sphinx errors from 208 to 135

# Description
This change excludes inherited tqdm methods from being documented in the API docs for `napari.utils.progress`.

Before this change, when building the docs we can see the following error messages:

```sh
/home/melissa/micromamba/envs/napari-dev/lib/python3.11/site-packages/napari/utils/progress.py:docstring of tqdm.std.tqdm.format_meter:36: ERROR: Unexpected indentation.
/home/melissa/micromamba/envs/napari-dev/lib/python3.11/site-packages/napari/utils/progress.py:docstring of tqdm.std.tqdm.format_meter:37: WARNING: Block quote ends without a blank line; unexpected unindent.
/home/melissa/micromamba/envs/napari-dev/lib/python3.11/site-packages/napari/utils/progress.py:docstring of tqdm.std.tqdm.format_meter:42: WARNING: Definition list ends without a blank line; unexpected unindent.
/home/melissa/micromamba/envs/napari-dev/lib/python3.11/site-packages/napari/utils/progress.py:docstring of tqdm.std.tqdm.format_meter:50: WARNING: Inline emphasis start-string without end-string.
/home/melissa/micromamba/envs/napari-dev/lib/python3.11/site-packages/napari/utils/progress.py:docstring of tqdm.std.tqdm.wrapattr:3: ERROR: Unexpected indentation.
<snip>
/home/melissa/micromamba/envs/napari-dev/lib/python3.11/site-packages/napari/utils/progress.py:docstring of tqdm.std.tqdm.format_meter:36: ERROR: Unexpected indentation.
/home/melissa/micromamba/envs/napari-dev/lib/python3.11/site-packages/napari/utils/progress.py:docstring of tqdm.std.tqdm.format_meter:37: WARNING: Block quote ends without a blank line; unexpected unindent.
/home/melissa/micromamba/envs/napari-dev/lib/python3.11/site-packages/napari/utils/progress.py:docstring of tqdm.std.tqdm.format_meter:42: WARNING: Definition list ends without a blank line; unexpected unindent.
/home/melissa/micromamba/envs/napari-dev/lib/python3.11/site-packages/napari/utils/progress.py:docstring of tqdm.std.tqdm.format_meter:50: WARNING: Inline emphasis start-string without end-string.
/home/melissa/micromamba/envs/napari-dev/lib/python3.11/site-packages/napari/utils/progress.py:docstring of tqdm.std.tqdm.wrapattr:3: ERROR: Unexpected indentation.
```

These errors also create formatting issues on the [rendered api docs](https://napari.org/dev/api/napari.utils.progress.html?highlight=progress#napari.utils.progress).

The only drawback to this change is that only the new napari methods are documented, but my thinking is since we already link to the tqdm documentation from the progress docstring, users can find any extra information there. Here is how the details rubric in the progress documentation looks like after the change:
![Screenshot_20240109_131118](https://github.com/napari/docs/assets/3949932/ca30820a-0c26-4c3c-8673-a1d706d68a91)





