### PR TITLE
Update conf.py to address pygment -> pygments deprecation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -121,8 +121,8 @@ html_theme_options = {
     "navbar_persistent": [],
     "header_links_before_dropdown": 6,
     "secondary_sidebar_items": ["page-toc"],
-    "pygment_light_style": "napari",
-    "pygment_dark_style": "napari",
+    "pygments_light_style": "napari",
+    "pygments_dark_style": "napari",
     "announcement": "",
     "back_to_top_button": False,
     "analytics": {


### PR DESCRIPTION
# References and relevant issues
Part of: https://github.com/napari/docs/issues/596

Adresses deprecation warnings in docs building, see:
https://github.com/napari/docs/actions/runs/13578084932/job/37958725624#step:9:273
```
The parameter "pygment_light_style" was renamed to "pygments_light_style" (note the "s" on "pygments").
The parameter "pygment_dark_style" was renamed to "pygments_dark_style" (note the "s" on "pygments").
```
See also: https://github.com/pydata/pydata-sphinx-theme/pull/1614

# Description
This PR renames the parameter in conf.py in accordance with the deprecation warning.
