### PR TITLE
Add preferred option to version_switcher.json

### DIFF
--- a/docs/_static/version_switcher.json
+++ b/docs/_static/version_switcher.json
@@ -7,6 +7,7 @@
 	{
 		"name": "stable (0.4.19)",
 		"version": "0.4.19",
+		"preferred": true,
 		"url": "https://napari.org/stable/"
 	},
 	{


### PR DESCRIPTION
# References and relevant issues
N/A

# Description
While investigating another issue I realized we should be using the "preferred" field if we at some point want to turn on the [version warning banner](https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/announcements.html#version-warning-banners). It won't have any effect right now, but also doesn't hurt.
