### PR TITLE
Suppress detached head warning in prep_docs script

### DIFF
--- a/docs/_scripts/prep_docs.py
+++ b/docs/_scripts/prep_docs.py
@@ -23,7 +23,7 @@ def prep_npe2():
     check_call(f"rm -rf {NPE}".split())
     check_call(f"git clone https://github.com/napari/npe2 {NPE}".split())
     if not parse(npe2_version).is_devrelease:
-        check_call(f"git checkout tags/v{npe2_version}".split(), cwd=NPE)
+        check_call(f"git -c advice.detachedHead=false checkout tags/v{npe2_version}".split(), cwd=NPE)
     check_call([sys.executable, f"{NPE}/_docs/render.py", DOCS / 'plugins'])
     check_call(f"rm -rf {NPE}".split())
 


### PR DESCRIPTION
# Description
Add a -c option to suppress the detached head warning when building docs, specifically when checking out a tag.

