### PR TITLE
Add maintenance workflows from main repo (edit PR description/clean up ready to merge label)

### DIFF
--- a/.github/workflows/edit_pr_description.yml
+++ b/.github/workflows/edit_pr_description.yml
@@ -1,5 +1,4 @@
 name: Remove html In PR description
-# see https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
 on:
   # see https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
   pull_request_target:

--- a/.github/workflows/edit_pr_description.yml
+++ b/.github/workflows/edit_pr_description.yml
@@ -1,0 +1,17 @@
+name: Remove html In PR description
+# see https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
+on:
+  # see https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
+permissions:
+  pull-requests: write
+
+jobs:
+  remove_comment:
+    name: Remove html comments.
+    uses: napari/napari/.github/workflows/edit_pr_description.yml@main

--- a/.github/workflows/remove_ready_to_merge.yml
+++ b/.github/workflows/remove_ready_to_merge.yml
@@ -1,0 +1,15 @@
+name: Remove "ready to merge" label
+
+on:
+  pull_request_target:
+    types: [closed]
+  workflow_call:
+
+
+permissions:
+  pull-requests: write
+
+jobs:
+  remove_label:
+    name: Remove ready to merge label
+    uses: napari/napari/.github/workflows/remove_ready_to_merge.yml@main


### PR DESCRIPTION
# References and relevant issues

Depends on https://github.com/napari/napari/pull/6839

# Description

In the main repository, we have 2 useful workflows

1) Remove html comment In PR description
2) Remove "Ready to merge" 

This PR adds this to docs repository by calling these workflows. Calling workflow instead of coping, it allows having fix in a single place. 