### PR TITLE
Update working groups leads

### DIFF
--- a/docs/community/working_groups.md
+++ b/docs/community/working_groups.md
@@ -18,9 +18,9 @@ We believe working groups are a helpful way to move forward work on particular t
 
 ## Existing working groups
 
-- Bundled Application (Co-Leads: [Gonzalo Peña-Castellanos](https://github.com/goanpeca) and [Ziyang Liu](https://github.com/potating-potato))
-- Architecture (Co-Leads: [Juan Nunez-Iglesias](https://github.com/jni) and [Andy Sweet](https://github.com/andy-sweet))
-- Documentation (Co-Leads: [Genevieve Buckley](https://github.com/GenevieveBuckley) and [Justin Kiggins](https://github.com/neuromusic))
+- Bundled Application (Co-Leads: [Jaime Rodríguez-Guerra](https://github.com/jaimergp) and [Gonzalo Peña-Castellanos](https://github.com/goanpeca))
+- Documentation (Co-Leads: [Peter Sobolewski](https://github.com/psobolewskiPhD) and [Melissa Weber Mendonça](https://github.com/melissawm/))
+- Graphs layer (Co-Leads: [Draga Doncila Pop](https://github.com/DragaDoncila) and [Jordão Bragantini](https://github.com/JoOkuma))
 
 ## How to join an existing working group
 


### PR DESCRIPTION
# References and relevant issues

Closes #324

See also [this Zulip thread](https://napari.zulipchat.com/#narrow/stream/298358-working-group-documentation/topic/update-docs-working-group-contacts/near/416509330)

# Description

Our working groups docs are woefully out of date. I've updated to reflect the
current makeup of the groups.

I kinda winged it for the second person of the Graphs WG, but I think it should
be all right. (CC @JoOkuma :joy:) Happy to nominate myself otherwise.
