### PR TITLE
Bump napari sphinx theme version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ clean:
 
 docs-install:
 	python -m pip install -qr $(current_dir)requirements.txt
+	python -m pip freeze
 
 prep-docs:
 	python $(docs_dir)/_scripts/prep_docs.py

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -23,3 +23,9 @@ div.sphx-glr-download a:hover {
   background-image: none;
   background-color: #ffffff !important;
 }
+
+/* Workaround for https: //github.com/napari/docs/pull/423#issuecomment-2141165872 */
+.bd-content .sd-tab-set>label {
+  background-color: var(--napari-gray);
+  color: #222832;
+}

--- a/docs/_templates/sidebar-nav-bs.html
+++ b/docs/_templates/sidebar-nav-bs.html
@@ -1,4 +1,14 @@
-<nav class="bd-docs-nav bd-links"
-     aria-label="{{ _('Section Navigation') }}">
-  <div class="bd-toc-item navbar-nav">{{ sidebar_nav_html }}</div>
+{# Displays the TOC-subtree for pages nested under the currently active top-level TOCtree element. #}
+<nav class="bd-docs-nav bd-links" aria-label="{{ _('Section Navigation') }}">
+  <div class="bd-toc-item navbar-nav">
+    {{- generate_toctree_html(
+    "sidebar",
+    show_nav_level=theme_show_nav_level | int,
+    maxdepth=theme_navigation_depth | int,
+    collapse=theme_collapse_navigation | tobool,
+    includehidden=theme_sidebar_includehidden | tobool,
+    titles_only=True
+    )
+    -}}
+  </div>
 </nav>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -117,6 +117,11 @@ html_theme_options = {
     "back_to_top_button": False,
 }
 
+html_context = {
+   # use Light theme only, don't auto switch (default)
+   "default_mode": "light"
+}
+
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -100,9 +100,7 @@ else:
     version_match = release
 
 html_theme_options = {
-    "external_links": [
-        {"name": "napari hub", "url": "https://napari-hub.org"}
-    ],
+    "external_links": [{"name": "napari hub", "url": "https://napari-hub.org"}],
     "github_url": "https://github.com/napari/napari",
     "navbar_start": ["navbar-logo", "navbar-project"],
     "navbar_end": ["version-switcher", "navbar-icon-links"],
@@ -116,6 +114,7 @@ html_theme_options = {
     "pygment_light_style": "napari",
     "pygment_dark_style": "napari",
     "announcement": "https://napari.org/dev/_static/announcement.html",
+    "back_to_top_button": False,
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,


### PR DESCRIPTION
# References and relevant issues
Depends on napari/napari-sphinx-theme#161

(and a new release of the theme)

# Description
Restores the sidebar after the PyData Sphinx Theme is updated to version 0.15.3