### PR TITLE
Update CircleCI config.yml to use napari docs and gallery dependency groups

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           name: Install napari-dev
           command: |
             . venv/bin/activate
-            python -m pip install -e "napari/[pyside,dev,docs,gallery]"
+            python -m pip install -e "napari/[pyside,dev,docs]"
           environment:
             PIP_CONSTRAINT: napari/resources/constraints/constraints_py3.10_docs.txt
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           name: Install napari-dev
           command: |
             . venv/bin/activate
-            python -m pip install -e "napari/[pyside,dev]"
+            python -m pip install -e "napari/[pyside,dev,docs,gallery]"
           environment:
             PIP_CONSTRAINT: napari/resources/constraints/constraints_py3.10_docs.txt
       - run:
@@ -40,7 +40,7 @@ jobs:
           command: |
             . venv/bin/activate
             cd docs
-            xvfb-run --auto-servernum make docs
+            xvfb-run --auto-servernum make html
           environment:
             PIP_CONSTRAINT: ../napari/resources/constraints/constraints_py3.10_docs.txt
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           name: Install napari-dev
           command: |
             . venv/bin/activate
-            python -m pip install -e "napari/[pyside,dev,docs]"
+            python -m pip install -e "napari/[pyside,docs]"
           environment:
             PIP_CONSTRAINT: napari/resources/constraints/constraints_py3.10_docs.txt
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           name: Install napari-dev
           command: |
             . venv/bin/activate
-            python -m pip install -e "napari/[pyside,docs]"
+            python -m pip install -e "napari/[pyqt5,docs]"
           environment:
             PIP_CONSTRAINT: napari/resources/constraints/constraints_py3.10_docs.txt
       - run:


### PR DESCRIPTION
# References and relevant issues
Part of addressing: https://github.com/napari/docs/issues/589
Depends on: https://github.com/napari/napari/pull/7637

# Description
Instead of using the `docs-install` make step, this installs napari with the `docs` and `gallery` dependency groups.
Also, switch to using PyQT5 to make things less flaky.
Note: our main build and deploy workflow has always been using pyqt5, so now CircleCI matches what is deployed.