### PR TITLE
Clarify optionality of type annotations for writing a plugin

### DIFF
--- a/docs/plugins/building_a_plugin/_layer_data_guide.md
+++ b/docs/plugins/building_a_plugin/_layer_data_guide.md
@@ -8,8 +8,8 @@ up often in plugins and is explained here.
 
 Note that when writing your own plugin, type annotations are optional, 
 except in the case of [`magicgui` function widgets](magicgui).
-Here in this section we sometimes provide a type annotation with a more informative name, 
-indicating its value's _functional role_ in a plugin, in addition its possible types.
+Here we sometimes provide a type annotation with a more informative name, 
+indicating its value's _functional role_ in a plugin, in addition to its possible types.
 
 ### Informal description
 

--- a/docs/plugins/building_a_plugin/_layer_data_guide.md
+++ b/docs/plugins/building_a_plugin/_layer_data_guide.md
@@ -8,8 +8,9 @@ up often in plugins and is explained here.
 
 Note that when writing your own plugin, type annotations are optional, 
 except in the case of [`magicgui` function widgets](magicgui).
-Here we sometimes provide a type annotation with a more informative name, 
-indicating its value's _functional role_ in a plugin, in addition to its possible types.
+For several types related to `LayerData` tuples, Napari defines an alias 
+which better indicates a value's _functional role_ in a plugin. 
+We describe these below.
 
 ### Informal description
 

--- a/docs/plugins/building_a_plugin/_layer_data_guide.md
+++ b/docs/plugins/building_a_plugin/_layer_data_guide.md
@@ -58,7 +58,7 @@ class ArrayLike(Protocol):
 
 Note that when writing your own plugin, such type annotations are nearly always optional, 
 except in rare cases like `magicgui` function widgets.
-Here, for clarity, we've provided aliases that indicate how values of the type are 
+Here, for clarity, we've provided type names which indicate how values of the type are 
 being used and the level of generality that's possible (e.g., with `ArrayLike`). 
 
 ### Examples

--- a/docs/plugins/building_a_plugin/_layer_data_guide.md
+++ b/docs/plugins/building_a_plugin/_layer_data_guide.md
@@ -8,8 +8,8 @@ up often in plugins and is explained here.
 
 Note that when writing your own plugin, type annotations are nearly always optional, 
 except in rare cases like [`magicgui` function widgets](magicgui).
-Here in this section, in some examples we provide these annotations with names which indicate 
-their role in a plugin, and the level of generality that's possible (e.g., with `ArrayLike`). 
+Here in this section we sometimes provide a type annotation with a more informative name, 
+indicating its value's _functional role_ in a plugin, in addition its possible types.
 
 ### Informal description
 

--- a/docs/plugins/building_a_plugin/_layer_data_guide.md
+++ b/docs/plugins/building_a_plugin/_layer_data_guide.md
@@ -39,14 +39,13 @@ LayerData = Union[Tuple[DataType], Tuple[DataType, LayerProps], FullLayerData]
 where ...
 
 ```python
-from typing import Dict, Literal, Protocol, Sequence, Tuple, Union
-import numpy as np
+from typing import Literal, Protocol, Sequence
 
 LayerTypeName = Literal[
     "image", "labels", "points", "shapes", "surface", "tracks", "vectors"
 ]
 LayerProps = Dict
-DataType = Union["ArrayLike", Sequence["ArrayLike"]]
+DataType = Union[ArrayLike, Sequence[ArrayLike]]
 FullLayerData = Tuple[DataType, LayerProps, LayerTypeName]
 LayerData = Union[Tuple[DataType], Tuple[DataType, LayerProps], FullLayerData]
 
@@ -57,7 +56,7 @@ class ArrayLike(Protocol):
     ndim: int
     dtype: np.dtype
     def __array__(self) -> np.ndarray: ...
-    def __getitem__(self, key) -> "ArrayLike": ...
+    def __getitem__(self, key) -> ArrayLike: ...
 
 # the main point is that we're more concerned with structural
 # typing than literal array types (e.g. numpy, dask, xarray, etc...)

--- a/docs/plugins/building_a_plugin/_layer_data_guide.md
+++ b/docs/plugins/building_a_plugin/_layer_data_guide.md
@@ -8,7 +8,7 @@ up often in plugins and is explained here.
 
 Note that when writing your own plugin, type annotations are optional, 
 except in the case of [`magicgui` function widgets](magicgui).
-For several types related to `LayerData` tuples, Napari defines an alias 
+For several types related to `LayerData` tuples, Napari defines a type alias 
 which better indicates a value's _functional role_ in a plugin. 
 We describe these below.
 

--- a/docs/plugins/building_a_plugin/_layer_data_guide.md
+++ b/docs/plugins/building_a_plugin/_layer_data_guide.md
@@ -38,13 +38,14 @@ LayerData = Union[Tuple[DataType], Tuple[DataType, LayerProps], FullLayerData]
 where ...
 
 ```python
