### PR TITLE
Update `docs_deployment.md` and add paths to workflow

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -1,6 +1,5 @@
 # As much as possible, this file should be kept in sync with
 # https://github.com/napari/napari/blob/main/.github/workflows/build_docs.yml
-# and https://github.com/napari/napari/blob/main/.github/workflows/deploy_docs.yml
 #
 # Note this workflow is also triggered by
 # https://github.com/napari/napari/blob/main/.github/workflows/deploy_docs.yml when a

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -1,6 +1,10 @@
 # As much as possible, this file should be kept in sync with
 # https://github.com/napari/napari/blob/main/.github/workflows/build_docs.yml
 # and https://github.com/napari/napari/blob/main/.github/workflows/deploy_docs.yml
+#
+# This workflow is triggered by
+# https://github.com/napari/napari/blob/main/.github/workflows/deploy_docs.yml when a
+# merge to `main` occurs in napari/napari
 
 name: Build & Deploy PR Docs
 

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -92,16 +92,14 @@ jobs:
     name: Download & Deploy Artifact
     needs: build-and-upload
     runs-on: ubuntu-latest
+    # Working directory: '/home/runner/work/docs/docs'
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
           name: html
+          # Downloads to '/home/runner/work/docs/docs/html'
           path: html
-      - name: show files
-        run: |
-          pwd
-          ls -lR
 
       - name: get directory name
         # if this is a tag, use the tag name as the directory name else dev

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -1,5 +1,7 @@
 # As much as possible, this file should be kept in sync with
 # https://github.com/napari/napari/blob/main/.github/workflows/build_docs.yml
+# and https://github.com/napari/napari/blob/main/.github/workflows/deploy_docs.yml
+
 name: Build PR Docs
 
 on:

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -2,9 +2,9 @@
 # https://github.com/napari/napari/blob/main/.github/workflows/build_docs.yml
 # and https://github.com/napari/napari/blob/main/.github/workflows/deploy_docs.yml
 #
-# This workflow is triggered by
+# Note this workflow is also triggered by
 # https://github.com/napari/napari/blob/main/.github/workflows/deploy_docs.yml when a
-# merge to `main` occurs in napari/napari
+# merge to `main` occurs in `napari/napari`
 
 name: Build & Deploy PR Docs
 

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -2,7 +2,7 @@
 # https://github.com/napari/napari/blob/main/.github/workflows/build_docs.yml
 # and https://github.com/napari/napari/blob/main/.github/workflows/deploy_docs.yml
 
-name: Build PR Docs
+name: Build & Deploy PR Docs
 
 on:
   push:
@@ -27,11 +27,13 @@ jobs:
       - name: Clone docs repo
         uses: actions/checkout@v4
         with:
+          # place in '/home/runner/work/docs/docs/docs'
           path: docs  # place in a named directory
 
       - name: Clone main repo
         uses: actions/checkout@v4
         with:
+          # place in '/home/runner/work/docs/docs/napari'
           path: napari  # place in a named directory
           repository: napari/napari
           # ensure version metadata is proper
@@ -71,6 +73,8 @@ jobs:
           GOOGLE_CALENDAR_API_KEY: ${{ secrets.GOOGLE_CALENDAR_API_KEY }}
           PIP_CONSTRAINT: ${{ github.workspace }}/napari/resources/constraints/constraints_py3.10_docs.txt
         with:
+          # Runs in '/home/runner/work/docs/docs/docs'
+          # Built HTML pages in '/home/runner/work/docs/docs/docs/docs/_build/html'
           run:  make -C docs docs
           # skipping setup stops the action from running the default (tiling) window manager
           # the window manager is not necessary for docs builds at this time and it was causing
@@ -101,9 +105,9 @@ jobs:
         # if this is a tag, use the tag name as the directory name else dev
         run: |
           if [[ "${{ github.ref }}" == "refs/tags/"* ]]; then
-            echo "branch_name=${{ github.ref_name }}" >> $GITHUB_ENV 
+            echo "branch_name=${{ github.ref_name }}" >> $GITHUB_ENV
           else
