### PR TITLE
Update version switcher for 0.5.6

### DIFF
--- a/docs/_static/version_switcher.json
+++ b/docs/_static/version_switcher.json
@@ -5,10 +5,15 @@
 		"url": "https://napari.org/dev/"
 	},
 	{
-		"name": "stable (0.5.5)",
-		"version": "0.5.5",
+		"name": "stable (0.5.6)",
+		"version": "0.5.6",
 		"preferred": true,
 		"url": "https://napari.org/stable/"
+	},
+	{
+		"name": "0.5.5",
+		"version": "0.5.5",
+		"url": "https://napari.org/0.5.5/"
 	},
 	{
 		"name": "0.5.4",


### PR DESCRIPTION
# References and relevant issues
Follow-up to 0.5.6 release
Pair with https://github.com/napari/napari.github.io/pull/421

# Description
Updates version switcher to point to 0.5.6 as the stable version. 
