### PR TITLE
Add reference to napari architecture guide in the contributing guide

### DIFF
--- a/docs/developers/contributing/index.md
+++ b/docs/developers/contributing/index.md
@@ -2,8 +2,9 @@
 # Contributing guide
 
 We welcome your contributions! Here you will find a guide to the contribution
-workflow and tips for contributing to napari. Do not hesitate to [contact](contact) us
-if you have any queries.
+workflow and tips for contributing to napari.
+If you are looking to learn more about the napari code base, see the [napari architecture guide](architecture-index).
+Do not hesitate to [contact](contact) us if you have any queries.
 
 ```{note}
 To contribute to our blog, the [Island Dispatch](https://napari.org/island-dispatch), check out https://github.com/napari/island-dispatch.


### PR DESCRIPTION
# References and relevant issues

In [napari issue #7447](https://github.com/napari/napari/issues/7447#issuecomment-2543230977), @psobolewskiPhD shared with me the architecture guide, saying not many people know about it. 

This adds a reference to the napari architecture guide to the main Contributing guide index page, as a first-guess place a user might find it. I myself did not know about this, in part because I'm a noob that did not ever connect 'Architecture Guide' to something code related, and therefore useful in my quest to start contributing. As such, having an explicit mention of the guide and its purpose in different language could be helpful. 