### PR TITLE
Fix execution of magicgui guide (2)

### DIFF
--- a/docs/howtos/extending/magicgui.md
+++ b/docs/howtos/extending/magicgui.md
@@ -514,7 +514,7 @@ time the function is called:
 ```{code-cell} python
 :tags: [remove-output]
 
-@magicgui(call_button='Make Points', n_points={'maximum': 200})
+@magicgui(call_button='Make Points', n_points={'max': 200})
 def make_points(n_points=40) -> napari.types.LayerDataTuple:
   data = 500 * np.random.rand(n_points, 2)
   # 'My Points' is the name of an existing layer


### PR DESCRIPTION
# Description
This error was first fixed in #314 but undone in https://github.com/napari/docs/pull/286 - probably due to a conflict that wasn't flagged because of the files moving around.