### PR TITLE
Update version switcher to add 0.5.3

### DIFF
--- a/docs/_static/version_switcher.json
+++ b/docs/_static/version_switcher.json
@@ -5,10 +5,15 @@
 		"url": "https://napari.org/dev/"
 	},
 	{
-		"name": "stable (0.5.2)",
-		"version": "0.5.2",
+		"name": "stable (0.5.3)",
+		"version": "0.5.3",
 		"preferred": true,
 		"url": "https://napari.org/stable/"
+	},
+	{
+		"name": "0.5.2",
+		"version": "0.5.2",
+		"url": "https://napari.org/0.5.2/"
 	},
 	{
 		"name": "0.5.1",


### PR DESCRIPTION
I already updated https://github.com/napari/napari.github.io, but that will get
overwritten with the next PR that gets merged in this repo. This PR should be
that. 😂
