### PR TITLE
Update labeler.yml to check subfolders

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,7 +1,7 @@
 # See: .github/workflows/labeler.yml and https://github.com/marketplace/actions/labeler
 documentation:
 - changed-files:
-  - any-glob-to-any-file: 'docs/*'
+  - any-glob-to-any-file: 'docs/**'
 
 maintenance:
 - changed-files:


### PR DESCRIPTION
# References and relevant issues
The labeler action still hasn't auto-labeled stuff:
https://github.com/napari/docs/pull/519#issuecomment-2485959231

# Description
This PR makes the labeler recurse through `docs`, which should fix the lack of labeling noted above.