-from typing import Literal, Protocol, Sequence
+from typing import Dict, Literal, Protocol, Sequence, Tuple, Union
+import numpy as np
 
 LayerTypeName = Literal[
     "image", "labels", "points", "shapes", "surface", "tracks", "vectors"
 ]
 LayerProps = Dict
-DataType = Union[ArrayLike, Sequence[ArrayLike]]
+DataType = Union["ArrayLike", Sequence["ArrayLike"]]
 FullLayerData = Tuple[DataType, LayerProps, LayerTypeName]
 LayerData = Union[Tuple[DataType], Tuple[DataType, LayerProps], FullLayerData]
 
@@ -55,7 +56,7 @@ class ArrayLike(Protocol):
     ndim: int
     dtype: np.dtype
     def __array__(self) -> np.ndarray: ...
-    def __getitem__(self, key) -> ArrayLike: ...
+    def __getitem__(self, key) -> "ArrayLike": ...
 
 # the main point is that we're more concerned with structural
 # typing than literal array types (e.g. numpy, dask, xarray, etc...)

--- a/docs/plugins/building_a_plugin/_layer_data_guide.md
+++ b/docs/plugins/building_a_plugin/_layer_data_guide.md
@@ -6,6 +6,11 @@ directly. Instead, it passes (mostly) pure-python and array-like types,
 deconstructed into a {class}`tuple` that we refer to as a `LayerData` tuple.  This type shows
 up often in plugins and is explained here.
 
+Note that when writing your own plugin, type annotations are nearly always optional, 
+except in rare cases like [`magicgui` function widgets](magicgui).
+Here in this section, in some examples we provide these annotations with names which indicate 
+their role in a plugin, and the level of generality that's possible (e.g., with `ArrayLike`). 
+
 ### Informal description
 
 ```py
@@ -55,11 +60,6 @@ class ArrayLike(Protocol):
 # the main point is that we're more concerned with structural
 # typing than literal array types (e.g. numpy, dask, xarray, etc...)
 ```
-
-Note that when writing your own plugin, such type annotations are nearly always optional, 
-except in rare cases like `magicgui` function widgets.
-Here, for clarity, we've provided type names which indicate how values of the type are 
-being used and the level of generality that's possible (e.g., with `ArrayLike`). 
 
 ### Examples
 

--- a/docs/plugins/building_a_plugin/_layer_data_guide.md
+++ b/docs/plugins/building_a_plugin/_layer_data_guide.md
@@ -56,6 +56,11 @@ class ArrayLike(Protocol):
 # typing than literal array types (e.g. numpy, dask, xarray, etc...)
 ```
 
+Note that when writing your own plugin, such type annotations are nearly always optional, 
+except in rare cases like `magicgui` function widgets.
+Here, for clarity, we've provided aliases that indicate the how values of the type are 
+being used and the level of generality that's possible (e.g., with `ArrayLike`). 
+
 ### Examples
 
 Assume that `data` is a numpy array:

--- a/docs/plugins/building_a_plugin/_layer_data_guide.md
+++ b/docs/plugins/building_a_plugin/_layer_data_guide.md
@@ -8,7 +8,7 @@ up often in plugins and is explained here.
 
 Note that when writing your own plugin, type annotations are optional, 
 except in the case of [`magicgui` function widgets](magicgui).
-For several types related to `LayerData` tuples, Napari defines a type alias 
+For several types related to `LayerData` tuples, napari defines a type alias 
 which better indicates a value's _functional role_ in a plugin. 
 We describe these below.
 

--- a/docs/plugins/building_a_plugin/_layer_data_guide.md
+++ b/docs/plugins/building_a_plugin/_layer_data_guide.md
@@ -58,7 +58,7 @@ class ArrayLike(Protocol):
 
 Note that when writing your own plugin, such type annotations are nearly always optional, 
 except in rare cases like `magicgui` function widgets.
-Here, for clarity, we've provided aliases that indicate the how values of the type are 
+Here, for clarity, we've provided aliases that indicate how values of the type are 
 being used and the level of generality that's possible (e.g., with `ArrayLike`). 
 
 ### Examples

--- a/docs/plugins/building_a_plugin/_layer_data_guide.md
+++ b/docs/plugins/building_a_plugin/_layer_data_guide.md
@@ -6,8 +6,8 @@ directly. Instead, it passes (mostly) pure-python and array-like types,
 deconstructed into a {class}`tuple` that we refer to as a `LayerData` tuple.  This type shows
 up often in plugins and is explained here.
 
-Note that when writing your own plugin, type annotations are nearly always optional, 
-except in rare cases like [`magicgui` function widgets](magicgui).
+Note that when writing your own plugin, type annotations are optional, 
+except in the case of [`magicgui` function widgets](magicgui).
 Here in this section we sometimes provide a type annotation with a more informative name, 
 indicating its value's _functional role_ in a plugin, in addition its possible types.
 


### PR DESCRIPTION
This would close #365 by making more explicit the optionality of type annotations when writing a plugin, and adding a general note about their utility in the doc.