### PR TITLE
Update conf.py to bump the recommended python version to 3.11

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -229,6 +229,7 @@ min_python_version = min(napari_supported_python_versions)
 max_python_version = max(napari_supported_python_versions)
 
 version_string = '.'.join(str(x) for x in __version_tuple__[:3])
+# when updating the version below, ensure to also update napari/napari README
 python_version = '3.11'
 python_version_range = f"{min_python_version}-{max_python_version}"
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -229,7 +229,7 @@ min_python_version = min(napari_supported_python_versions)
 max_python_version = max(napari_supported_python_versions)
 
 version_string = '.'.join(str(x) for x in __version_tuple__[:3])
-python_version = '3.10'
+python_version = '3.11'
 python_version_range = f"{min_python_version}-{max_python_version}"
 
 myst_substitutions = {


### PR DESCRIPTION
# References and relevant issues
Closes: https://github.com/napari/docs/issues/566

# Description
It was previously discussed that when napari dropped py3.9, so py3.10 was the minimum, we would move up the recommended version to be one notch ahead. This is what this PR does, bumping it to 3.11.

