### PR TITLE
Update version switcher for v0.5.1

### DIFF
--- a/docs/_static/version_switcher.json
+++ b/docs/_static/version_switcher.json
@@ -5,10 +5,15 @@
 		"url": "https://napari.org/dev/"
 	},
 	{
-		"name": "stable (0.5.0)",
-		"version": "0.5.0",
+		"name": "stable (0.5.1)",
+		"version": "0.5.1",
 		"preferred": true,
 		"url": "https://napari.org/stable/"
+	},
+	{
+		"name": "0.5.0",
+		"version": "0.5.0",
+		"url": "https://napari.org/0.5.0/"
 	},
 	{
 		"name": "0.4.19",


### PR DESCRIPTION
This ensures that visitors can access the 0.5.1 notes ~~(once the stable symlink is updated, which I'll do now)~~ **Edit: this is done.**
