### PR TITLE
Add contributing text and link about CI

### DIFF
--- a/docs/developers/contributing/index.md
+++ b/docs/developers/contributing/index.md
@@ -84,6 +84,12 @@ keeping napari maintainable as it grows.
 We have dedicated documentation on [testing](napari-testing) that we recommend you
 read as you're working on your first contribution.
 
+### Automation and CI
+
+We use GitHub Actions to automate our continuous integration and project workflows.
+The [`CONTRIBUTING.md` doc in the `.github` directory](https://github.com/napari/napari/blob/main/.github/CONTRIBUTING.md)
+highlights basics about the GitHub Actions used in the project.
+
 ### Adding icons
 
 If you want to add a new icon to the app, make the icon in whatever program you

--- a/docs/developers/contributing/index.md
+++ b/docs/developers/contributing/index.md
@@ -90,6 +90,8 @@ We use GitHub Actions to automate our continuous integration and project workflo
 The [`CONTRIBUTING.md` doc in the `.github` directory](https://github.com/napari/napari/blob/main/.github/CONTRIBUTING.md)
 highlights basics about the GitHub Actions used in the project.
 
+We also automate [deployment of our documentation and website](https://napari.org/stable/developers/contributing/documentation/docs_deployment.html).
+
 ### Adding icons
 
 If you want to add a new icon to the app, make the icon in whatever program you


### PR DESCRIPTION
# References and relevant issues
This is a follow up from https://github.com/napari/napari/issues/7364#issuecomment-2470394033

# Description
Adds text and link to CI CONTRIBUTING.md doc in napari/napari.