### PR TITLE
Add links to blog and napari workshop template on navbar

### DIFF
--- a/docs/community/index.md
+++ b/docs/community/index.md
@@ -11,3 +11,7 @@ To ask questions and interact with the team, you can join our
 
 If you are interested in contributing, check out our
 [contributing guide](contributing).
+
+To read announcements, learn more about who is using napari and see what our
+community has to say, check out our blog, the
+[Island Dispatch](https://napari.org/island-dispatch).

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -100,7 +100,11 @@ else:
     version_match = release
 
 html_theme_options = {
-    "external_links": [{"name": "napari hub", "url": "https://napari-hub.org"}],
+    "external_links": [
+        {"name": "napari hub", "url": "https://napari-hub.org"},
+        {"name": "Island Dispatch", "url": "https://napari.org/island-dispatch"},
+        {"name": "workshop template", "url": "https://napari.org/napari-workshop-template"},
+        ],
     "github_url": "https://github.com/napari/napari",
     "navbar_start": ["navbar-logo", "navbar-project"],
     "navbar_end": ["version-switcher", "navbar-icon-links"],

--- a/docs/developers/contributing/index.md
+++ b/docs/developers/contributing/index.md
@@ -5,6 +5,10 @@ We welcome your contributions! Here you will find a guide to the contribution
 workflow and tips for contributing to napari. Do not hesitate to [contact](contact) us
 if you have any queries.
 
+```note
+To contribute to our blog, the [Island Dispatch](https://napari.org/island-dispatch), check out https://github.com/napari/island-dispatch.
+```
+
 ## Contributing workflow
 
 napari development occurs primarily on GitHub. If you are new to GitHub we recommend checking out the detailed [Github Docs](https://docs.github.com/en).


### PR DESCRIPTION

# References and relevant issues
N/A

# Description
Add links to blog and napari workshop template on navbar

Also adds links to blog to our community and contributing pages.