### PR TITLE
Add notes about versionadded/versionchanged directives to dev guide

### DIFF
--- a/docs/developers/contributing/index.md
+++ b/docs/developers/contributing/index.md
@@ -120,7 +120,7 @@ identify the cause and where to optimize.
 
 ### API Changes
 
-If you are changing and existing API or adding a new one, make sure you update
+If you are changing an existing API or adding a new one, make sure you update
 the corresponding docstring to contain the `.. versionadded::` or
 `.. versionchanged::` directive. For more information see the
 [Sphinx documentation](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#describing-changes-between-versions).

--- a/docs/developers/contributing/index.md
+++ b/docs/developers/contributing/index.md
@@ -123,7 +123,9 @@ identify the cause and where to optimize.
 If you are changing an existing API or adding a new one, make sure you update
 the corresponding docstring to contain the `.. versionadded::` or
 `.. versionchanged::` directive. For more information see the
-[Sphinx documentation](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#describing-changes-between-versions).
+[Sphinx documentation](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#describing-changes-between-versions). 
+Please also consider documenting any major features/changes in our
+[tutorials](tutorials) and other [usage documentation](usage).
 
 ### Contributing documentation
 

--- a/docs/developers/contributing/index.md
+++ b/docs/developers/contributing/index.md
@@ -118,6 +118,13 @@ also include benchmarks to show the new feature is not too slow but this is less
 poor performance, [profiling](profiling) and [performance monitoring](napari-perfmon) can help
 identify the cause and where to optimize.
 
+### API Changes
+
+If you are changing and existing API or adding a new one, make sure you update
+the corresponding docstring to contain the `.. versionadded::` or
+`.. versionchanged::` directive. For more information see the
+[Sphinx documentation](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#describing-changes-between-versions).
+
 ### Contributing documentation
 
 See [](contributing-docs) for information on how to contribute documentation.

--- a/docs/developers/coredev/core_dev_guide.md
+++ b/docs/developers/coredev/core_dev_guide.md
@@ -95,9 +95,13 @@ version numbers `0.x` and do not have a deprecation policy, but we will work to 
 4. **Documentation and tutorials:** All new methods should have appropriate doc
 strings following [PEP257](https://peps.python.org/pep-0257/) and the
 [NumPy documentation guide](https://numpy.org/devdocs/dev/howto-docs.html#documentation-style).
-For any major new features, accompanying changes should be made to our
-[tutorials](tutorials). These should not only
-illustrates the new feature, but explains it. Titles for all documents in napari should follow [sentence case capitalization](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case), but the name `napari` should always be written in lowercase.
+For API changes, make sure to check that a `.. versionadded::` or
+`.. versionchanged::` directive has been added to the appropriate docstring. For
+any major new features, accompanying changes should be made to our
+[tutorials](tutorials). These should not only illustrate the new feature, but
+explain it. Titles for all documents in napari should follow
+[sentence case capitalization](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case),
+but the name `napari` should always be written in lowercase.
 
 5. **Implementations and algorithms:** You should understand the code being modified
 or added before approving it.  (See [Merge Only Changes You Understand](#merge-only-changes-you-understand)


### PR DESCRIPTION
# References and relevant issues
Closes napari/napari#7192
Complements napari/napari#7359

# Description
Adds note about using versionadded/versionchanged directives to the core dev and contributing guides.

