### PR TITLE
Hotfix for announcement banner in dark theme

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -23,3 +23,8 @@ div.sphx-glr-download a:hover {
   background-image: none;
   background-color: #ffffff !important;
 }
+
+/* Workaround for announcement banner */
+html[data-theme="dark"] {
+  --pst-color-secondary-bg: #e0c7ff;
+}


### PR DESCRIPTION
# References and relevant issues

copied from psobolewskiPhD/napari-docs#10

# Description

The announcement banner looks crap in dark mode (see eg
[here](https://github.com/napari/docs/pull/342#issuecomment-1918986743)). This
was fixed for the theme in napari/napari-sphinx-theme#145, but this fixes it
until the theme pin is updated.

