### PR TITLE
Update conf.py to display the announcement banner

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -110,6 +110,7 @@ html_theme_options = {
     "secondary_sidebar_items": ["page-toc"],
     "pygment_light_style": "napari",
     "pygment_dark_style": "napari",
+    "announcement": "https://napari.org/dev/_static/announcement.html",
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,


### PR DESCRIPTION
# References and relevant issues

Together with #341, this PR supersedes #332.

# Description

The announcement banner text html was added in #341. This PR now points our
config to it, allowing the banner to be displayed.

Note: #332 also has a CSS fix. However, that fix is included in the latest
release of the napari-sphinx-theme, so I think it's best to leave it out of
this PR. (I would be happy to make a separate PR for it if we don't want to
wait until the dependencies are updated.)
