### PR TITLE
Add release notes and community chat links to homepage sidebar

### DIFF
--- a/docs/_templates/sidebar-link-items.html
+++ b/docs/_templates/sidebar-link-items.html
@@ -4,6 +4,12 @@
             <li class="toctree-l1">
                 <a class="reference internal" href="community/meeting_schedule.html">Community calendar</a>
             </li>
+            <li class="toctree-l1">
+                <a class="reference external" href="https://napari.zulipchat.com/">Community chat</a>
+            </li>
+            <li class="toctree-l1">
+                <a class="reference internal" href="release/index.html">Release notes</a>
+            </li>
         </ul>
     </div>
 </nav>

--- a/docs/_templates/sidebar-link-items.html
+++ b/docs/_templates/sidebar-link-items.html
@@ -8,7 +8,11 @@
                 <a class="reference external" href="https://napari.zulipchat.com/">Community chat</a>
             </li>
             <li class="toctree-l1">
-                <a class="reference internal" href="release/index.html">Release notes</a>
+                {% if version == "dev" %}
+                <a class="reference internal" href="{'release/index.html'}">Release notes</a>
+                {% else %}
+                <a class="reference internal" href="{{ 'release/release_' + version.replace('.', '_') + '.html' }}">Latest release notes</a>
+                {% endif %}
             </li>
         </ul>
     </div>

--- a/docs/_templates/sidebar-link-items.html
+++ b/docs/_templates/sidebar-link-items.html
@@ -9,7 +9,7 @@
             </li>
             <li class="toctree-l1">
                 {% if version == "dev" %}
-                <a class="reference internal" href="{'release/index.html'}">Release notes</a>
+                <a class="reference internal" href="{{ 'release/index.html' }}">Release notes</a>
                 {% else %}
                 <a class="reference internal" href="{{ 'release/release_' + version.replace('.', '_') + '.html' }}">Latest release notes</a>
                 {% endif %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -143,7 +143,10 @@ html_sidebars = {
 
 html_context = {
    # use Light theme only, don't auto switch (default)
-   "default_mode": "light"
+   "default_mode": "light",
+   # add release version to context
+   "release": release,
+   "version": version,
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -138,7 +138,7 @@ html_theme_options = {
 
 html_sidebars = {
     "**": ["search-field.html", "sidebar-nav-bs"],
-    "index": ["search-field.html" , "calendar-template"],
+    "index": ["search-field.html" , "sidebar-link-items.html"],
 }
 
 html_context = {


### PR DESCRIPTION
# References and relevant issues
<!-- What relevant resources were used in the creation of this PR?
If this PR addresses an existing issue on the repo,
please link to that issue here as "Closes #(issue-number)".
If this PR adds docs for a napari PR please add a "Depends on <napari PR link>" -->
Closes #601

# Description
<!-- What does this pull request (PR) do? Does it add new content, improve/fix existing
context, improve/fix workflow/documentation build/deployment or something else?
<!-- If relevant, please include a screenshot or a screen capture in your content
change: "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations. -->
<!-- You can also see a preview of the documentation changes you are submitting by
clicking on "Details" to the right of the "Check the rendered docs here!" check on your PR.-->
Adds two links to the homepage sidebar
1. community chat (I find it a bit hidden under More)
2. release notes landing page (is there a way we could instead use current release notes link?)
    - the first commit works properly to link to the index
    - the second commit attempts to dynamically link to the current release notes, can fall back to first commit if this isn't worth getting right. I think right now it would 404 for any rc/a/b/post?

<!-- Final Checklist
- If images included: I have added [alt text](https://webaim.org/techniques/alttext/)
If workflow, documentation build or deployment change:
- My PR is the minimum possible work for the desired functionality
- I have commented my code, to let others know what it does
-->
