### PR TITLE
Update installation notes about macOS arm processors and Qt5 backends 

### DIFF
--- a/docs/tutorials/fundamentals/installation.md
+++ b/docs/tutorials/fundamentals/installation.md
@@ -192,17 +192,6 @@ python -m pip install "napari[pyqt5]"    # for PyQt5
 python -m pip install "napari[pyside2]"  # for PySide2
 ```
 
-(note-m1)=
-```{note}
-
-For arm64 macOS machines (Apple Silicon), pre-compiled PySide2 packages
-([wheels](https://realpython.com/python-wheels/)) are not available on
-[PyPI](https://pypi.org), the repository used by `pip`, so trying to
-`pip install napari[pyside2]` or similar variant above will fail. However,
-you can install `pyside2` separately, for example from `conda-forge`,
-and then use `pip install napari`.
-```
-
 ```{note}
 If you switch backends, it's a good idea to `pip uninstall` the one
 you're not using.

--- a/docs/tutorials/fundamentals/installation.md
+++ b/docs/tutorials/fundamentals/installation.md
@@ -180,8 +180,7 @@ running napari will result in an error message asking you to install one of
 them.
 
 Running `python -m pip install "napari[all]"` will install the default framework, which is currently
-PyQt5--but this could change in the future. However, if you have a Mac with the newer arm64
-architecture (Apple Silicon), this will not work--see [note on m1](note-m1).
+PyQt5--but this could change in the future. 
 
 To install napari with a specific framework, you can use:
 
@@ -191,6 +190,9 @@ python -m pip install "napari[pyqt5]"    # for PyQt5
 # OR
 python -m pip install "napari[pyside2]"  # for PySide2
 ```
+
+However, if you have a Mac with the newer arm64
+architecture (Apple Silicon), the installing pyside2 backend using `pip` is not supported. See [note on m1](note-m1).
 
 (note-m1)=
 ```{note}

--- a/docs/tutorials/fundamentals/installation.md
+++ b/docs/tutorials/fundamentals/installation.md
@@ -72,7 +72,7 @@ Choose one of the options below to install napari as a Python package.
 
 If you prefer to manage packages with conda, napari is available on the
 conda-forge channel. We also recommend this path for users of arm64 macOS machines
-(Apple Silicon, meaning a processor with a name like "M1"). You can install it with:
+([Apple Silicon](https://support.apple.com/en-us/116943), meaning a processor with a name like "M1"). You can install it with:
 
 ```sh
 conda install -c conda-forge napari pyqt
@@ -111,7 +111,7 @@ conda update -n base conda
 
 :::::{tab-item} From PyPI using pip
 
-napari can be installed from PyPI on most macOS (Intel x86), Linux, and Windows systems with Python
+napari can be installed from PyPI on most macOS, Linux, and Windows systems with Python
 {{ python_version_range }} using pip:
 
 ```sh

--- a/docs/tutorials/fundamentals/installation.md
+++ b/docs/tutorials/fundamentals/installation.md
@@ -192,8 +192,12 @@ python -m pip install "napari[pyside2]"  # for PySide2
 ```
 
 
-However, if you have a Mac with the newer arm64
-architecture (Apple Silicon), the installing pyside2 backend using `pip` is not supported. See [note on m1](note-m1).
+Please note that, if you have a Mac with the newer arm64
+architecture ([Apple Silicon](https://support.apple.com/en-us/116943)), then installing the PySide2 backend using `pip` is not supported because pre-compiled PySide2 packages
+([wheels](https://realpython.com/python-wheels/)) are not available on
+[PyPI](https://pypi.org), the repository used by `pip`. However,
+you can install `pyside2` separately, for example from `conda-forge`,
+and then use `pip install napari`.
 
 ```{note}
 If you switch backends, it's a good idea to `pip uninstall` the one


### PR DESCRIPTION
# References and relevant issues

Pointed here https://github.com/scverse/spatialdata/pull/647#issuecomment-2260948723

# Description

Our description of installation on macOS ARM still suggests that pyqt5 is not supported. It is no longer true. I try to update description but any reviewer, feel free to rephrase. 
