### PR TITLE
Add version warning banner for old versions of the docs

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -29,3 +29,22 @@ div.sphx-glr-download a:hover {
   background-color: var(--napari-gray);
   color: #222832;
 }
+
+/* Version warning banner color */
+#bd-header-version-warning {
+  background-color: color-mix(in srgb, var(--pst-color-secondary-bg), transparent 30%);
+}
+
+#bd-header-version-warning .pst-button-link-to-stable-version {
+  background-color: color-mix(in srgb, var(--pst-color-secondary-bg), transparent 0%);
+  border-color: var(--pst-color-secondary-bg);
+  color: #222832;
+  font-weight: 700;
+}
+
+#bd-header-version-warning .pst-button-link-to-stable-version:hover {
+  background-color: var(--pst-color-secondary-bg);
+  border-color: var(--pst-color-secondary-bg);
+  color: #222832;
+  font-weight: 700;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -128,6 +128,7 @@ html_theme_options = {
     },
     "footer_start": ["napari-footer-links"],
     "footer_end": ["napari-copyright"],
+    "show_version_warning_banner": True,
 }
 
 html_sidebars = {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -118,7 +118,7 @@ html_theme_options = {
     "secondary_sidebar_items": ["page-toc"],
     "pygment_light_style": "napari",
     "pygment_dark_style": "napari",
-    "announcement": "https://napari.org/dev/_static/announcement.html",
+    "announcement": "",
     "back_to_top_button": False,
     "analytics": {
         # The domain you'd like to use for this analytics instance


### PR DESCRIPTION
# References and relevant issues
Closes #82

# Description
We now get the version warning banner for free so we can turn it on :) 

It looks like this currently:

![Captura de imagem_20241205_171236](https://github.com/user-attachments/assets/fceca5d6-5ef9-4e32-9bff-e3bb646141a9)

I'm happy to do some CSS styling if we are not happy with how it looks!