### PR TITLE
Inlcude docstring of `make_napari_viewer` in `testing.md`

### DIFF
--- a/docs/developers/contributing/documentation/index.md
+++ b/docs/developers/contributing/documentation/index.md
@@ -447,6 +447,7 @@ If you are using an IDE, it is likely that it will not use Git Bash by default. 
 ```json
 "terminal.integrated.defaultProfile.windows": "Git Bash"
 ```
+
 ````
 
 ### Windows Subsystem for Linux (WSL)

--- a/docs/developers/contributing/documentation/index.md
+++ b/docs/developers/contributing/documentation/index.md
@@ -447,7 +447,6 @@ If you are using an IDE, it is likely that it will not use Git Bash by default. 
 ```json
 "terminal.integrated.defaultProfile.windows": "Git Bash"
 ```
-<br/><br/>
 ````
 
 ### Windows Subsystem for Linux (WSL)

--- a/docs/developers/contributing/documentation/index.md
+++ b/docs/developers/contributing/documentation/index.md
@@ -447,7 +447,7 @@ If you are using an IDE, it is likely that it will not use Git Bash by default. 
 ```json
 "terminal.integrated.defaultProfile.windows": "Git Bash"
 ```
-
+<br/><br/>
 ````
 
 ### Windows Subsystem for Linux (WSL)

