### PR TITLE
Remove not applicable labels from labeler.yml

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,26 +1,7 @@
 # See: .github/workflows/labeler.yml and https://github.com/marketplace/actions/labeler
-design:
-  - 'napari/_qt/qt_resources/**/*'
-
 documentation:
   - 'docs/**/*'
   - 'docs/*'
 
-preferences:
-  - 'napari/_qt/**/*/preferences_dialog.py'
-  - 'napari/settings/**/*.py'
-
-qt:
-  - 'napari/_qt/**/*.py'
-  - 'napari/_qt/**/*.py'
-  - 'napari/qt/**/*.py'
-  - 'napari/qt/**/*.py'
-
 task:
   - '.github/**/*'
-
-tests:
-  - '**/*/_tests/**/*.py'
-
-vispy:
-  - 'napari/_vispy'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,5 +3,6 @@ documentation:
   - 'docs/**/*'
   - 'docs/*'
 
-task:
+maintenance:
+  - '.circleci/*'
   - '.github/**/*'


### PR DESCRIPTION
# References and relevant issues
Fixes failing CI labeling step on #516 

# Description
This PR removes labels that are unneeded for the configuration of the labeler action. These were carried over from the napari repo and are not needed here.