### PR TITLE
Update version switcher for 0.4.19 release

### DIFF
--- a/docs/_static/version_switcher.json
+++ b/docs/_static/version_switcher.json
@@ -5,9 +5,14 @@
 		"url": "https://napari.org/dev/"
 	},
 	{
-		"name": "stable (0.4.18)",
-		"version": "0.4.18",
+		"name": "stable (0.4.19)",
+		"version": "0.4.19",
 		"url": "https://napari.org/stable/"
+	},
+	{
+		"name": "0.4.18",
+		"version": "0.4.18",
+		"url": "https://napari.org/0.4.18/"
 	},
 	{
 		"name": "0.4.17",


### PR DESCRIPTION
Don't merge until the 0.4.19 docs are up! There should be a folder called
0.4.19 in this page:

https://github.com/napari/napari.github.io/tree/gh-pages

and this link should point to 0.4.19/:

https://github.com/napari/napari.github.io/blob/gh-pages/stable

