### PR TITLE
[maint] fix app-model intersphinx link

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -162,8 +162,8 @@ intersphinx_mapping = {
         'https://pyapp-kit.github.io/magicgui/objects.inv',
     ],
     'app-model': [
-        'https://app-model--142.org.readthedocs.build/en/142/',
-        'https://app-model--142.org.readthedocs.build/en/142/objects.inv',
+        'http://app-model.readthedocs.io/en/latest/',
+        'http://app-model.readthedocs.io/en/latest/objects.inv',
     ],
 }
 


### PR DESCRIPTION
# References and relevant issues
Closes: https://github.com/napari/docs/issues/387

# Description
This PR fixes the link to the app-model API docs in the intersphinx_mapping in conf.py
