### PR TITLE
Add actionlint to prevent GHA workflow errors

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,18 @@
+name: Actionlint
+
+on:
+  pull_request:
+    paths:
+      - '.github/**'
+
+jobs:
+  actionlint:
+    name: Action lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check workflow files
+        run: |
+          bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          ./actionlint -color -ignore SC2129
+        shell: bash

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -106,11 +106,18 @@ jobs:
 
       - name: get directory name
         # if this is a tag, use the tag name as the directory name else dev
+        env:
+          REF: ${{ github.ref }}
         run: |
-          if [[ "${{ github.ref }}" == "refs/tags/"* ]]; then
-            echo "branch_name=${{ github.ref_name }}" >> $GITHUB_ENV
+          TAG="${GITHUB_REF/refs\/tags\/v/}"
+          VER="${TAG/a*/}"  # remove alpha identifier
+          VER="${VER/b*/}"  # remove beta identifier
+          VER="${VER/rc*/}"  # remove rc identifier
+
+          if [[ "$REF" == "refs/tags/v"* ]]; then
+            echo "branch_name=$VER" >> "$GITHUB_ENV"
           else
-            echo "branch_name=dev" >> $GITHUB_ENV
+            echo "branch_name=dev" >> "$GITHUB_ENV"
           fi
 
       - name: Deploy Docs


### PR DESCRIPTION
This adds actionlint from napari/napari#7049 to help prevent errors in GHA workflows.

**Update:** @Czaki also fixed the errors found by actionlint and ensured that new docs builds from tags (a) end up in their own folder (rather than dev/), and (b) don't include alpha, beta and rc tags.