### PR TITLE
Fixes display of inherited members of classes

### DIFF
--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -5,8 +5,7 @@
 .. autoclass:: {{ objname }}
    :members:
    :show-inheritance:
-   {# These classes inherit docstrings from the raw qt source, which
-   generates rst syntax errors when building the docs #}
+   {#- These classes inherit docstrings from the raw qt source, which generates rst syntax errors when building the docs #}
    {% if objname not in ["progress", "cancelable_progress"] -%}
    :inherited-members:
    {%- endif %}

--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -5,9 +5,11 @@
 .. autoclass:: {{ objname }}
    :members:
    :show-inheritance:
-   {% if objname != "progress" %}
-      :inherited-members:
-   {% endif %}
+   {# These classes inherit docstrings from the raw qt source, which
+   generates rst syntax errors when building the docs #}
+   {% if objname not in ["progress", "cancelable_progress"] -%}
+   :inherited-members:
+   {%- endif %}
 
    {% block methods %}
 


### PR DESCRIPTION
# References and relevant issues
Follow-up to #316

# Description
I inadvertently added a Jinja syntax error in #316. Also adds a comment to explain why this is necessary.
