### PR TITLE
Fix broken cross links in docs

### DIFF
--- a/docs/developers/architecture/app_model.md
+++ b/docs/developers/architecture/app_model.md
@@ -37,7 +37,7 @@ Currently, the primary purpose of the `app` is to compose the following
   [commands](app-model-commands) (the actual callable objects) that have been
   registered with the application. Accessible via `app.commands`.
 * {class}`~app_model.registries.MenusRegistry`: maintains all of the
-  [menus and submenus](appp-model-menus) that have been registered with the application.
+  [menus and submenus](app-model-menus) that have been registered with the application.
   Accessible via `app.menus`.
 * {class}`~app_model.registries.KeyBindingsRegistry`: maintains the association
   between a [KeyBinding](app-model-keybindings) and a command ID in the

--- a/docs/naps/9-multiple-canvases.md
+++ b/docs/naps/9-multiple-canvases.md
@@ -75,7 +75,7 @@ Providing native support in napari would allow developers to more easily create 
     * There will be no possibility of a viewer with no canvases.
 * Users shall be able to add, remove, and (maybe[^maybe-rearrange]) rearrange canvases.
 
-[^maybe-rearrange]: Exact UI/UX may is yet to be decided, see [UI Architecture](#UI-Design-and-Architecture) for some discussion.
+[^maybe-rearrange]: Exact UI/UX may is yet to be decided, see [UI Architecture](nap_9_design_and_architecture) for some discussion.
 
 ### Design Considerations & Decisions
 Part of this design document is intended to capture the desired behavior and prevent scope creep. At the extreme “multiple canvases” can be achieved with “multiple viewers”. Therefore we need to draw a line somewhere to differentiate a “canvas” from a “viewer”. [^napari-lite]
@@ -164,8 +164,10 @@ Slice state for each layer is currently stored on the Layer model. Again, see [N
 > Also - the various `_<Layer>SliceResponse` classes introduced by async slicing may already fill much of this role. Another option to consider here is to codify a protocol ([`typing.Protocol`](https://docs.python.org/3/library/typing.html#typing.Protocol)) for these classes. Even this protocol may not be necessary - early prototypes use these classes as-is with minimal modifications.
 > [name=Ashley A]
 
+(nap_9_design_and_architecture)
+
 ### UI Design and Architecture
-Specific UI design and architecture remains to be determined. This will be explored as part of step 4 in the [Implementation Plan](#Implementation). UI design needs additional refinement and exploration, and this is expected to continue after basic/core implementation propsed in this NAP is complete. UI changes may also be described in a separate NAP along with a discussion of convenience functions and affordances for common operations. Some placeholder or experimental code will be used in the meantime as a prototype implementation.
+Specific UI design and architecture remains to be determined. This will be explored as part of step 4 in the [Implementation Plan](nap_9_implementation). UI design needs additional refinement and exploration, and this is expected to continue after basic/core implementation propsed in this NAP is complete. UI changes may also be described in a separate NAP along with a discussion of convenience functions and affordances for common operations. Some placeholder or experimental code will be used in the meantime as a prototype implementation.
 
 Some open questions here are (for example):
 * Should each canvas also have visible dims sliders, or can we keep one set of dims sliders that changes based on the active (selected) canvas?
@@ -194,6 +196,8 @@ See other image viewers for examples for multiple canvases (mostly demonstrating
 * [OHIF/Cornerstone.js](https://www.cornerstonejs.org/live-examples/crosshairs)
 * [neuroglancer](https://neuroglancer-demo.appspot.com/#!%7B%22dimensions%22:%7B%22x%22:%5B8e-9%2C%22m%22%5D%2C%22y%22:%5B8e-9%2C%22m%22%5D%2C%22z%22:%5B8e-9%2C%22m%22%5D%7D%2C%22position%22:%5B2914.500732421875%2C3088.243408203125%2C4045%5D%2C%22crossSectionScale%22:3.762185354999915%2C%22projectionOrientation%22:%5B0.31435418128967285%2C0.8142172694206238%2C0.4843378961086273%2C-0.06040274351835251%5D%2C%22projectionScale%22:4593.980956070107%2C%22layers%22:%5B%7B%22type%22:%22image%22%2C%22source%22:%22precomputed://gs://neuroglancer-public-data/flyem_fib-25/image%22%2C%22tab%22:%22source%22%2C%22name%22:%22image%22%7D%2C%7B%22type%22:%22segmentation%22%2C%22source%22:%22precomputed://gs://neuroglancer-public-data/flyem_fib-25/ground_truth%22%2C%22tab%22:%22source%22%2C%22segments%22:%5B%2221894%22%2C%2222060%22%2C%22158571%22%2C%2224436%22%2C%222515%22%5D%2C%22name%22:%22ground-truth%22%7D%5D%2C%22showSlices%22:false%2C%22layout%22:%224panel%22%7D)
 
+(nap_9_implementation)
+
 ## Implementation
 
 1. Introduce minimally disruptive `_canvases` attribute on the ViewerModel
@@ -221,7 +225,7 @@ See other image viewers for examples for multiple canvases (mostly demonstrating
     * Update main widget as `ViewerModel` “active” canvas changes, storing additional canvases and swapping them out as necessary
 
 4. Update `QtViewer` to show multiple canvases simultaneously
-    * This is exploratory work at the moment, see [UI Architecture](#UI-Design-and-Architecture) section below
+    * This is exploratory work at the moment, see [UI Architecture](nap_9_design_and_architectures) section below
 
 [^async-only]: Depending on the timeline and prototype implementation, it may be acceptable/preferable for multi-canvas feature to rely on (currently experimental) async slicing ([see NAP-4](https://napari.org/stable/naps/4-async-slicing.html)).
 

--- a/docs/tutorials/processing/dask.md
+++ b/docs/tutorials/processing/dask.md
@@ -111,6 +111,8 @@ napari.view_image(stack, contrast_limits=[0,2000], multiscale=False)
 *Note: providing the* `contrast_limits` *and* `multiscale` *arguments prevents* `napari` *from trying to calculate the data min/max, which can take an extremely long time with big data.
 See [napari issue #736](https://github.com/napari/napari/issues/736) for further discussion.*
 
+(dask_image)=
+
 ## Make your life easier with `dask-image`
 
 This pattern for creating a `dask.array` from image data
@@ -205,7 +207,7 @@ directory. The dataset is 3.69 GB unzipped.
 ```
 
 While we could use plain `dask` through `delayed`, as we have shown above, we
-will [make our lives easier](make-your-life-easier-with-dask-image) here and use
+will [make our lives easier](dask_images) here and use
 `dask-image`.
 
 Using [dask_image.imread](https://image.dask.org/en/latest/dask_image.imread.html#module-dask_image.imread),
@@ -326,4 +328,3 @@ ready to show you the result on demand!
 - [Documentation on dask.delayed](https://docs.dask.org/en/latest/delayed.html)
 - [Dask working notes on dask-image](https://blog.dask.org/2019/06/20/load-image-data)
 - [Dask working notes on image processing with `dask.array.map_blocks`](https://blog.dask.org/2019/08/09/image-itk)
-- [](brain_dataset_tutorial.md)


### PR DESCRIPTION
Our doc build has the following broken link warnings:
```
/home/runner/work/docs/docs/docs/docs/developers/architecture/app_model.md:39: WARNING: 'myst' cross-reference target not found: 'appp-model-menus' [myst.xref_missing]
/home/runner/work/docs/docs/docs/docs/naps/9-multiple-canvases.md:168: WARNING: 'myst' cross-reference target not found: 'Implementation' [myst.xref_missing]
/home/runner/work/docs/docs/docs/docs/naps/9-multiple-canvases.md:224: WARNING: 'myst' cross-reference target not found: 'UI-Design-and-Architecture' [myst.xref_missing]
/home/runner/work/docs/docs/docs/docs/naps/9-multiple-canvases.md:78: WARNING: 'myst' cross-reference target not found: 'UI-Design-and-Architecture' [myst.xref_missing]
/home/runner/work/docs/docs/docs/docs/release/release_0_4_19.md:72: WARNING: 'myst' cross-reference target not found: 'Deprecations' [myst.xref_missing]
/home/runner/work/docs/docs/docs/docs/tutorials/processing/dask.md:207: WARNING: 'myst' cross-reference target not found: 'make-your-life-easier-with-dask-image' [myst.xref_missing]
/home/runner/work/docs/docs/docs/docs/tutorials/processing/dask.md:329: WARNING: 'myst' cross-reference target not found: 'brain_dataset_tutorial.md' [myst.xref_missing]
```

I've just used reference labels when the original title (?) labels have broken, reference labels seem easier and less brittle.

Note the last one, AFAICT there originally was a PR to add a `brain_dataset_tutorial/md` file: https://github.com/napari/napari.github.io/pull/64

But what got merged was: https://github.com/napari/docs/pull/132 where that example was just added to the `dask.md` file, so I've removed that reference from the list.