### PR TITLE
Update `app-model` doc with new information about `_mock_app` fixture

### DIFF
--- a/docs/developers/architecture/app_model.md
+++ b/docs/developers/architecture/app_model.md
@@ -485,7 +485,7 @@ singleton `app` may keep a reference to an object, e.g., a
 {class}`~napari._qt.qt_main_window.Window`, that has
 since been cleaned up at the end of a previous test.
 Thus, we mock the `app` in a `_mock_app` fixture, and
-explicitly use it in `make_napari_viewer` as well as in all tests that
+explicitly use it in [`make_napari_viewer`](make_napari_viewer) as well as in all tests that
 use the `get_app` function. This way, a new instance of `app` is returned 
 every time {func}`~napari._app_model.get_app`
 is used inside a test. This 'test' `app` is available for use throughout the test's

--- a/docs/developers/architecture/app_model.md
+++ b/docs/developers/architecture/app_model.md
@@ -482,16 +482,17 @@ Segmentation faults can also occur as a
 singleton `app` may keep a reference to an object, e.g., a
 {class}`~napari._qt.qt_main_window.Window`, that has
 since been cleaned up at the end of a previous test.
-Thus, we mock the `app` in a `_mock_app` fixture and
-[autouse](https://docs.pytest.org/en/latest/how-to/fixtures.html#autouse-fixtures-fixtures-you-don-t-have-to-request)
-it so a new instance of `app` is returned every time {func}`~napari._app_model.get_app`
+Thus, we mock the `app` in a `_mock_app` fixture, and
+explicitly use it in `make_napari_viewer` as well as in all tests that
+use the `get_app` function. This way, a new instance of `app` is returned 
+every time {func}`~napari._app_model.get_app`
 is used inside a test. This 'test' `app` is available for use throughout the test's
 duration and will get cleaned up at the end.
 
 ```{note}
-Since the `_mock_app` fixture is autouse, a
-:class:`~napari._app_model._app.NapariApplication` is instantiated during setup
-of every test.
+Since the `_mock_app` fixture is used in `make_napari_viewer`, plugins and other
+external users that write tests using `make_napari_viewer` will also have the benefit
+of a new app for each test.
 ```
 
 The mock `app` registers non-Qt `Action`s, providers and processors. This is

--- a/docs/developers/contributing/testing.md
+++ b/docs/developers/contributing/testing.md
@@ -240,6 +240,7 @@ def test_something_else(qtbot):
     ...
 ```
 
+(make_napari_viewer)=
 #### `make_napari_viewer`
 
 We provide a


### PR DESCRIPTION
# References and relevant issues
Depends on [napari/#6823](https://github.com/napari/napari/pull/6823)

# Description
Updates the information about `_mock_app` to state that we use it explicitly in `_make_napari_viewer` and all
other tests that require a `NapariApplication`.

Also make note that plugins that use `make_napari_viewer` now get the benefit of the `_mock_app`.

<!-- Final Checklist
- If images included: I have added [alt text](https://webaim.org/techniques/alttext/)
If workflow, documentation build or deployment change:
- My PR is the minimum possible work for the desired functionality
- I have commented my code, to let others know what it does
-->
