### PR TITLE
Untab the plugin users and plugin developers grids

### DIFF
--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -18,7 +18,7 @@ a [copier](https://copier.readthedocs.io/en/stable/) template, bootstraps author
 
 ## Plugin users
 
-Check out the user focused guides for installing and using napari plugins.
+Check out the user focused guides for finding, installing, and using napari plugins.
 
 ::::{grid} Plugin Users
 :::{grid-item-card} Start using plugins

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -38,7 +38,7 @@ How to find and install plugins using the napari plugin installer or napari hub.
 
 ## Plugin Developers
 
-Checkout our plugin developer guides to start creating your own napari plugins.
+Check out our plugin developer guides to start creating your own napari plugins.
 
 ::::{grid}
 :::{grid-item-card} Building a plugin

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -9,11 +9,12 @@ Existing plugins extend napari to add:
 - support for import and export of image and related data types.
 - support for working with specialized data formats.
 - domain specific features, including microscopy, climate, geoscience, and more.
-  Share and discover napari plugins on [napari hub](https://napari-hub.org),
-  [PyPI](https://pypi.org/search/?q=napari), or [conda-forge](https://conda-forge.org/packages/).
-  Interested in creating a plugin? A [napari-plugin-template](https://github.com/napari/napari-plugin-template),
-  a [copier](https://copier.readthedocs.io/en/stable/) template, bootstraps authoring
-  [npe](https://github.com/napari/npe2)-based napari plugins.
+
+Share and discover napari plugins on [napari hub](https://napari-hub.org),
+[PyPI](https://pypi.org/search/?q=napari), or [conda-forge](https://conda-forge.org/packages/).
+Interested in creating a plugin? A [napari-plugin-template](https://github.com/napari/napari-plugin-template),
+a [copier](https://copier.readthedocs.io/en/stable/) template, bootstraps authoring
+[npe](https://github.com/napari/npe2)-based napari plugins.
 
 ## Plugin users
 

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -36,7 +36,7 @@ How to find and install plugins using the napari plugin installer or napari hub.
 :::
 ::::
 
-## Plugin Developers
+## Plugin developers
 
 Check out our plugin developer guides to start creating your own napari plugins.
 

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -20,7 +20,7 @@ a [copier](https://copier.readthedocs.io/en/stable/) template, bootstraps author
 
 Check out the user focused guides for finding, installing, and using napari plugins.
 
-::::{grid} Plugin Users
+::::{grid} 2
 :::{grid-item-card} Start using plugins
 :link: plugins-getting-started
 :link-type: ref
@@ -40,7 +40,7 @@ How to find and install plugins using the napari plugin installer or napari hub.
 
 Check out our plugin developer guides to start creating your own napari plugins.
 
-::::{grid}
+::::{grid} 2
 :::{grid-item-card} Building a plugin
 :link: how-to-build-a-plugin
 :link-type: ref
@@ -56,7 +56,7 @@ Workshop on virtual environments and useful tools for plugin development.
 
 ::::
 
-::::{grid}
+::::{grid} 2
 :::{grid-item-card} Testing and publishing
 :link: plugin-test-deploy
 :link-type: ref

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -1,24 +1,25 @@
 (plugins-index)=
+
 # Plugins
 
 Plugins extend napari's functionality, allowing for customization and sharing with the community.
 While you can use scripts and widgets to extend napari, plugins provide great flexibility.
 Existing plugins extend napari to add:
+
 - support for import and export of image and related data types.
 - support for working with specialized data formats.
 - domain specific features, including microscopy, climate, geoscience, and more.
-Share and discover napari plugins on [napari hub](https://napari-hub.org), 
-[PyPI](https://pypi.org/search/?q=napari), or [conda-forge](https://conda-forge.org/packages/).
-Interested in creating a plugin? A [napari-plugin-template](https://github.com/napari/napari-plugin-template),
-a [copier](https://copier.readthedocs.io/en/stable/) template, bootstraps authoring
-[npe](https://github.com/napari/npe2)-based napari plugins.
+  Share and discover napari plugins on [napari hub](https://napari-hub.org),
+  [PyPI](https://pypi.org/search/?q=napari), or [conda-forge](https://conda-forge.org/packages/).
+  Interested in creating a plugin? A [napari-plugin-template](https://github.com/napari/napari-plugin-template),
+  a [copier](https://copier.readthedocs.io/en/stable/) template, bootstraps authoring
+  [npe](https://github.com/napari/npe2)-based napari plugins.
 
-Check out the user focused guides for installing and using napari plugins, or plugin developer guides to start
-creating your own napari plugins.
+## Plugin users
 
-::::::{tab-set}
-:::::{tab-item} For plugin users
-::::{grid}
+Check out the user focused guides for installing and using napari plugins.
+
+::::{grid} Plugin Users
 :::{grid-item-card} Start using plugins
 :link: plugins-getting-started
 :link-type: ref
@@ -33,9 +34,11 @@ Introduction to napari plugins, what they can provide, and where to get support.
 How to find and install plugins using the napari plugin installer or napari hub.
 :::
 ::::
-:::::
 
-:::::{tab-item} For plugin developers
+## Plugin Developers
+
+Checkout our plugin developer guides to start creating your own napari plugins.
+
 ::::{grid}
 :::{grid-item-card} Building a plugin
 :link: how-to-build-a-plugin
@@ -70,4 +73,3 @@ and guides to convert from first generation plugins to npe2.
 :::
 ::::
 :::::
-::::::


### PR DESCRIPTION
# References and relevant issues
Partially addresses #582

# Description
This PR untabs the plugin landing page so a reader can quickly skim info for plugin users and plugin developers without having to click the tab.