-            echo "branch_name=dev" >> $GITHUB_ENV 
+            echo "branch_name=dev" >> $GITHUB_ENV
           fi
 
       - name: Deploy Docs

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -99,7 +99,9 @@ jobs:
           name: html
           path: html
       - name: show files
-        run: ls -lR
+        run: |
+          pwd
+          ls -lR
 
       - name: get directory name
         # if this is a tag, use the tag name as the directory name else dev

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -3,7 +3,7 @@
 #
 # Note this workflow is also triggered by
 # https://github.com/napari/napari/blob/main/.github/workflows/deploy_docs.yml when a
-# merge to `main` occurs in `napari/napari`
+# commit to `main` occurs in `napari/napari`
 
 name: Build & Deploy PR Docs
 

--- a/docs/developers/contributing/documentation/docs_deployment.md
+++ b/docs/developers/contributing/documentation/docs_deployment.md
@@ -29,13 +29,12 @@ through several CI workflows detailed below.
           `napari.org` website.)
 
 2. [`napari/docs`](https://github.com/napari/docs)
-    - **Workflow file:** [`build_docs.yml`](https://github.com/napari/docs/blob/main/.github/workflows/build_docs.yml)
+    - **Workflow file:** [`build_and_deploy.yml`](https://github.com/napari/docs/blob/main/.github/workflows/build_and_deploy.yml)
         - **job:** `build-and-upload`
         - Pulls in sources from `napari/napari` and builds docs locally. Uploads
           artifacts to this repo (`napari/docs`).
         - This is triggered on every Pull Request and shows up as a "Build PR
           Docs" check on the PR.
-    - **Workflow file:** [`deploy_docs.yml`](https://github.com/napari/docs/blob/main/.github/workflows/deploy_docs.yml)
         - **job:** `build-and-deploy`
         - Builds docs locally and deploys resulting artifacts to GitHub pages at
           the `gh-pages` branch of [napari/napari.github.io](https://github.com/napari/napari.github.io/tree/gh-pages).
@@ -45,7 +44,7 @@ through several CI workflows detailed below.
           (and consequently triggers a new deployment of the `napari.org`
           website.)
 
-    Note that these file are not identical to the `napari/napari` versions.
+    Note that these files are not identical to the `napari/napari` version.
 
 3. [`napari/napari.github.io`](https://github.com/napari/napari.github.io)
     - Contains built documentation files (.html) for all versions in the

--- a/docs/developers/contributing/documentation/docs_deployment.md
+++ b/docs/developers/contributing/documentation/docs_deployment.md
@@ -28,7 +28,7 @@ through several CI workflows detailed below.
         - This is triggered on any commit to the `main` branch on
           `napari/napari` (and consequently triggers a new deployment of the
           `napari.org` website). When the commit is tagged, the `build_and_deploy.yml`
-          workflow will deploy to the version folder e.g., `0.4.19/`.
+          workflow will deploy to the version folder e.g., `{{ napari_version }}`.
 
 2. [`napari/docs`](https://github.com/napari/docs)
     - **Workflow file:** [`build_and_deploy.yml`](https://github.com/napari/docs/blob/main/.github/workflows/build_and_deploy.yml)

--- a/docs/developers/contributing/documentation/docs_deployment.md
+++ b/docs/developers/contributing/documentation/docs_deployment.md
@@ -20,7 +20,7 @@ through several CI workflows detailed below.
         - This is triggered on every Pull Request and shows up as a "Build PR
           Docs" check on the PR.
     - **Workflow file:** [`deploy_docs.yml`](https://github.com/napari/napari/blob/main/.github/workflows/deploy_docs.yml)
-        - **job:** `build-and-deploy`
+        - **job:** `deploy`
         - Triggers [`deploy_docs.yml`](https://github.com/napari/docs/blob/main/.github/workflows/deploy_docs.yml)
           workflow at the [napari/docs](https://github.com/napari/docs) repo.
           Waits for results and reports it.
@@ -31,13 +31,14 @@ through several CI workflows detailed below.
 2. [`napari/docs`](https://github.com/napari/docs)
     - **Workflow file:** [`build_and_deploy.yml`](https://github.com/napari/docs/blob/main/.github/workflows/build_and_deploy.yml)
         - **job:** `build-and-upload`
-        - Pulls in sources from `napari/napari` and builds docs locally. Uploads
-          artifacts to this repo (`napari/docs`).
-        - This is triggered on every Pull Request and shows up as a "Build PR
-          Docs" check on the PR.
+        - Pulls in sources from `napari/napari`, builds docs, then uploads as an
+          artifact named 'html'.
+        - This is triggered on every Pull Request and shows up as a "Build & Deploy PR
+          Docs / Build & Uplod Artifact" check on the PR.
         - **job:** `build-and-deploy`
-        - Builds docs locally and deploys resulting artifacts to GitHub pages at
-          the `gh-pages` branch of [napari/napari.github.io](https://github.com/napari/napari.github.io/tree/gh-pages).
+        - Downloads the artifact from the `build-and-upload` job and deploys the html
+          to GitHub pages at the `gh-pages` branch of
+          [napari/napari.github.io](https://github.com/napari/napari.github.io/tree/gh-pages).
         - Always deploys to the `dev/` folder on `napari.github.io` (version
           "latest" on the website).
         - This is triggered on any commit to the `main` branch on `napari/docs`

--- a/docs/developers/contributing/documentation/docs_deployment.md
+++ b/docs/developers/contributing/documentation/docs_deployment.md
@@ -19,7 +19,7 @@ through several CI workflows detailed below.
           artifacts to this repository (`napari/napari`).
         - This is triggered on any commit tagged 'v*'.
     - **Workflow file:** [`deploy_docs.yml`](https://github.com/napari/napari/blob/main/.github/workflows/deploy_docs.yml)
-        - **job:** `deploy`
+        - **job:** `build-napari-docs`
         - Triggers [`build_and_deploy.yml`](https://github.com/napari/docs/blob/main/.github/workflows/build_and_deploy.yml)
           workflow at the [napari/docs](https://github.com/napari/docs) repo.
           Waits for results and reports it.
@@ -34,7 +34,7 @@ through several CI workflows detailed below.
           artifact named 'html' to this repository (`napari/docs`).
         - This is triggered on every Pull Request and shows up as a "Build & Deploy PR
           Docs / Build & Uplod Artifact" check on the PR.
-        - **job:** `build-and-deploy`
+        - **job:** `deploy`
         - Downloads the artifact from the `build-and-upload` job and deploys the html
           to GitHub pages at the `gh-pages` branch of
           [napari/napari.github.io](https://github.com/napari/napari.github.io/tree/gh-pages).

--- a/docs/developers/contributing/documentation/docs_deployment.md
+++ b/docs/developers/contributing/documentation/docs_deployment.md
@@ -28,7 +28,7 @@ through several CI workflows detailed below.
         - This is triggered on any commit to the `main` branch on
           `napari/napari` (and consequently triggers a new deployment of the
           `napari.org` website). When the commit is tagged, the `build_and_deploy.yml`
-          workflow will deploy to the version folder e.g., {{ napari_version }}.
+          workflow will deploy to the version folder e.g., '{{ napari_version }}/'.
 
 2. [`napari/docs`](https://github.com/napari/docs)
     - **Workflow file:** [`build_and_deploy.yml`](https://github.com/napari/docs/blob/main/.github/workflows/build_and_deploy.yml)

--- a/docs/developers/contributing/documentation/docs_deployment.md
+++ b/docs/developers/contributing/documentation/docs_deployment.md
@@ -41,7 +41,7 @@ through several CI workflows detailed below.
           [napari/napari.github.io](https://github.com/napari/napari.github.io/tree/gh-pages).
         - Always deploys to the `dev/` folder on `napari.github.io` (version
           "latest" on the website).
-        - This is triggered on any commit to the `main` branch on `napari/docs`
+        - Deployment is triggered by any commit to the `main` branch on `napari/docs`
           (and consequently triggers a new deployment of the `napari.org`
           website.)
 

--- a/docs/developers/contributing/documentation/docs_deployment.md
+++ b/docs/developers/contributing/documentation/docs_deployment.md
@@ -28,7 +28,7 @@ through several CI workflows detailed below.
         - This is triggered on any commit to the `main` branch on
           `napari/napari` (and consequently triggers a new deployment of the
           `napari.org` website). When the commit is tagged, the `build_and_deploy.yml`
-          workflow will deploy to the version folder e.g., `{{ napari_version }}`.
+          workflow will deploy to the version folder e.g., {{ napari_version }}.
 
 2. [`napari/docs`](https://github.com/napari/docs)
     - **Workflow file:** [`build_and_deploy.yml`](https://github.com/napari/docs/blob/main/.github/workflows/build_and_deploy.yml)

--- a/docs/developers/contributing/documentation/docs_deployment.md
+++ b/docs/developers/contributing/documentation/docs_deployment.md
@@ -17,7 +17,9 @@ through several CI workflows detailed below.
         - **job:** `build-and-upload`
         - Pulls in sources from `napari/docs` and builds docs locally. Uploads
           artifacts to this repository (`napari/napari`).
-        - This is triggered on any commit tagged 'v*'.
+        - This is triggered on any push to a branch named 'docs*' or tag named 'v*',
+          to `napari/napari`. The artifact can be used to check the documentation
+          but is not used for docs deployment.
     - **Workflow file:** [`deploy_docs.yml`](https://github.com/napari/napari/blob/main/.github/workflows/deploy_docs.yml)
         - **job:** `build-napari-docs`
         - Triggers [`build_and_deploy.yml`](https://github.com/napari/docs/blob/main/.github/workflows/build_and_deploy.yml)
@@ -25,7 +27,8 @@ through several CI workflows detailed below.
           Waits for results and reports it.
         - This is triggered on any commit to the `main` branch on
           `napari/napari` (and consequently triggers a new deployment of the
-          `napari.org` website.)
+          `napari.org` website). When the commit is tagged, the `build_and_deploy.yml`
+          workflow will deploy to the version folder e.g., `0.4.19/`.
 
 2. [`napari/docs`](https://github.com/napari/docs)
     - **Workflow file:** [`build_and_deploy.yml`](https://github.com/napari/docs/blob/main/.github/workflows/build_and_deploy.yml)

--- a/docs/developers/contributing/documentation/docs_deployment.md
+++ b/docs/developers/contributing/documentation/docs_deployment.md
@@ -16,12 +16,11 @@ through several CI workflows detailed below.
     - **Workflow file:** [`build_docs.yml`](https://github.com/napari/napari/blob/main/.github/workflows/build_docs.yml)
         - **job:** `build-and-upload`
         - Pulls in sources from `napari/docs` and builds docs locally. Uploads
-          artifacts to this repo (`napari/napari`).
-        - This is triggered on every Pull Request and shows up as a "Build PR
-          Docs" check on the PR.
+          artifacts to this repository (`napari/napari`).
+        - This is triggered on any commit tagged 'v*'.
     - **Workflow file:** [`deploy_docs.yml`](https://github.com/napari/napari/blob/main/.github/workflows/deploy_docs.yml)
         - **job:** `deploy`
-        - Triggers [`deploy_docs.yml`](https://github.com/napari/docs/blob/main/.github/workflows/deploy_docs.yml)
+        - Triggers [`build_and_deploy.yml`](https://github.com/napari/docs/blob/main/.github/workflows/build_and_deploy.yml)
           workflow at the [napari/docs](https://github.com/napari/docs) repo.
           Waits for results and reports it.
         - This is triggered on any commit to the `main` branch on
@@ -32,7 +31,7 @@ through several CI workflows detailed below.
     - **Workflow file:** [`build_and_deploy.yml`](https://github.com/napari/docs/blob/main/.github/workflows/build_and_deploy.yml)
         - **job:** `build-and-upload`
         - Pulls in sources from `napari/napari`, builds docs, then uploads as an
-          artifact named 'html'.
+          artifact named 'html' to this repository (`napari/docs`).
         - This is triggered on every Pull Request and shows up as a "Build & Deploy PR
           Docs / Build & Uplod Artifact" check on the PR.
         - **job:** `build-and-deploy`


### PR DESCRIPTION

* Update `docs_deployment.md` now that we unified workflows in #348.
* Change workflow name to be Build & Deploy PR Docs, since #348
* Add file paths to the workflow to aid other working on it