### PR TITLE
Add Zulip link to More menu on navbar

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -103,6 +103,7 @@ html_theme_options = {
     "external_links": [
         {"name": "napari hub", "url": "https://napari-hub.org"},
         {"name": "Island Dispatch", "url": "https://napari.org/island-dispatch"},
+        {"name": "Community chat", "url": "https://napari.zulipchat.com"},
         {"name": "workshop template", "url": "https://napari.org/napari-workshop-template"},
         ],
     "github_url": "https://github.com/napari/napari",


### PR DESCRIPTION
# References and relevant issues
As discussed in the last [Documentation WG Meeting](https://hackmd.io/10DKrIMhREmk9sa_QRirlg)

# Description
Adds a link to zulip in the "More" menu of the navbar with the title "Community chat"
