### PR TITLE
Update links to napari hub guide

### DIFF
--- a/docs/plugins/testing_and_publishing/deploy.md
+++ b/docs/plugins/testing_and_publishing/deploy.md
@@ -26,7 +26,7 @@ Wiki](https://github.com/chanzuckerberg/napari-hub/wiki).
 
 If you want your plugin to be available on PyPI, but not visible on the napari
 hub, add a `visibility` flag to your plugin manifest. For more details, see the 
-manifest reference and napari hub [customization
+[manifest reference](plugin-manifest) and napari hub [customization
 guide][hub-guide-custom-viz].
 ```
 

--- a/docs/plugins/testing_and_publishing/deploy.md
+++ b/docs/plugins/testing_and_publishing/deploy.md
@@ -38,7 +38,7 @@ PyPI][pypi-upload] after which it will be installable using `python -m pip insta
 in the builtin plugin installer dialog.
 
 If you used the {ref}`plugin-cookiecutter-template`, you can also
-[setup automated deployments][autodeploy] on github for every tagged commit.
+[setup automated deployments][autodeploy] on GitHub for every tagged commit.
 
 ````{admonition} What about conda?
 While you are free to distribute your plugin on anaconda cloud in addition to

--- a/docs/plugins/testing_and_publishing/deploy.md
+++ b/docs/plugins/testing_and_publishing/deploy.md
@@ -11,13 +11,12 @@ Once your package is listed on [PyPI] (and includes the `Framework :: napari`
 [classifier]), it will also be visible on the [napari
 hub](https://napari-hub.org/). To ensure you are providing the relevant metadata and
 description for your plugin, see the following documentation in the [napari hub
-GitHub](https://github.com/chanzuckerberg/napari-hub/tree/main/docs)’s docs
-folder:
+wiki](https://github.com/chanzuckerberg/napari-hub/wiki/Plugin-Developer's-Guide-to-the-napari-hub):
 
 - [Customizing your plugin’s
-  listing](https://github.com/chanzuckerberg/napari-hub/blob/main/docs/customizing-plugin-listing.md)
+  listing][hubguide]
 - [Writing the perfect description for your
-  plugin](https://github.com/chanzuckerberg/napari-hub/blob/main/docs/writing-the-perfect-description.md)
+  plugin](https://github.com/chanzuckerberg/napari-hub/wiki/Writing-the-Perfect-Description-for-your-Plugin)
 
 ```{admonition} The hub
 For more about the napari hub, see the [napari hub About
@@ -26,14 +25,10 @@ development process, see the [napari hub GitHub’s
 Wiki](https://github.com/chanzuckerberg/napari-hub/wiki).
 
 If you want your plugin to be available on PyPI, but not visible on the napari
-hub, you can add a `.napari/config.yml` file to the root of your repository with
-a visibility key. For details, see the [customization
+hub, add a `visibility` flag to your plugin manifest. For more details, see the 
+manifest reference and napari hub [customization
 guide][hub-guide-custom-viz].
 ```
-
-Finally, once you have curated your package metadata and description, you can
-preview your metadata, and check any missing fields using the
-napari hub preview page service. Check out [this guide](https://github.com/chanzuckerberg/napari-hub/blob/main/docs/setting-up-preview.md) for instructions on how to set it up.
 
 ## Deployment
 
@@ -65,5 +60,4 @@ forum](https://forum.image.sc/tag/napari).
 [pypi-upload]: https://packaging.python.org/tutorials/packaging-projects/#uploading-the-distribution-archives
 [hubguide]: https://github.com/chanzuckerberg/napari-hub/blob/main/docs/customizing-plugin-listing.md
 [hub-guide-custom-viz]: https://github.com/chanzuckerberg/napari-hub/wiki/Customizing-your-plugin's-listing#visibility
-[hub-guide-preview]: https://github.com/chanzuckerberg/napari-hub/blob/main/docs/setting-up-preview.md
 [autodeploy]: https://github.com/napari/cookiecutter-napari-plugin#set-up-automatic-deployments

--- a/docs/plugins/testing_and_publishing/deploy.md
+++ b/docs/plugins/testing_and_publishing/deploy.md
@@ -14,7 +14,7 @@ description for your plugin, see the following documentation in the [napari hub
 wiki](https://github.com/chanzuckerberg/napari-hub/wiki/Plugin-Developer's-Guide-to-the-napari-hub):
 
 - [Customizing your plugin’s
-  listing][hubguide]
+  listing](https://github.com/chanzuckerberg/napari-hub/wiki/Customizing-your-plugin's-listing)
 - [Writing the perfect description for your
   plugin](https://github.com/chanzuckerberg/napari-hub/wiki/Writing-the-Perfect-Description-for-your-Plugin)
 

--- a/docs/plugins/testing_and_publishing/test.md
+++ b/docs/plugins/testing_and_publishing/test.md
@@ -4,7 +4,7 @@
 (plugin-testing-tips)=
 ## Tips for testing napari plugins
 
-Testing is a big topic!  If you are completely new to writing tests in python,
+Testing is a big topic!  If you are completely new to writing tests in Python,
 consider reading this post on [Getting Started With Testing in
 Python](https://realpython.com/python-testing/)
 


### PR DESCRIPTION
# References and relevant issues
Supersedes #143.

# Description
This PR updates the links to the napari hub documentation about customizing a plugin's listing. It also removes mentions of the preview page, as the service has been [deprecated](https://github.com/chanzuckerberg/napari-hub/discussions/1216).

<!-- Final Checklist
- If images included: I have added [alt text](https://webaim.org/techniques/alttext/)
If workflow, documentation build or deployment change:
- My PR is the minimum possible work for the desired functionality
- I have commented my code, to let others know what it does
-->
