### PR TITLE
Update build_and_deploy.yml to use napari docs dependency group

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install "napari/[all]"
+          python -m pip install "napari/[pyqt5, docs]"
         env:
           PIP_CONSTRAINT: ${{ github.workspace }}/napari/resources/constraints/constraints_py3.10_docs.txt
 
@@ -83,7 +83,7 @@ jobs:
         with:
           # Runs in '/home/runner/work/docs/docs/docs'
           # Built HTML pages in '/home/runner/work/docs/docs/docs/docs/_build/html'
-          run:  make -C docs docs
+          run:  make -C docs html
           # skipping setup stops the action from running the default (tiling) window manager
           # the window manager is not necessary for docs builds at this time and it was causing
           # problems with screenshots (https://github.com/napari/docs/issues/285)

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -52,7 +52,6 @@ jobs:
           python-version: "3.10"
           cache-dependency-path: |
             napari/pyproject.toml
-            docs/requirements.txt
 
       - uses: tlambert03/setup-qt-libs@v1
 


### PR DESCRIPTION
# References and relevant issues
Part of: https://github.com/napari/docs/issues/589
Depends on: https://github.com/napari/napari/pull/7637

# Description
Installs napari with `[docs]` and then doesn't run the `docs-install` step of the Makefile.

