### PR TITLE
Add cards to the Advanced Topics landing page for plugins

### DIFF
--- a/docs/plugins/advanced_topics/index.md
+++ b/docs/plugins/advanced_topics/index.md
@@ -26,7 +26,7 @@ A technical specification for how plugins can contribute additional functionalit
 
 ## Deprecated: napari plugin engine v1
 
-:::{important} Use npe2.
+:::{important}
 New plugins should use the `npe2` standard.
 We encourage first generation plugin authors to migrate their plugin to the `npe2` standard.
 :::

--- a/docs/plugins/advanced_topics/index.md
+++ b/docs/plugins/advanced_topics/index.md
@@ -8,13 +8,6 @@ Some plugin developers may find more **in-depth, technical information** helpful
 ## npe2 advanced topics and reference
 
 ::::{grid}
-:::{grid-item-card} Migration guide to `npe2`
-:link: npe2-migration-guide
-:link-type: ref
-Have a plugin written for the first generation plugin system? This guide will help you migrate to the `npe2` plugin system.
-
-:::
-
 :::{grid-item-card} npe2 manifest reference
 :link: plugin-manifest
 :link-type: ref
@@ -45,4 +38,12 @@ New plugins should use the `npe2` standard.
 We encourage first generation plugin authors to migrate their plugin to the `npe2` standard.
 
 :::
+
+:::{grid-item-card} Migration guide to `npe2`
+:link: npe2-migration-guide
+:link-type: ref
+Have a plugin written for the first generation plugin system? This guide will help you migrate to the `npe2` plugin system.
+
+:::
+
 ::::

--- a/docs/plugins/advanced_topics/index.md
+++ b/docs/plugins/advanced_topics/index.md
@@ -32,7 +32,7 @@ A technical specification for how plugins can contribute additional functionalit
 :::
 ::::
 
-## Historical documents
+## Deprecated v1 napari plugin engine reference
 
 ::::{grid}
 :::{grid-item-card} First generation napari plugin engine v1

--- a/docs/plugins/advanced_topics/index.md
+++ b/docs/plugins/advanced_topics/index.md
@@ -1,11 +1,10 @@
 # Advanced Topics
 
 Some plugin developers may find more **in-depth, technical information** helpful. This section describes topics, such as:
-- specifications for napari's plugin ecosystem using the standard plugin engine `npe2`.
-- migration to the present standard plugin engine `npe2` from the deprecated plugin engine, napari plugin engine v1.
-- reference documentation about the deprecated napari plugin engine v1.
+- specifications for napari's plugin ecosystem using the plugin engine `npe2`.
+- migration to `npe2` from the deprecated napari plugin engine v1.
 
-## npe2 advanced topics and reference
+## npe2: napari plugin engine v2
 
 ::::{grid}
 :::{grid-item-card} npe2 manifest reference
@@ -25,17 +24,19 @@ A technical specification for how plugins can contribute additional functionalit
 :::
 ::::
 
-## Deprecated v1 napari plugin engine reference
+## Deprecated: napari plugin engine v1
+
+:::{important} Use npe2.
+New plugins should use the `npe2` standard.
+We encourage first generation plugin authors to migrate their plugin to the `npe2` standard.
+:::
 
 ::::{grid}
-:::{grid-item-card} First generation napari plugin engine v1
+:::{grid-item-card} Napari plugin engine v1 reference
 :link: napari-plugin-engine
 :link-type: ref
 
 These documents provide background on the first generation plugin system which is now deprecated.
-
-New plugins should use the `npe2` standard.
-We encourage first generation plugin authors to migrate their plugin to the `npe2` standard.
 
 :::
 

--- a/docs/plugins/advanced_topics/index.md
+++ b/docs/plugins/advanced_topics/index.md
@@ -1,20 +1,48 @@
 # Advanced Topics
 
-Advanced topics for plugin developers around the deprecated first generation napari plugins, and how to move to the new system.
+Some plugin developers may find more **in-depth, technical information** helpful. This section describes topics, such as:
+- specifications for napari's plugin ecosystem using the standard plugin engine `npe2`.
+- migration to the present standard plugin engine `npe2` from the deprecated plugin engine, napari plugin engine v1.
+- reference documentation about the deprecated napari plugin engine v1.
+
+## npe2 advanced topics and reference
 
 ::::{grid}
 :::{grid-item-card} Migration guide to `npe2`
 :link: npe2-migration-guide
 :link-type: ref
-Have a plugin written for the first generation plugin system? This guide will help you migrate to the new plugin system.
+Have a plugin written for the first generation plugin system? This guide will help you migrate to the `npe2` plugin system.
 
 :::
 
-:::{grid-item-card} First generation plugin system
+:::{grid-item-card} npe2 manifest reference
+:link: plugin-manifest
+:link-type: ref
+
+A reference for the `npe2` manifest file, which is used to define the plugin and its contributions.
+
+:::
+
+:::{grid-item-card} `npe2` contributions reference
+:link: contributions-ref
+:link-type: ref
+
+A technical specification for how plugins can contribute additional functionality and features to napari.
+
+:::
+::::
+
+## Historical documents
+
+::::{grid}
+:::{grid-item-card} First generation napari plugin engine v1
 :link: napari-plugin-engine
 :link-type: ref
 
-A guide to the first generation plugin system. This is now deprecated and should not be used for new plugins.
+These documents provide background on the first generation plugin system which is now deprecated.
+
+New plugins should use the `npe2` standard.
+We encourage first generation plugin authors to migrate their plugin to the `npe2` standard.
 
 :::
 ::::


### PR DESCRIPTION
# References and relevant issues
Partially addresses #600 by improving the Advanced Topics landing page.

# Description
This PR adds cards to guide the reader to the npe2 specification. It also more clearly indicates that napari plugin engine v1 is deprecated.

@DragaDoncila @melissawm @psobolewskiPhD FYI