### PR TITLE
Move note after screeenshot in install guide

### DIFF
--- a/docs/tutorials/fundamentals/installation.md
+++ b/docs/tutorials/fundamentals/installation.md
@@ -152,13 +152,14 @@ simply running
 napari
 ```
 
-An empty napari viewer should appear as follows.
+An empty napari viewer should appear as follows:
+
+![macOS desktop with a napari viewer window without any image opened in the foreground, and a terminal in the background with the appropriate conda environment activated (if applicable) and the command to open napari entered.](../assets/tutorials/launch_cli_empty.png)
 
 ````{note}
 You can check the napari version, to ensure it's what you expect, for example
 the current release {{ napari_version }}, using command: `napari --version` .
 ````
-![macOS desktop with a napari viewer window without any image opened in the foreground, and a terminal in the background with the appropriate conda environment activated (if applicable) and the command to open napari entered.](../assets/tutorials/launch_cli_empty.png)
 
 ````{note}
 On some platforms, particularly macOS and Windows, there may be a ~30 second

--- a/docs/tutorials/fundamentals/installation.md
+++ b/docs/tutorials/fundamentals/installation.md
@@ -157,16 +157,14 @@ An empty napari viewer should appear as follows:
 ![macOS desktop with a napari viewer window without any image opened in the foreground, and a terminal in the background with the appropriate conda environment activated (if applicable) and the command to open napari entered.](../assets/tutorials/launch_cli_empty.png)
 
 ````{note}
-You can check the napari version, to ensure it's what you expect, for example
-the current release {{ napari_version }}, using command: `napari --version` .
-````
-
-````{note}
 On some platforms, particularly macOS and Windows, there may be a ~30 second
 delay before the viewer appears on first launch. This is expected and subsequent
 launches should be quick. However, anti-malware and other security software
 measures may further delay launches—even after the first launch.
 ````
+
+You can check the napari version, to ensure it's what you expect, for example
+the current release {{ napari_version }}, using the command: `napari --version` .
 
 ### Choosing a different Qt backend
 


### PR DESCRIPTION
I think it makes sense to put the image next to the text that references it, instead of the note getting between them. Currently:

![Screenshot 2024-01-23 at 16 08 31](https://github.com/napari/docs/assets/6197628/1f845747-bcec-489c-a0f3-6368b3d19d04)