--- a/docs/developers/contributing/testing.md
+++ b/docs/developers/contributing/testing.md
@@ -231,12 +231,13 @@ def test_something_else(qtbot):
 
 We provide a
 [pytest fixture](https://docs.pytest.org/en/stable/explanation/fixtures.html) called
-`make_napari_viewer` for tests that require the {class}`~napari.Viewer`:
+`make_napari_viewer` for tests that require the {class}`~napari.Viewer`. This
+fixture is available globally and to all tests in the same environment that `napari`
+is in (see [](test-organization) for details). To use, simply include
+`make_napari_viewer` as a test function parameter, as shown below:
 
 ```{eval-rst}
-.. automodule:: napari.utils._testsupport
-
-    .. autofunction:: .make_napari_viewer()
+.. autofunction:: napari.utils._testsupport.make_napari_viewer()
 ```
 
 #### Skipping tests that show GUI elements or need window focus

--- a/docs/developers/contributing/testing.md
+++ b/docs/developers/contributing/testing.md
@@ -191,62 +191,52 @@ See also [this paper on property-based testing in science](https://conference.sc
 ### Testing with `Qt` and `napari.Viewer`
 
 There are a couple things to keep in mind when writing a test where a `Qt` event
-loop or a `napari.Viewer` is required.  The important thing is that any widgets
-you create during testing need to be cleaned up at the end of each test:
+loop or a {class}`~napari.Viewer` is required.  The important thing is that any widgets
+you create during testing need to be cleaned up at the end of each test. We thus
+recommend that you use the following fixtures when needing a widget or
+{class}`~napari.Viewer` in a test.
 
-1. If you need a `QApplication` to be running for your test, you can use the
-   [`qtbot`](https://pytest-qt.readthedocs.io/en/latest/reference.html#pytestqt.qtbot.QtBot) fixture from `pytest-qt`
+#### qtbot
 
-    > note: fixtures in pytest can be a little mysterious, since it's not always
-    > clear where they are coming from.  In this case, using a pytest-qt fixture
-    > looks like this:
+If you need a `QApplication` to be running for your test, you can use the
+[`qtbot`](https://pytest-qt.readthedocs.io/en/latest/reference.html#pytestqt.qtbot.QtBot) fixture from `pytest-qt`
 
-    ```python
-    # just by putting `qtbot` in the list of arguments
-    # pytest-qt will start up an event loop for you
-    def test_something(qtbot):
-        ...
-    ```
+> note: fixtures in pytest can be a little mysterious, since it's not always
+> clear where they are coming from.  In this case, using a pytest-qt fixture
+> looks like this:
 
-   `qtbot` provides a convenient
-   [`addWidget`](https://pytest-qt.readthedocs.io/en/latest/reference.html#pytestqt.qtbot.QtBot.addWidget)
-   method that will ensure that the widget gets closed at the end of the test.
-   It *also* provides a whole bunch of other
-   convenient methods for interacting with your GUI tests (clicking, waiting
-   signals, etc...).  See the [`qtbot` docs](https://pytest-qt.readthedocs.io/en/latest/reference.html#pytestqt.qtbot.QtBot) for details.
+```python
+# just by putting `qtbot` in the list of arguments
+# pytest-qt will start up an event loop for you
+def test_something(qtbot):
+    ...
+```
 
-    ```python
-    # the qtbot provides convenience methods like addWidget
-    def test_something_else(qtbot):
-        widget = QWidget()
-        qtbot.addWidget(widget)  # tell qtbot to clean this widget later
-        ...
-    ```
+`qtbot` provides a convenient
+[`addWidget`](https://pytest-qt.readthedocs.io/en/latest/reference.html#pytestqt.qtbot.QtBot.addWidget)
+method that will ensure that the widget gets closed at the end of the test.
+It *also* provides a whole bunch of other
+convenient methods for interacting with your GUI tests (clicking, waiting
+signals, etc...).  See the [`qtbot` docs](https://pytest-qt.readthedocs.io/en/latest/reference.html#pytestqt.qtbot.QtBot) for details.
 
-2. When writing a test that requires a `napari.Viewer` object, we provide a
-   [pytest fixture](https://docs.pytest.org/en/stable/explanation/fixtures.html) called
-   `make_napari_viewer` that will take care of creating a viewer and cleaning up
-   at the end of the test.  When using this function, it is **not** necessary to
-   use a `qtbot` fixture, nor should you do any additional cleanup (such as
-   using `qtbot.addWidget` or calling `viewer.close()`) at the end of the test.
-   Duplicate cleanup may cause an error.  Use the fixture as follows:
+```python
+# the qtbot provides convenience methods like addWidget
+def test_something_else(qtbot):
+    widget = QWidget()
+    qtbot.addWidget(widget)  # tell qtbot to clean this widget later
+    ...
+```
 
-    ```python
-    # the make_napari_viewer fixture is defined in napari/utils/_testsupport.py
-    def test_something_with_a_viewer(make_napari_viewer):
-        # make_napari_viewer takes any keyword arguments that napari.Viewer() takes
-        viewer = make_napari_viewer()
+#### `make_napari_viewer`
 
-        # do stuff with the viewer, no qtbot or viewer.close() methods needed.
-        ...
-    ```
+.. autofunction:: napari.utils._testsupport.make_napari_viewer
 
 > If you're curious to see the actual `make_napari_viewer` fixture definition, it's
 > in [`napari/utils/_testsupport.py`](https://github.com/napari/napari/blob/main/napari/utils/_testsupport.py).
 
 #### Skipping tests that show GUI elements or need window focus
 
-Tests that require showing GUI elements should be marked with `skip_local_popups`. If a test requires window focus, it should be marked with `skip_local_focus`. 
+Tests that require showing GUI elements should be marked with `skip_local_popups`. If a test requires window focus, it should be marked with `skip_local_focus`.
 This is so they can be excluded and run only during continuous integration (see [](running-tests) for details).
 
 #### Testing `QWidget` visibility

--- a/docs/developers/contributing/testing.md
+++ b/docs/developers/contributing/testing.md
@@ -230,7 +230,7 @@ def test_something_else(qtbot):
 #### `make_napari_viewer`
 
 ```{eval-rst}
-.. autofunction:: make_napari_viewer
+.. autofunction:: napari.utils._testsupport.make_napari_viewer
 ```
 
 > If you're curious to see the actual `make_napari_viewer` fixture definition, it's

--- a/docs/developers/contributing/testing.md
+++ b/docs/developers/contributing/testing.md
@@ -207,12 +207,12 @@ Fixtures in pytest can be a little mysterious, since it's not always
 clear where they are coming from.  In this case using the `pytest-qt` `qtbot`fixture
 looks like this:
 
-    ```python
-    # just by putting `qtbot` in the list of arguments
-    # pytest-qt will start up an event loop for you
-    def test_something(qtbot):
-        ...
-    ```
+```python
+# just by putting `qtbot` in the list of arguments
+# pytest-qt will start up an event loop for you
+def test_something(qtbot):
+    ...
+```
 ````
 
 `qtbot` provides a convenient

--- a/docs/developers/contributing/testing.md
+++ b/docs/developers/contributing/testing.md
@@ -202,7 +202,7 @@ If you need a `QApplication` to be running for your test, you can use the
 [`qtbot`](https://pytest-qt.readthedocs.io/en/latest/reference.html#pytestqt.qtbot.QtBot)
 fixture from `pytest-qt`, a napari testing dependency.
 
-```{note}
+````{note}
 Fixtures in pytest can be a little mysterious, since it's not always
 clear where they are coming from.  In this case using the `pytest-qt` `qtbot`fixture
 looks like this:
@@ -213,7 +213,7 @@ looks like this:
     def test_something(qtbot):
         ...
     ```
-```
+````
 
 `qtbot` provides a convenient
 [`addWidget`](https://pytest-qt.readthedocs.io/en/latest/reference.html#pytestqt.qtbot.QtBot.addWidget)

--- a/docs/developers/contributing/testing.md
+++ b/docs/developers/contributing/testing.md
@@ -213,6 +213,7 @@ looks like this:
 def test_something(qtbot):
     ...
 ```
+
 ````
 
 `qtbot` provides a convenient

--- a/docs/developers/contributing/testing.md
+++ b/docs/developers/contributing/testing.md
@@ -229,7 +229,9 @@ def test_something_else(qtbot):
 
 #### `make_napari_viewer`
 
-.. autofunction:: napari.utils._testsupport.make_napari_viewer
+```{eval-rst}
+.. autofunction:: make_napari_viewer
+```
 
 > If you're curious to see the actual `make_napari_viewer` fixture definition, it's
 > in [`napari/utils/_testsupport.py`](https://github.com/napari/napari/blob/main/napari/utils/_testsupport.py).

--- a/docs/developers/contributing/testing.md
+++ b/docs/developers/contributing/testing.md
@@ -213,7 +213,7 @@ looks like this:
 def test_something(qtbot):
     ...
 ```
-<br/><br/>
+<br/>
 ````
 
 `qtbot` provides a convenient

--- a/docs/developers/contributing/testing.md
+++ b/docs/developers/contributing/testing.md
@@ -201,15 +201,17 @@ recommend that you use the following fixtures when needing a widget or
 If you need a `QApplication` to be running for your test, you can use the
 [`qtbot`](https://pytest-qt.readthedocs.io/en/latest/reference.html#pytestqt.qtbot.QtBot) fixture from `pytest-qt`
 
-> note: fixtures in pytest can be a little mysterious, since it's not always
-> clear where they are coming from.  In this case, using a pytest-qt fixture
-> looks like this:
+```{admonition}
+Fixtures in pytest can be a little mysterious, since it's not always
+clear where they are coming from.  In this case, using `qtbot` is a fixture from
+`pytest-qt`, a napari testing dependency, and can be used like this:
 
 ```python
 # just by putting `qtbot` in the list of arguments
 # pytest-qt will start up an event loop for you
 def test_something(qtbot):
     ...
+```
 ```
 
 `qtbot` provides a convenient
@@ -233,8 +235,9 @@ We provide a
 [pytest fixture](https://docs.pytest.org/en/stable/explanation/fixtures.html) called
 `make_napari_viewer` for tests that require the {class}`~napari.Viewer`. This
 fixture is available globally and to all tests in the same environment that `napari`
-is in (see [](test-organization) for details). To use, simply include
-`make_napari_viewer` as a test function parameter, as shown below:
+is in (see [](test-organization) for details). Thus, there is no need to import it,
+you simply include `make_napari_viewer` as a test function parameter, as shown in the
+**Examples** section below:
 
 ```{eval-rst}
 .. autofunction:: napari.utils._testsupport.make_napari_viewer()

--- a/docs/developers/contributing/testing.md
+++ b/docs/developers/contributing/testing.md
@@ -230,7 +230,8 @@ def test_something_else(qtbot):
 #### `make_napari_viewer`
 
 ```{eval-rst}
-.. autofunction:: napari.utils._testsupport.make_napari_viewer
+.. currentmodule:: napari.utils._testsupport
+.. autofunction:: make_napari_viewer()
 ```
 
 > If you're curious to see the actual `make_napari_viewer` fixture definition, it's

--- a/docs/developers/contributing/testing.md
+++ b/docs/developers/contributing/testing.md
@@ -229,13 +229,13 @@ def test_something_else(qtbot):
 
 #### `make_napari_viewer`
 
-```{eval-rst}
-.. currentmodule:: napari.utils._testsupport
-.. autofunction:: make_napari_viewer()
-```
+We provide a
+[pytest fixture](https://docs.pytest.org/en/stable/explanation/fixtures.html) called
+`make_napari_viewer` for tests that require the {class}`~napari.Viewer`:
 
-> If you're curious to see the actual `make_napari_viewer` fixture definition, it's
-> in [`napari/utils/_testsupport.py`](https://github.com/napari/napari/blob/main/napari/utils/_testsupport.py).
+```{eval-rst}
+.. autofunction:: napari.utils._testsupport.make_napari_viewer()
+```
 
 #### Skipping tests that show GUI elements or need window focus
 

--- a/docs/developers/contributing/testing.md
+++ b/docs/developers/contributing/testing.md
@@ -213,7 +213,7 @@ looks like this:
 def test_something(qtbot):
     ...
 ```
-
+<br/><br/>
 ````
 
 `qtbot` provides a convenient

--- a/docs/developers/contributing/testing.md
+++ b/docs/developers/contributing/testing.md
@@ -236,7 +236,7 @@ We provide a
 ```{eval-rst}
 .. automodule:: napari.utils._testsupport
 
-    .. autofunction:: make_napari_viewer()
+    .. autofunction:: .make_napari_viewer()
 ```
 
 #### Skipping tests that show GUI elements or need window focus

--- a/docs/developers/contributing/testing.md
+++ b/docs/developers/contributing/testing.md
@@ -234,7 +234,9 @@ We provide a
 `make_napari_viewer` for tests that require the {class}`~napari.Viewer`:
 
 ```{eval-rst}
-.. autofunction:: napari.utils._testsupport.make_napari_viewer()
+.. automodule:: napari.utils._testsupport
+
+    .. autofunction:: make_napari_viewer()
 ```
 
 #### Skipping tests that show GUI elements or need window focus

--- a/docs/developers/contributing/testing.md
+++ b/docs/developers/contributing/testing.md
@@ -199,19 +199,20 @@ recommend that you use the following fixtures when needing a widget or
 #### qtbot
 
 If you need a `QApplication` to be running for your test, you can use the
-[`qtbot`](https://pytest-qt.readthedocs.io/en/latest/reference.html#pytestqt.qtbot.QtBot) fixture from `pytest-qt`
+[`qtbot`](https://pytest-qt.readthedocs.io/en/latest/reference.html#pytestqt.qtbot.QtBot)
+fixture from `pytest-qt`, a napari testing dependency.
 
-```{admonition}
+```{note}
 Fixtures in pytest can be a little mysterious, since it's not always
-clear where they are coming from.  In this case, using `qtbot` is a fixture from
-`pytest-qt`, a napari testing dependency, and can be used like this:
+clear where they are coming from.  In this case using the `pytest-qt` `qtbot`fixture
+looks like this:
 
-```python
-# just by putting `qtbot` in the list of arguments
-# pytest-qt will start up an event loop for you
-def test_something(qtbot):
-    ...
-```
+    ```python
+    # just by putting `qtbot` in the list of arguments
+    # pytest-qt will start up an event loop for you
+    def test_something(qtbot):
+        ...
+    ```
 ```
 
 `qtbot` provides a convenient


### PR DESCRIPTION
# References and relevant issues
Towards https://github.com/napari/docs/issues/150
Depends on https://github.com/napari/napari/pull/6774

# Description
Use `autofunction` to include docstring of `make_napari_viewer`


