### PR TITLE
Update conda section of install docs

### DIFF
--- a/docs/tutorials/fundamentals/installation.md
+++ b/docs/tutorials/fundamentals/installation.md
@@ -101,20 +101,9 @@ For example, use {{ python_version_code }} to get Python {{ python_version }} an
 the current release.
 
 2. Switching to the new, faster [`libmamba` solver](https://conda.github.io/conda-libmamba-solver/libmamba-vs-classic/),
-by updating your `conda` (>22.11), if needed, and then installing and activating
-the solver, as follows:
+by updating your `conda` (`libmamba` is the default solver from conda 23.10 onwards):
 ```
 conda update -n base conda
-conda install -n base conda-libmamba-solver
-conda config --set solver libmamba
-```
-3. Alternately, consider installing [`mamba`](https://github.com/mamba-org/mamba)
-in your base environment with `conda install -n base -c conda-forge mamba`.
-Then you can use `mamba` by replacing `conda` with `mamba` in the installation instructions, for example:
-```
-mamba install napari
-```
-
 ````
 
 :::::

--- a/docs/tutorials/fundamentals/installation.md
+++ b/docs/tutorials/fundamentals/installation.md
@@ -104,6 +104,7 @@ the current release.
 by updating your `conda` (`libmamba` is the default solver from conda 23.10 onwards):
 ```
 conda update -n base conda
+```
 ````
 
 :::::


### PR DESCRIPTION
# References and relevant issues

# Description
 The `libmamba` solver is now the default one (https://conda.org/blog/2023-11-06-conda-23-10-0-release/), so instructing users to update conda is enough to get a fast solver (no need to manually install the solver or install mamba)
