### PR TITLE
For this repo, link contributions to documentation contribution guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ You can see details of [the project roadmap here](https://napari.org/roadmaps/in
 
 ## contributing
 
-Contributions are encouraged! Please read our [contributing guide](https://napari.org/stable/developers/documentation/index.html) to get started. Given that we're in an early stage, you may want to reach out on our [Github Issues](https://github.com/napari/napari/issues) before jumping in.
+Contributions are encouraged! Please read our [contributing guide](https://napari.org/dev/developers/contributing/documentation/index.html) to get started. Given that we're in an early stage, you may want to reach out on our [Github Issues](https://github.com/napari/napari/issues) before jumping in.
 
 ## code of conduct
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ You can see details of [the project roadmap here](https://napari.org/roadmaps/in
 
 ## contributing
 
-Contributions are encouraged! Please read our [contributing guide](https://napari.org/dev/developers/contributing/documentation/index.html) to get started. Given that we're in an early stage, you may want to reach out on our [Github Issues](https://github.com/napari/napari/issues) before jumping in.
+Contributions are encouraged! Please read our [contributing guide](https://napari.org/dev/developers/contributing/documentation/index.html) to get started. Given that we're in an early stage, you may want to reach out on our [Github Issues](https://github.com/napari/docs/issues) before jumping in.
 
 ## code of conduct
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ You can see details of [the project roadmap here](https://napari.org/roadmaps/in
 
 ## contributing
 
-Contributions are encouraged! Please read our [contributing guide](https://napari.org/developers/contributing.html) to get started. Given that we're in an early stage, you may want to reach out on our [Github Issues](https://github.com/napari/napari/issues) before jumping in.
+Contributions are encouraged! Please read our [contributing guide](https://napari.org/stable/developers/documentation/index.html) to get started. Given that we're in an early stage, you may want to reach out on our [Github Issues](https://github.com/napari/napari/issues) before jumping in.
 
 ## code of conduct
 


### PR DESCRIPTION
Right now, the "contributing" section of the main README links to the contribution guide for the main project rather than for the documentation itself. This updates the link to point to the contribution guide for the napari documentation.

Partially adresses: https://github.com/napari/docs/issues/265