### PR TITLE
[ENH] Add napari.utils.transforms to API docs

### DIFF
--- a/docs/api/modules.rst
+++ b/docs/api/modules.rst
@@ -13,6 +13,7 @@ For the average user's workflows.
    napari.types
    napari.utils
    napari.window
+   napari.utils.transforms
 
 .. rubric:: Advanced
 


### PR DESCRIPTION
# References and relevant issues
Closes: https://github.com/napari/docs/issues/358

# Description

Adds the transforms to the end of the primary section of the API docs.