### PR TITLE
[Maint] fix the download and deploy part of workflow

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -80,18 +80,18 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: docs
-          path: docs/docs/_build/html
+          path: docs/docs/_build/html/
 
   deploy:
     if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/heads/main'))
-    name: Build & Upload Artifact
+    name: Download & Deploy Artifact
+    needs: build-and-upload
     runs-on: ubuntu-latest
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
           name: docs
-          path: docs
 
       - name: get directory name
         # if this is a tag, use the tag name as the directory name else dev

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -107,7 +107,7 @@ jobs:
         with:
           deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
           external_repository: napari/napari.github.io
-          publish_dir: docs/docs/_build/html
+          publish_dir: ./docs
           publish_branch: gh-pages
           destination_dir: ${{ env.branch_name }}
           cname: napari.org


### PR DESCRIPTION
# References and relevant issues
The second part, deployment, of the new unified workflow is failing:
`Error: Unable to download artifact(s): Artifact not found for name: docs`
https://github.com/napari/docs/actions/runs/8457634044/job/23170039408
If you check the timestamps it's running *concurrently* with the `build&upload` job, so the artifact probably isn't there to download.
Additionally, I think the `publish_dir` is wrong, because it's the dir the docs were built into, but now the docs are being downloaded as an artifact, so the artifact should be used.


# Description
In this PR:
- I make the 2nd job depend on the completion of the first using `needs`
- I change the name to `Download & Deploy` to reduce confusion with the previous job.
- I think the extra `path` in for the `actions/download-artifact@v4` step  is spurious, so I delete it.
- fix the `publish_dir` of the deploy action to use the downloaded artifact