### PR TITLE
Fix linkchecker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ html-live: prep-docs
 html-noplot: clean prep-docs
 	NAPARI_APPLICATION_IPY_INTERACTIVE=0 sphinx-build -M html docs/ docs/_build -D plot_gallery=0 -D sphinx_gallery_conf.examples_dirs=$(GALLERY_PATH) $(SPHINXOPTS)
 
-linkcheck-files:
+linkcheck-files: prep-docs
 	NAPARI_APPLICATION_IPY_INTERACTIVE=0 sphinx-build -b linkcheck -D plot_gallery=0 --color docs/ docs/_build/html ${FILES} -D sphinx_gallery_conf.examples_dirs=$(GALLERY_PATH) $(SPHINXOPTS)
 
 fallback-videos:


### PR DESCRIPTION
# References and relevant issues
--

# Description
The linkchecker is failing due to the autogenerated docs that are not being generated - added this step to the linkcheck make target.

See for example https://github.com/napari/docs/actions/runs/12091824973/job/33720711245

