### PR TITLE
Remove sphinx pin to rely on upstream constraints

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-sphinx<6
 sphinx-autobuild
 sphinx-tabs
 sphinx-tags
@@ -9,7 +8,7 @@ sphinx-copybutton
 sphinx-gallery
 sphinx_autodoc_typehints==1.12.0
 myst-nb
-napari-sphinx-theme>=0.3.0.dev0
+napari-sphinx-theme>=0.3.0
 matplotlib
 lxml
 imageio-ffmpeg


### PR DESCRIPTION
# Description
Don't pin Sphinx directly, as we can rely on MyST and PyData Sphinx Theme to pin it if necessary.

cc @Czaki 
