### PR TITLE
Update installation instructions to mention the `optional` dependency group

### DIFF
--- a/docs/developers/contributing/dev_install.md
+++ b/docs/developers/contributing/dev_install.md
@@ -82,7 +82,13 @@ In order to make changes to `napari`, you will need to [fork](https://docs.githu
 
     Note that in this last case you will need to install your Qt backend separately.
 
-5. We use [`pre-commit`](https://pre-commit.com) to format code with
+    ```{note}
+    In all of the above cases, you may wish to include the `optional` dependency group,
+    in addition to `dev`. It includes `numba` and other performance packages that are
+    included with the typical end-user `napari[all]` installation.
+    ```
+
+6. We use [`pre-commit`](https://pre-commit.com) to format code with
    [`ruff-format`](https://docs.astral.sh/ruff/formatter/) and lint with
    [`ruff`](https://github.com/astral-sh/ruff) automatically prior to each commit.
    To minimize test errors when submitting pull requests, please install `pre-commit`

--- a/docs/developers/contributing/dev_install.md
+++ b/docs/developers/contributing/dev_install.md
@@ -84,7 +84,8 @@ In order to make changes to `napari`, you will need to [fork](https://docs.githu
 
     ```{note}
     In all of the above cases, you may wish to include the `optional` dependency group,
-    in addition to `dev`. It includes `numba` and other performance packages that are
+    in addition to `dev`, by using `pip install -e ".[dev, optional]"`, for example.
+    The `optional` dependency group includes `numba` and other performance packages that are
     included with the typical end-user `napari[all]` installation.
     ```
 

--- a/docs/tutorials/fundamentals/installation.md
+++ b/docs/tutorials/fundamentals/installation.md
@@ -185,12 +185,13 @@ PyQt5--but this could change in the future.
 To install napari with a specific framework, you can use:
 
 ```sh
-python -m pip install "napari[pyqt5]"    # for PyQt5
+python -m pip install "napari[pyqt6, optional]"    # for PyQt6
 
 # OR
-python -m pip install "napari[pyside2]"  # for PySide2
+python -m pip install "napari[pyside2, optional]"  # for PySide2
 ```
 
+By including `optional` you will install everything that `napari[all]` includes, but with the Qt backend of your choice.
 
 Please note that, if you have a Mac with the newer arm64
 architecture ([Apple Silicon](https://support.apple.com/en-us/116943)), then installing the PySide2 backend using `pip` is not supported because pre-compiled PySide2 packages
@@ -217,10 +218,10 @@ replacing `{tag}` with the desired napari version.
 pip install napari[backend_selection] -c path/to/constraints/file
 ```
 
-For example, if you would like to install napari on python 3.10:
+For example, if you would like to install napari with PyQt6 on python 3.10:
 
 ```sh
-pip install napari[all, pyqt] -c constraints_py3.10.txt
+pip install napari[pyqt6, optional] -c constraints_py3.10.txt
 ```
 
 ## Install as a bundled app


### PR DESCRIPTION
# References and relevant issues
Closes: https://github.com/napari/docs/issues/549

# Description
In this PR I update the end-user and developer installation guides to mention the `optional` dependency group.
This group, along with pyqt5, is in the typical end-user `napari[all]` installation.