### PR TITLE
Improve deploy workflow by use deploy directory from workflow dispatch input 

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -17,6 +17,11 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      target_directory:
+        description: 'The directory to deploy the docs to'
+        required: true
+        default: 'dev'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -104,23 +109,6 @@ jobs:
           # Downloads to '/home/runner/work/docs/docs/html'
           path: html
 
-      - name: get directory name
-        # if this is a tag, use the tag name as the directory name else dev
-        env:
-          REF: ${{ github.ref }}
-        run: |
-          TAG="${GITHUB_REF/refs\/tags\/v/}"
-          VER="${TAG/a*/}"  # remove alpha identifier
-          VER="${VER/b*/}"  # remove beta identifier
-          VER="${VER/rc*/}"  # remove rc identifier
-          VER="${VER/post*/}"  # remove post identifier
-
-          if [[ "$REF" == "refs/tags/v"* ]]; then
-            echo "branch_name=$VER" >> "$GITHUB_ENV"
-          else
-            echo "branch_name=dev" >> "$GITHUB_ENV"
-          fi
-
       - name: Deploy Docs
         if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/heads/main'))
         uses: peaceiris/actions-gh-pages@v3
@@ -129,5 +117,5 @@ jobs:
           external_repository: napari/napari.github.io
           publish_dir: ./html
           publish_branch: gh-pages
-          destination_dir: ${{ env.branch_name }}
+          destination_dir: ${{ github.event.inputs.target_directory || 'dev' }}
           cname: napari.org


### PR DESCRIPTION
# References and relevant issues

# Description

As `convictional/trigger-workflow-and-wait` do not pass proper reference to workflow, this PR changed to use workflow dispatch input. This will allow triggering deploy docs manually to a given directory without the need to create a tag. 