### PR TITLE
Move release notes to be under Usage

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -75,6 +75,57 @@ subtrees:
       - file: further-resources/napari-workshops
       - file: further-resources/sample_data
       - file: gallery
+      - file: release/index
+        subtrees:
+        - entries:
+          - file: release/release_0_5_3
+          - file: release/release_0_5_2
+          - file: release/release_0_5_1
+          - file: release/release_0_5_0
+          - file: release/release_0_4_19
+          - file: release/release_0_4_18
+          - file: release/release_0_4_17
+          - file: release/release_0_4_16
+          - file: release/release_0_4_15
+          - file: release/release_0_4_14
+          - file: release/release_0_4_13
+          - file: release/release_0_4_12
+          - file: release/release_0_4_11
+          - file: release/release_0_4_10
+          - file: release/release_0_4_9
+          - file: release/release_0_4_8
+          - file: release/release_0_4_7
+          - file: release/release_0_4_6
+          - file: release/release_0_4_5
+          - file: release/release_0_4_4
+          - file: release/release_0_4_3
+          - file: release/release_0_4_2
+          - file: release/release_0_4_1
+          - file: release/release_0_4_0
+          - file: release/release_0_3_8
+          - file: release/release_0_3_7
+          - file: release/release_0_3_6
+          - file: release/release_0_3_5
+          - file: release/release_0_3_4
+          - file: release/release_0_3_3
+          - file: release/release_0_3_2
+          - file: release/release_0_3_1
+          - file: release/release_0_3_0
+          - file: release/release_0_2_12
+          - file: release/release_0_2_11
+          - file: release/release_0_2_10
+          - file: release/release_0_2_9
+          - file: release/release_0_2_8
+          - file: release/release_0_2_7
+          - file: release/release_0_2_6
+          - file: release/release_0_2_5
+          - file: release/release_0_2_4
+          - file: release/release_0_2_3
+          - file: release/release_0_2_1
+          - file: release/release_0_2_0
+          - file: release/release_0_1_5
+          - file: release/release_0_1_3
+          - file: release/release_0_1_0
   - file: plugins/index
     subtrees:
     - entries:
@@ -178,57 +229,6 @@ subtrees:
           - file: naps/7-key-binding-dispatch
           - file: naps/8-telemetry
           - file: naps/9-multiple-canvases
-      - file: release/index
-        subtrees:
-        - entries:
-          - file: release/release_0_5_3
-          - file: release/release_0_5_2
-          - file: release/release_0_5_1
-          - file: release/release_0_5_0
-          - file: release/release_0_4_19
-          - file: release/release_0_4_18
-          - file: release/release_0_4_17
-          - file: release/release_0_4_16
-          - file: release/release_0_4_15
-          - file: release/release_0_4_14
-          - file: release/release_0_4_13
-          - file: release/release_0_4_12
-          - file: release/release_0_4_11
-          - file: release/release_0_4_10
-          - file: release/release_0_4_9
-          - file: release/release_0_4_8
-          - file: release/release_0_4_7
-          - file: release/release_0_4_6
-          - file: release/release_0_4_5
-          - file: release/release_0_4_4
-          - file: release/release_0_4_3
-          - file: release/release_0_4_2
-          - file: release/release_0_4_1
-          - file: release/release_0_4_0
-          - file: release/release_0_3_8
-          - file: release/release_0_3_7
-          - file: release/release_0_3_6
-          - file: release/release_0_3_5
-          - file: release/release_0_3_4
-          - file: release/release_0_3_3
-          - file: release/release_0_3_2
-          - file: release/release_0_3_1
-          - file: release/release_0_3_0
-          - file: release/release_0_2_12
-          - file: release/release_0_2_11
-          - file: release/release_0_2_10
-          - file: release/release_0_2_9
-          - file: release/release_0_2_8
-          - file: release/release_0_2_7
-          - file: release/release_0_2_6
-          - file: release/release_0_2_5
-          - file: release/release_0_2_4
-          - file: release/release_0_2_3
-          - file: release/release_0_2_1
-          - file: release/release_0_2_0
-          - file: release/release_0_1_5
-          - file: release/release_0_1_3
-          - file: release/release_0_1_0
       - file: roadmaps/index
         subtrees:
         - entries:


### PR DESCRIPTION
# References and relevant issues
Closes #317

# Description
Moves Release notes to appear under Usage in the docs. Files are not moved, only the ToC is updated since the release notes are unversioned (see https://github.com/napari/napari.github.io/blob/gh-pages/.github/workflows/unversioned_pages.yml)