### PR TITLE
Update release guide anchor

### DIFF
--- a/docs/developers/index.md
+++ b/docs/developers/index.md
@@ -24,7 +24,7 @@ napari has a [Code of Conduct](napari-coc) that should be honored by everyone wh
   onboarding new core developers:
   - [Core Developer guide](core-dev-guide)
   - [Maintenance](napari-maintenance)
-  - [Release guide](release)
+  - [Release guide](napari-release)
   - [Deploying documentation](docs-deployment)
   - [Packaging](napari-packaging)
 


### PR DESCRIPTION
# Description
Pointed by @willingc in zulip: the current link gets processed by intersphinx and links out to the numpy release guide.
