### PR TITLE
Add 0.5.2 to the version switcher

### DIFF
--- a/docs/_static/version_switcher.json
+++ b/docs/_static/version_switcher.json
@@ -5,10 +5,15 @@
 		"url": "https://napari.org/dev/"
 	},
 	{
-		"name": "stable (0.5.1)",
-		"version": "0.5.1",
+		"name": "stable (0.5.2)",
+		"version": "0.5.2",
 		"preferred": true,
 		"url": "https://napari.org/stable/"
+	},
+	{
+		"name": "0.5.1",
+		"version": "0.5.1",
+		"url": "https://napari.org/0.5.1/"
 	},
 	{
 		"name": "0.5.0",


### PR DESCRIPTION
Should merge after [this workflow](https://github.com/napari/docs/actions/runs/10365633631) is finished and the stable symlink is updated.
