### PR TITLE
fix build_and_deploy.yml take 2

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
-          path: html
+          name: html
 
       - name: get directory name
         # if this is a tag, use the tag name as the directory name else dev


### PR DESCRIPTION
# References and relevant issues
The current deployment is working but writing to `dev/html`
https://github.com/napari/napari.github.io/commit/610d1d91f801dd99fef8c6ffaa01927a201d43c9

Downloading the artifact is making an extra `html`:
> Starting download of artifact to: /home/runner/work/docs/docs/html/html


# Description
I think this PR should fix it, by not creating an extra path.
