### PR TITLE
Add resources page with logos

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -184,6 +184,7 @@ subtrees:
       - file: community/working_groups
       - file: community/meeting_schedule
       - file: community/licensing
+      - file: community/resources
   - file: developers/index
     subtrees:
     - entries:

--- a/docs/community/resources.md
+++ b/docs/community/resources.md
@@ -1,0 +1,34 @@
+# Community resources
+
+## napari logo
+
+Below are several versions of the napari logo that you can use in your docs or presentations.
+
+<table>
+    <tr>
+        <th class="text-center">
+            <a href="https://raw.githubusercontent.com/napari/docs/refs/heads/main/docs/_static/images/logo.png">
+            <img src="../_static/images/logo.png" alt="napari logo" width="150"/>
+            Download .png
+            </a>
+        </th>
+        <th class="text-center">
+            <a href="https://raw.githubusercontent.com/napari/docs/refs/heads/main/docs/_static/favicon/logo-noborder-180.png">
+            <img src="../_static/favicon/logo-noborder-180.png" alt="napari logo with no border" width="150"/>
+            Download .png
+            </a>
+        </th>
+        <th class="text-center">
+            <a href="https://raw.githubusercontent.com/napari/docs/refs/heads/main/docs/_static/favicon/logo-silhouette-192.png">
+            <img src="../_static/favicon/logo-silhouette-192.png" alt="napari logo, silhouette only" width="150"/>
+            Download .png
+            </a>
+        </th>
+        <th class="text-center">
+            <a href="https://raw.githubusercontent.com/napari/docs/refs/heads/main/docs/_static/favicon/logo-silhouette-dark-light.svg">
+            <img src="../_static/favicon/logo-silhouette-dark-light.svg" alt="napari logo, silhouette only, svg format" width="150"/>
+            Download .svg
+            </a>
+        </th>
+    </tr>
+</table>


### PR DESCRIPTION
# References and relevant issues
Closes #189

# Description
Adds a page under community to highlight some resources. Right now only versions of the napari logo are listed, but in the future we could include links to presentations or other resources.
