### PR TITLE
Replace survey with help banner

### DIFF
--- a/docs/_static/announcement.html
+++ b/docs/_static/announcement.html
@@ -5,5 +5,5 @@ in the html_theme_options section of conf.py using the key:
 "announcement"
 -->
 <div class="sidebar-message">
-    We want your feedback: take the <a href="https://bit.ly/napari-survey-2023-h">2023 annual survey</a> and help us improve napari for you and the community!
+    Need help? <a href="https://napari.zulipchat.com">Chat with us</a> or join us at one of our <a href="https://napari.org/stable/community/meeting_schedule.html">Community meetings</a>!
 </div>


### PR DESCRIPTION
The survey has now closed. Until we build the docs with a release of pydata sphinx theme containing [this PR](https://github.com/pydata/pydata-sphinx-theme/pull/1703), we can't remove the banner without rebuilding the docs entirely. Therefore, until our next release, we can have some helpful text at the top. 😊

