### PR TITLE
Add announcement banner html to enable config

### DIFF
--- a/docs/_static/announcement.html
+++ b/docs/_static/announcement.html
@@ -1,0 +1,9 @@
+<!-- This will appear in the announcement banner at the top of the site.
+It needs to be activated by passing the link:
+"https://napari.org/dev/_static/announcement.html"
+in the html_theme_options section of conf.py using the key:
+"announcement"
+-->
+<div class="sidebar-message">
+    We want your feedback: take the <a href="https://bit.ly/napari-survey-2023-h">2023 annual survey</a> and help us improve napari for you and the community!
+</div>


### PR DESCRIPTION
# References and relevant issues

First part of #332: make sure the banner html is publicly accessible on
napari.org.

# Description

Discussion [on Zulip](https://napari.zulipchat.com/#narrow/stream/215289-release/topic/0.2E4.2E19/near/418942751).

After this is merged, the banner text will live in

https://napari.org/dev/_static/announcement.html

forever. Since that file can be updated with a merge to main here, it is easy
to add or remove announcements, pending the pydata-sphinx-theme removing the
banner when the text is empty (see @melissawm's [changes soon to be
suggested](https://github.com/melissawm/pydata-sphinx-theme/compare/master...empty-announcement)).
