### PR TITLE
Add information about show= kwarg for make_napari_viewer fixture

### DIFF
--- a/docs/developers/contributing/testing.md
+++ b/docs/developers/contributing/testing.md
@@ -77,7 +77,7 @@ Pytest fixtures to aid testing live in:
   available globally to all of `napari` **and** to all tests in the same environment
   that `napari` is in (as this file is exported).
 
-One often used fixture is `make_napari_viewer`. This fixture can take as argument `show`
+One often used fixture is `make_napari_viewer`. This fixture can take an argument `show`
 which is either `True` or `False`. In case your test depends on rendering of the viewer,
 it should be set to `True`. This is for example the case when testing a screenshot 
 functionality. Otherwise, it is best to set the argument to `False` to prevent the viewer

--- a/docs/developers/contributing/testing.md
+++ b/docs/developers/contributing/testing.md
@@ -77,6 +77,12 @@ Pytest fixtures to aid testing live in:
   available globally to all of `napari` **and** to all tests in the same environment
   that `napari` is in (as this file is exported).
 
+One often used fixture is `make_napari_viewer`. This fixture can take as argument `show`
+which is either `True` or `False`. In case your test depends on rendering of the viewer,
+it should be set to `True`. This is for example the case when testing a screenshot 
+functionality. Otherwise, it is best to set the argument to `False` to prevent the viewer
+from fully rendering.
+
 There are also fixtures for testing the `napari` builtin plugin (provides contributions
 that come builtin with `napari`).
 These live in

--- a/docs/developers/contributing/testing.md
+++ b/docs/developers/contributing/testing.md
@@ -79,7 +79,7 @@ Pytest fixtures to aid testing live in:
 
 One often used fixture is `make_napari_viewer`. This fixture can take an argument `show`
 which is either `True` or `False`. In case your test depends on rendering of the viewer,
-it should be set to `True`. This is for example the case when testing a screenshot 
+it should be set to `True`. This is, for example, the case when testing a screenshot 
 functionality. Otherwise, it is best to set the argument to `False` to prevent the viewer
 from fully rendering.
 


### PR DESCRIPTION
As discussed in [#7678](https://github.com/napari/napari/pull/7678) this PR adds a bit of information when it is required to set `show` to `True` when using the `make_napari_viewer`  fixture.
