### PR TITLE
[Maint] use lxml[html_clean] in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ sphinx_autodoc_typehints==1.12.0
 myst-nb
 napari-sphinx-theme>=0.3.0
 matplotlib
-lxml
+lxml[html_clean]
 imageio-ffmpeg


### PR DESCRIPTION
# References and relevant issues
Build & deploy is failing:
https://github.com/napari/docs/actions/runs/8608784588/job/23591705821?pr=390
This is because of the change to lxml. This was fixed in napari/napari, but  we ~~install from pypi~~  arn't using [dev] at the moment.


# Description
We have lxml in the requirements.txt so this PR just updates that to fix the current issue, but we should revisit the actual requirements/dependencies/install.
