### PR TITLE
Add community calendar link to landing page

### DIFF
--- a/docs/_templates/calendar-template.html
+++ b/docs/_templates/calendar-template.html
@@ -1,0 +1,9 @@
+<nav class="bd-docs-nav bd-links">
+    <div class="bd-toc-item navbar-nav">
+        <ul class="nav bd-sidenav">
+            <li class="toctree-l1">
+                <a class="reference internal" href="community/meeting_schedule.html">Community calendar</a>
+            </li>
+        </ul>
+    </div>
+</nav>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -130,6 +130,11 @@ html_theme_options = {
     "footer_end": ["napari-copyright"],
 }
 
+html_sidebars = {
+    "**": ["search-field.html", "sidebar-nav-bs"],
+    "index": ["search-field.html" , "calendar-template"],
+}
+
 html_context = {
    # use Light theme only, don't auto switch (default)
    "default_mode": "light"

--- a/docs/index.md
+++ b/docs/index.md
@@ -121,3 +121,4 @@ napari is extensible! Find plugins, or develop your own!
 :::
 
 ::::
+


### PR DESCRIPTION
# References and relevant issues
Closes #353

# Description
Adds a link to the community calendar to the landing page primary sidebar.

Happy to adjust the appearance/style!