### PR TITLE
DOC Link `magicgui` type annotation to providers/processors

### DIFF
--- a/docs/developers/architecture/app_model.md
+++ b/docs/developers/architecture/app_model.md
@@ -480,10 +480,10 @@ initialization of the napari `app`, in `NapariApplication`'s
 Providers and processors allow us to mirror behaviour enabled by
 [`magicgui` type registration](magicgui_type_registration) for widgets. Providers
 allow generalization of `magicgui` parameter annotation behaviour to all
-actions, while processors does this for return annotation behaviour.
+actions, while processors do this for return annotation behaviour.
 
 The intended users of providers/processors are end-users, plugins as well as `napari`
-internally.
+internally, however it is currently only used internally.
 For a detailed discussion on this framework see
 [issue 4532](https://github.com/napari/napari/issues/4532).
 

--- a/docs/developers/architecture/app_model.md
+++ b/docs/developers/architecture/app_model.md
@@ -477,6 +477,11 @@ They would be registered in the `app` `Store` during
 initialization of the napari `app`, in `NapariApplication`'s
 {meth}`~napari._app_model._app.NapariApplication.__init__`.
 
+Providers and processors allow us to mirror behaviour enabled by
+[`magicgui` type registration](magicgui_type_registration) for widgets. Providers
+allow generalization of `magicgui` parameter annotation behaviour to all
+actions, while processors does this for return annotation behaviour.
+
 (app-model-testing)=
 
 ## `app-model` testing

--- a/docs/developers/architecture/app_model.md
+++ b/docs/developers/architecture/app_model.md
@@ -482,6 +482,11 @@ Providers and processors allow us to mirror behaviour enabled by
 allow generalization of `magicgui` parameter annotation behaviour to all
 actions, while processors does this for return annotation behaviour.
 
+The intended users of providers/processors are end-users, plugins as well as `napari`
+internally.
+For a detailed discussion on this framework see
+[issue 4532](https://github.com/napari/napari/issues/4532).
+
 (app-model-testing)=
 
 ## `app-model` testing

--- a/docs/developers/architecture/magicgui_type_reg.md
+++ b/docs/developers/architecture/magicgui_type_reg.md
@@ -78,3 +78,9 @@ to be used in the `magicgui` widget.
 When widget is not a `magicgui` widget, the {class}`~napari.viewer.Viewer` is provided
 via a wrapper `napari` adds around widget contributions.
 ```
+
+# Generalization of `magicgui` type annotation
+
+`napari` generalizes `magicgui` type annotation behaviour beyond widgets, to all
+actions via `app-model` providers and processors. See [](app_model_dep_inj_result)
+for details.


### PR DESCRIPTION
# References and relevant issues

See https://github.com/napari/napari/pull/4543 for Talley original PR and his notes on this.

# Description

Links `magicgui` type annotation and providers/processor behaviour.

