### PR TITLE
Replace cookiecutter references with napari-plugin-template

### DIFF
--- a/docs/howtos/extending/magicgui.md
+++ b/docs/howtos/extending/magicgui.md
@@ -48,7 +48,7 @@ extensibility;
 More examples of widget use can be found in the
 ['GUI' gallery examples](https://napari.org/stable/_tags/gui.html) (note: not every
 example includes a widget). Additionally,
-[cookiecutter-napari-plugin](https://github.com/napari/cookiecutter-napari-plugin)
+[napari-plugin-template](https://github.com/napari/napari-plugin-template)
 has more robust widget examples that you can adapt to your needs.
 
 (adding_widgets)=

--- a/docs/naps/0-nap-process.md
+++ b/docs/naps/0-nap-process.md
@@ -34,7 +34,7 @@ their revision history is the historical record of the feature proposal
 The napari project has grown in scope beyond just the software living in the
 github.com/napari/napari repository. It includes several other software
 packages such as npe2 (napari plugin engine 2), superqt, and magicgui, tools
-for the community such as the cookiecutter napari plugin, a webpage, and a chat
+for the community such as the napari plugin template, a webpage, and a chat
 forum, among others.
 
 Additionally, napari sits at the center of a much broader community of users,

--- a/docs/naps/2-conda-based-packaging.md
+++ b/docs/naps/2-conda-based-packaging.md
@@ -389,7 +389,7 @@ non-compliant licensing schemes or bad packaging practices.
 
 * [ ] Add documentation about conda-forge in the release guide
 * [ ] Add documentation about conda-forge in the plugin developer guide
-* [ ] Ensure the cookiecutter template has some notion of conda packaging
+* [ ] Ensure the napari plugin template has some notion of conda packaging
 * [ ] Decide which packages need to be governed by the _napari pinnings_ metapackage
 
 ### Milestone 2: Building conda-based installers for napari

--- a/docs/plugins/advanced_topics/npe1.md
+++ b/docs/plugins/advanced_topics/npe1.md
@@ -213,25 +213,26 @@ See [testing and deploying](plugin-test-deploy) your plugin.  (This hasn't chang
 significantly with the secod generation (`npe2`) plugin engine).
 
 
-(plugin-cookiecutter-template)=
+(napari-plugin-template)=
 
-## Cookiecutter template
+## napari plugin template
 
 To quickly generate a new napari plugin project, you may wish to use the
-[cookiecutter-napari-plugin](https://github.com/napari/cookiecutter-napari-plugin) template. This uses
-the [cookiecutter](https://github.com/cookiecutter/cookiecutter) command line
+[napari-plugin-template](https://github.com/napari/napari-plugin-template). This uses
+the [copier](https://copier.readthedocs.io/en/stable/) command line
 utility, which will ask you a few questions about your project and get you
 started with a ready-to-go package layout where you can begin implementing your
 plugin.
 
-Install cookiecutter and use the template as follows:
+Install copier and use the template as follows:
 
 ```sh
-python -m pip install cookiecutter
-cookiecutter https://github.com/napari/cookiecutter-napari-plugin
+python -m pip install copier jinja2-time
+python -m pip install npe2
+copier copy --trust https://github.com/napari/napari-plugin-template new-plugin-name
 ```
 
-See the [readme](https://github.com/napari/cookiecutter-napari-plugin) for details
+See the [readme](https://github.com/napari/napari-plugin-template) for details
 
 
 ----------------------------

--- a/docs/plugins/building_a_plugin/best_practices.md
+++ b/docs/plugins/building_a_plugin/best_practices.md
@@ -245,8 +245,8 @@ See [Tips for testing napari plugins](plugin-testing-tips).
 
 ### How to check test coverage?
 
-The [cookiecutter
-template](https://github.com/napari/cookiecutter-napari-plugin) is already set
+The [napari plugin
+template](https://github.com/napari/napari-plugin-template) is already set
 up to report test coverage, but you can test locally as well, using
 [pytest-cov](https://github.com/pytest-dev/pytest-cov)
 
@@ -259,8 +259,7 @@ up to report test coverage, but you can test locally as well, using
    [exempt specific
    lines](https://coverage.readthedocs.io/en/6.4.4/excluding.html#excluding-code-from-coverage-py)
    from coverage with the comment `# pragma: no cover`
-5. In the cookiecutter, coverage tests from github actions will be uploaded to
-   codecov.io
+5. In the napari plugin template, coverage tests from github actions will be uploaded to codecov.io
 
 ## Set style for additional windows in your plugin
 
@@ -338,11 +337,11 @@ change_style()
 
 ## Do not package your tests as a top-level package
 
-If you are using the [napari plugin cookiecutter template](https://github.com/napari/cookiecutter-napari-plugin),
+If you are using the [napari plugin template](https://github.com/napari/napari-plugin-template),
 your tests are already packaged in the correct way. No further action required!
 
 ```bash
-# project structure suggested by the cookiecutter template
+# project structure suggested by the napari plugin template
 src/
   my_package/
     _tests/
@@ -374,7 +373,7 @@ Most of the time, this is not wanted; e.g. do you want to do `import tests`? Pro
 Additionally, this unwanted behavior might cause installation issues with other projects.
 
 Ideally, you could change your project structure to follow the recommended skeleton followed in
-the cookiecutter template. Howevever, if that's unfeasible, you can fix this in the project metadata files.
+the napari plugin template. Howevever, if that's unfeasible, you can fix this in the project metadata files.
 
 You need to explicitly _exclude_ the top-level `tests` directory from the packaged contents:
 

--- a/docs/plugins/building_a_plugin/first_plugin.md
+++ b/docs/plugins/building_a_plugin/first_plugin.md
@@ -4,8 +4,8 @@
 In this tutorial, we'll step through the fundamental concepts for building a
 **bare minimum** "hello napari" plugin from scratch.
 
-At the end, we'll point you to a "cookiecutter" template
-repository that helps automate the creation of new plugins, and adds a number
+At the end, we'll point you to a [napari plugin template
+repository][napari_plugin_template] that helps automate the creation of new plugins, and adds a number
 of conveniences for testing, maintaining, and deploying your plugin.
 
 ````{admonition} new plugin format!
@@ -275,10 +275,10 @@ Once napari starts, select `napari-hello: Hello World` from the
 
 % ![hello-example](../images/hello.png)
 
-## Get going quickly with cookiecutter
+## Get going quickly with the napari plugin template
 
 Now that you've learned all of the critical steps for creating a plugin,
-you can use our [cookiecutter template repository][cookiecutter]
+you can use our [napari plugin template repository][napari_plugin_template]
 to get up and running quickly with each new plugin.
 This will ask you a few questions about your new plugin, and
 autogenerate a package structure much like the one above. It additionally
@@ -286,8 +286,9 @@ includes conveniences like testing, continuous integration, version
 management, and deployment hooks.
 
 ```sh
-python -m pip install cookiecutter
-cookiecutter https://github.com/napari/cookiecutter-napari-plugin
+python -m pip install copier jinja2-time
+python -m pip install npe2
+copier copy --trust https://github.com/napari/napari-plugin-template new-plugin-name
 ```
 
 ## Next Steps
@@ -303,5 +304,5 @@ when you're ready to share your plugin, see [Testing and Publishing](plugin-test
 [miniconda]: https://docs.conda.io/projects/conda/en/latest/user-guide/install/download.html
 [python_env]: https://docs.conda.io/projects/conda/en/latest/user-guide/getting-started.html#managing-python
 [editable_mode]: https://pip.pypa.io/en/stable/cli/pip_install/#editable-installs
-[cookiecutter]: https://github.com/napari/cookiecutter-napari-plugin
+[napari_plugin_template]: https://github.com/napari/napari-plugin-template
 [entry_points]: https://packaging.python.org/en/latest/specifications/entry-points/

--- a/docs/plugins/testing_and_publishing/deploy.md
+++ b/docs/plugins/testing_and_publishing/deploy.md
@@ -4,8 +4,8 @@
 ## Preparing for release
 
 To help users find your plugin, make sure to use the `Framework :: napari`
-[classifier] in your package's core metadata. (If you used the cookiecutter,
-this has already been done for you.)
+[classifier] in your package's core metadata. (If you used the napari plugin
+template, this has already been done for you.)
 
 Once your package is listed on [PyPI] (and includes the `Framework :: napari`
 [classifier]), it will also be visible on the [napari
@@ -37,7 +37,7 @@ PyPI][pypi-upload] after which it will be installable using `python -m pip insta
 <yourpackage>`, or (assuming you added the `Framework :: napari` classifier)
 in the builtin plugin installer dialog.
 
-If you used the {ref}`plugin-cookiecutter-template`, you can also
+If you used the {ref}`napari-plugin-template`, you can also
 [setup automated deployments][autodeploy] on GitHub for every tagged commit.
 
 ````{admonition} What about conda?
@@ -60,4 +60,4 @@ forum](https://forum.image.sc/tag/napari).
 [pypi-upload]: https://packaging.python.org/tutorials/packaging-projects/#uploading-the-distribution-archives
 [hubguide]: https://github.com/chanzuckerberg/napari-hub/blob/main/docs/customizing-plugin-listing.md
 [hub-guide-custom-viz]: https://github.com/chanzuckerberg/napari-hub/wiki/Customizing-your-plugin's-listing#visibility
-[autodeploy]: https://github.com/napari/cookiecutter-napari-plugin#set-up-automatic-deployments
+[autodeploy]: https://github.com/napari/napari-plugin-template#set-up-automatic-deployments

--- a/docs/plugins/testing_workshop_docs/3-readers-and-fixtures.md
+++ b/docs/plugins/testing_workshop_docs/3-readers-and-fixtures.md
@@ -22,7 +22,7 @@ This lesson explains how to use and test a plugin's reader function, built-in fi
 The example plugin and all the tests discussed in this lesson are available in [this GitHub repository](https://github.com/DragaDoncila/plugin-tests).
 
 ## Introduction
-In this lesson, we discuss a napari plugin called [plugin_tests](https://github.com/DragaDoncila/plugin-tests/tree/main/src/plugin_tests), generated using the [cookiecutter](https://github.com/napari/cookiecutter-napari-plugin), which has a reader and a widget. The reader is the cookiecutter [NumPy `.npy` file](https://numpy.org/doc/stable/reference/generated/numpy.lib.format.html#npy-format) reader, `napari_get_reader`. It checks whether a path ends in `.npy`. If it doesn't, it returns `None`, and if it does, it returns the `reader_function`, which loads the data.
+In this lesson, we discuss a napari plugin called [plugin_tests](https://github.com/DragaDoncila/plugin-tests/tree/main/src/plugin_tests), generated using the [napari plugin template](https://github.com/napari/napari-plugin-template), which has a reader and a widget. The reader is the template [NumPy `.npy` file](https://numpy.org/doc/stable/reference/generated/numpy.lib.format.html#npy-format) reader, `napari_get_reader`. It checks whether a path ends in `.npy`. If it doesn't, it returns `None`, and if it does, it returns the `reader_function`, which loads the data.
 
 ![napari_get_reader](../../images/napari_plugins_1st_napari_get_reader.png)
 


### PR DESCRIPTION
# References and relevant issues

Pair PR to ~~napari/cookiecutter-napari-plugin#190~~ napari/napari-plugin-template#7

# Description

This PR removes all references to cookiecutter (except in past release notes), and replaces them with references to the `napari-plugin-template` repository.

This is so that when we merge PR napari/napari-plugin-template#7 switching the template engine from cookiecutter to copier, the napari docs will match.

