### PR TITLE
[bugfix] Update contributing/index.md fix blog note

### DIFF
--- a/docs/developers/contributing/index.md
+++ b/docs/developers/contributing/index.md
@@ -5,7 +5,7 @@ We welcome your contributions! Here you will find a guide to the contribution
 workflow and tips for contributing to napari. Do not hesitate to [contact](contact) us
 if you have any queries.
 
-```note
+```{note}
 To contribute to our blog, the [Island Dispatch](https://napari.org/island-dispatch), check out https://github.com/napari/island-dispatch.
 ```
 


### PR DESCRIPTION
# References and relevant issues
The note about contributing to the blog is misrendered, like a monospace rather than formatted note.
<img width="693" alt="image" src="https://github.com/napari/docs/assets/76622105/6a1eb626-5924-498a-b034-9b897521e61f">
This is due to missing `{}`

# Description
Fix the syntax to add the `{}`
