### PR TITLE
Add documentation for run benchmark under debugger

### DIFF
--- a/docs/developers/contributing/performance/benchmarks.md
+++ b/docs/developers/contributing/performance/benchmarks.md
@@ -104,7 +104,7 @@ asv run -E existing -b ViewImageSuite
 
 ## Debugging a benchmark
 
-To simplify run a benchmark in a debugger, you can use the command:
+To run a benchmark in a debugger, you can use the command:
 
 ```bash
 python -m pdb napari/benchmarks/benchmark_file.py BenchmarkClass.benchmark_method

--- a/docs/developers/contributing/performance/benchmarks.md
+++ b/docs/developers/contributing/performance/benchmarks.md
@@ -102,6 +102,22 @@ of time since building napari can be a time consuming task:
 asv run -E existing -b ViewImageSuite
 ```
 
+## Debugging a benchmark
+
+To simplify run a benchmark in a debugger, you can use the command:
+
+```bash
+python -m pdb napari/_benchmarks/benchmark_file.py BenchmarkClass.benchmark_method
+```
+
+For example, to debug the ``time_set_view_slice`` method in the ``Image2DSuite``
+benchmark, you can run:
+
+```bash
+python -m pdb napari/_benchmarks/benchmark_image_layer.py Image2DSuite.time_set_view_slice
+```
+
+
 ## Comparing results to main
 
 Often, the goal of a PR is to compare the results of the modifications in terms

--- a/docs/developers/contributing/performance/benchmarks.md
+++ b/docs/developers/contributing/performance/benchmarks.md
@@ -107,14 +107,23 @@ asv run -E existing -b ViewImageSuite
 To simplify run a benchmark in a debugger, you can use the command:
 
 ```bash
-python -m pdb napari/_benchmarks/benchmark_file.py BenchmarkClass.benchmark_method
+python -m pdb napari/benchmarks/benchmark_file.py BenchmarkClass.benchmark_method
+```
+or 
+```bash
+python -m pdb -m napari.benchmarks benchmark_file.BenchmarkClass.benchmark_method
 ```
 
 For example, to debug the ``time_set_view_slice`` method in the ``Image2DSuite``
 benchmark, you can run:
 
 ```bash
-python -m pdb napari/_benchmarks/benchmark_image_layer.py Image2DSuite.time_set_view_slice
+python -m pdb napari/benchmarks/benchmark_image_layer.py Image2DSuite.time_set_view_slice
+```
+or 
+
+```bash
+python -m pdb -m napari.benchmarks benchmark_image_layer.Image2DSuite.time_set_view_slice
 ```
 
 


### PR DESCRIPTION
# References and relevant issues

depends on https://github.com/napari/napari/pull/7145

# Description

Add documentation on how easy run benchmarks under debugger to easier understand why benchmarks fail.
