### PR TITLE
Add info about tests that require window focus and `pyautogui` permissions setup on macOS

### DIFF
--- a/docs/developers/contributing/testing.md
+++ b/docs/developers/contributing/testing.md
@@ -82,13 +82,15 @@ and are available within
 To run our test suite locally, run `pytest` on the command line.  If, for some reason
 you don't already have the test requirements in your environment, run `python -m pip install -e .[testing]`.
 
-There are some tests that require showing GUI elements, (such
-as testing screenshots). By default, these are only run during continuous integration.
+There are some tests that require showing GUI elements (such
+as testing screenshots) and window focus (such as testing drag and drop behavior). By default, these are only run during continuous integration.
 If you'd like to include them in local tests, set the environment variable "CI":
 
 ```sh
 CI=1 pytest
 ```
+
+ Also, if running the tests on macOS, be sure to give the Terminal app `Accessibility` permissions in `System Settings > Privacy & Security > Accessibility` (needed for some tests that rely on `pyautogui`).
 
 It is also possible to run test using `tox`. This is the same way as it is done in CI.
 The main difference is that tox will create a virtual environment for each test environment, so it will take more time
@@ -241,11 +243,10 @@ you create during testing need to be cleaned up at the end of each test:
 > If you're curious to see the actual `make_napari_viewer` fixture definition, it's
 > in [`napari/utils/_testsupport.py`](https://github.com/napari/napari/blob/main/napari/utils/_testsupport.py).
 
-#### Skipping tests that show GUI elements
+#### Skipping tests that show GUI elements or need window focus
 
-Tests that require showing GUI elements should be marked with `skip_local_popups`.
-This is so they can be excluded and run only during continuous integration (see
-[](running-tests) for details).
+Tests that require showing GUI elements should be marked with `skip_local_popups`. If a test requires window focus, it should be marked with `skip_local_focus`. 
+This is so they can be excluded and run only during continuous integration (see [](running-tests) for details).
 
 #### Testing `QWidget` visibility
 

--- a/docs/developers/contributing/testing.md
+++ b/docs/developers/contributing/testing.md
@@ -84,13 +84,14 @@ you don't already have the test requirements in your environment, run `python -m
 
 There are some tests that require showing GUI elements (such
 as testing screenshots) and window focus (such as testing drag and drop behavior). By default, these are only run during continuous integration.
-If you'd like to include them in local tests, set the environment variable "CI":
+If you'd like to enable them in local tests, you can set the environment variables: `NAPARI_POPUP_TESTS=1` or `NAPARI_FOCUS_TESTS=1` or set the environment variable `CI=1`:
 
 ```sh
 CI=1 pytest
 ```
 
- Also, if running the tests on macOS, be sure to give the Terminal app `Accessibility` permissions in `System Settings > Privacy & Security > Accessibility` (needed for some tests that rely on `pyautogui`).
+Note: setting `CI=1` will also disable certain tests that take too long, etc. on CI.
+Also, if running the GUI tests that use `pyautogui` on macOS, be sure to give the Terminal app `Accessibility` permissions in `System Settings > Privacy & Security > Accessibility` so `pyautogui` can control the mouse, keyboard, etc.
 
 It is also possible to run test using `tox`. This is the same way as it is done in CI.
 The main difference is that tox will create a virtual environment for each test environment, so it will take more time


### PR DESCRIPTION
# References and relevant issues
<!-- What relevant resources were used in the creation of this PR?
If this PR addresses an existing issue on the repo,
please link to that issue here as "Closes #(issue-number)".
If this PR adds docs for a napari PR please add a "Depends on <napari PR link>" -->

# Description
<!-- What does this pull request (PR) do? Does it add new content, improve/fix existing
context, improve/fix workflow/documentation build/deployment or something else?
<!-- If relevant, please include a screenshot or a screen capture in your content
change: "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations. -->
<!-- You can also see a preview of the documentation changes you are submitting by
clicking on "Details" to the right of the "Check the rendered docs here!" check on your PR.-->
Add info related with tests that use `pyautogui` and the `skip_local_focus` decorator like the one being done at https://github.com/napari/napari/pull/6699


<!-- Final Checklist
- If images included: I have added [alt text](https://webaim.org/techniques/alttext/)
If workflow, documentation build or deployment change:
- My PR is the minimum possible work for the desired functionality
- I have commented my code, to let others know what it does
-->
