### PR TITLE
Fix version match for version switcher

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -95,7 +95,7 @@ html_theme = 'napari_sphinx_theme'
 json_url = "https://napari.org/dev/_static/version_switcher.json"
 
 if version == "dev":
-    version_match = "latest"
+    version_match = "dev"
 else:
     version_match = release
 


### PR DESCRIPTION
# References and relevant issues
Fixes https://github.com/napari/napari-sphinx-theme/issues/165

# Description

We had been using the wrong version match string and this was preventing the correct version to be highlighted when selected in the version switcher dropdown.