### PR TITLE
Document the SPEC-0 rule for bundled Python

### DIFF
--- a/docs/developers/coredev/packaging.md
+++ b/docs/developers/coredev/packaging.md
@@ -173,6 +173,10 @@ The main OS-agnostic keys are:
 
 Then, depending on the operating systems and the installer format, we customize the configuration a bit more.
 
+The bundled Python version in the installers follows the Python version installed in the CI
+`make_bundle_conda.yml` workflow at `napari/packaging`. Update the CI matrix configuration to bump
+the bundled Python. We use the oldest version supported by the [SPEC-0][SPEC0] recommendations.
+
 #### Default installation path
 
 This depends on each OS. Our general strategy is to put the general installation under
@@ -259,3 +263,4 @@ Generating a `conda`-based installer requires several components in place:
 [21]: https://anaconda.org/conda-forge/napari
 [22]: https://github.com/conda/constructor/blob/764ba8a/constructor/nsis/_nsis.py
 [nap-2]: https://napari.org/dev/naps/2-conda-based-packaging.html
+[SPEC0]: https://scientific-python.org/specs/spec-0000/


### PR DESCRIPTION
# References and relevant issues
<!-- What relevant resources were used in the creation of this PR?
If this PR addresses an existing issue on the repo,
please link to that issue here as "Closes #(issue-number)".
If this PR adds docs for a napari PR please add a "Depends on <napari PR link>" -->

# Description
<!-- What does this pull request (PR) do? Does it add new content, improve/fix existing
context, improve/fix workflow/documentation build/deployment or something else?
<!-- If relevant, please include a screenshot or a screen capture in your content
change: "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations. -->
<!-- You can also see a preview of the documentation changes you are submitting by
clicking on "Details" to the right of the "Check the rendered docs here!" check on your PR.-->

Document the decision of using SPEC-0 to dictate which Python version should be bundled in each installer release. See https://github.com/napari/packaging/pull/189 and https://napari.zulipchat.com/#narrow/channel/309872-plugins/topic/Bundled.20Python.20will.20be.20bumped.20to.203.2E11/near/476977691.

<!-- Final Checklist
- If images included: I have added [alt text](https://webaim.org/techniques/alttext/)
If workflow, documentation build or deployment change:
- My PR is the minimum possible work for the desired functionality
- I have commented my code, to let others know what it does
-->
