### PR TITLE
Fix typo in `app_model.md`

### DIFF
--- a/docs/developers/architecture/app_model.md
+++ b/docs/developers/architecture/app_model.md
@@ -468,7 +468,7 @@ initialization of `_QtMainWindow`. This is the same as
 
 (app-model-testing)=
 
-## app-model testing
+## `app-model` testing
 
 This section provides a guide to testing app-model aspects of napari. For general
 information on napari testing see [](napari-testing).
@@ -490,7 +490,7 @@ duration and will get cleaned up at the end.
 
 ```{note}
 Since the `_mock_app` fixture is autouse, a
-:class:`~napari._app_model._app.NapariApplication` is instantiated during setup
+{class}`~napari._app_model._app.NapariApplication` is instantiated during setup
 of every test.
 ```
 


### PR DESCRIPTION
Mixed rst and md syntax. Typo fixed.