### PR TITLE
Fix broken magicgui and app-model docs links

### DIFF
--- a/docs/developers/architecture/app_model.md
+++ b/docs/developers/architecture/app_model.md
@@ -485,7 +485,7 @@ singleton `app` may keep a reference to an object, e.g., a
 {class}`~napari._qt.qt_main_window.Window`, that has
 since been cleaned up at the end of a previous test.
 Thus, we mock the `app` in a `_mock_app` fixture, and
-explicitly use it in [`make_napari_viewer`](make_napari_viewer) as well as in all tests that
+explicitly use it in {ref}`make_napari_viewer` as well as in all tests that
 use the `get_app` function. This way, a new instance of `app` is returned 
 every time {func}`~napari._app_model.get_app`
 is used inside a test. This 'test' `app` is available for use throughout the test's

--- a/docs/howtos/extending/magicgui.md
+++ b/docs/howtos/extending/magicgui.md
@@ -178,7 +178,7 @@ When creating a widget that is not a
 {class}`~magicgui.widgets.bases.ContainerWidget` subclass,
 adding a layer input widget requires more than just
 parameter annotation.
-See the [`QWidget` example](#qtwidgets-qwidget) below.
+See the [`QWidget` example](#qtwidgetsqwidget) below.
 ```
 
 The consequence of each type annotation is described below:


### PR DESCRIPTION
# References and relevant issues
Towards #409 

# Description
Fixes one broken link in the magicgui how-to, and one warning about an ambiguous reference in the app model docs.