### PR TITLE
update left sidebar to persist resources

### DIFF
--- a/docs/_templates/sidebar-nav-bs.html
+++ b/docs/_templates/sidebar-nav-bs.html
@@ -1,5 +1,8 @@
 {# Displays the TOC-subtree for pages nested under the currently active top-level TOCtree element. #}
 <nav class="bd-docs-nav bd-links" aria-label="{{ _('Section Navigation') }}">
+  <p class="caption" role="heading" aria-level="1">
+    <span class="caption-text">>Section Navigation</span>
+  </p>
   <div class="bd-toc-item navbar-nav">
     {{- generate_toctree_html(
     "sidebar",
@@ -9,30 +12,31 @@
     includehidden=theme_sidebar_includehidden | tobool,
     titles_only=True
     )
+
     -}}
+    <p class="caption" role="heading" aria-level="2">
+      <span class="caption-text">>Resources</span>
+    </p>
+    <ul class="nav bd-sidenav">
+      <li class="toctree-l1">
+          <a class="reference internal" href="community/meeting_schedule.html">Community calendar</a>
+      </li>
+      <li class="toctree-l1">
+          <a class="reference external" href="https://napari.zulipchat.com/">Community chat</a>
+      </li>
+      <li class="toctree-l1">
+          <a class="reference internal" href="troubleshooting.html">Troubleshooting</a>
+      </li>
+      <li class="toctree-l1">
+          {% if version == "dev" %}
+          <a class="reference internal" href="{{ 'release/index.html' }}">Release notes</a>
+          {% else %}
+          <a class="reference internal" href="{{ 'release/release_' + version.replace('.', '_') + '.html' }}">Latest release notes</a>
+          {% endif %}
+      </li>
+      <li class="toctree-l1">
+          <a class="reference external" href="https://napari.org/island-dispatch">Blog</a>
+      </li>
+    </ul>
   </div>
-    <div class="bd-toc-item navbar-nav">
-        <p class="bd-links__title" role="heading" aria-level="1">{{ _("Resources") }}</p>
-          <ul class="nav bd-sidenav">
-            <li class="toctree-l1">
-                <a class="reference internal" href="community/meeting_schedule.html">Community calendar</a>
-            </li>
-            <li class="toctree-l1">
-                <a class="reference external" href="https://napari.zulipchat.com/">Community chat</a>
-            </li>
-            <li class="toctree-l1">
-                <a class="reference internal" href="troubleshooting.html">Troubleshooting</a>
-            </li>
-            <li class="toctree-l1">
-                {% if version == "dev" %}
-                <a class="reference internal" href="{{ 'release/index.html' }}">Release notes</a>
-                {% else %}
-                <a class="reference internal" href="{{ 'release/release_' + version.replace('.', '_') + '.html' }}">Latest release notes</a>
-                {% endif %}
-            </li>
-            <li class="toctree-l1">
-                <a class="reference external" href="https://napari.org/island-dispatch">Blog</a>
-            </li>
-          </ul>
-    </div>
 </nav>

--- a/docs/_templates/sidebar-nav-bs.html
+++ b/docs/_templates/sidebar-nav-bs.html
@@ -11,4 +11,28 @@
     )
     -}}
   </div>
+    <div class="bd-toc-item navbar-nav">
+        <p class="bd-links__title" role="heading" aria-level="1">{{ _("Resources") }}</p>
+          <ul class="nav bd-sidenav">
+            <li class="toctree-l1">
+                <a class="reference internal" href="community/meeting_schedule.html">Community calendar</a>
+            </li>
+            <li class="toctree-l1">
+                <a class="reference external" href="https://napari.zulipchat.com/">Community chat</a>
+            </li>
+            <li class="toctree-l1">
+                <a class="reference internal" href="troubleshooting.html">Troubleshooting</a>
+            </li>
+            <li class="toctree-l1">
+                {% if version == "dev" %}
+                <a class="reference internal" href="{{ 'release/index.html' }}">Release notes</a>
+                {% else %}
+                <a class="reference internal" href="{{ 'release/release_' + version.replace('.', '_') + '.html' }}">Latest release notes</a>
+                {% endif %}
+            </li>
+            <li class="toctree-l1">
+                <a class="reference external" href="https://napari.org/island-dispatch">Blog</a>
+            </li>
+          </ul>
+    </div>
 </nav>

--- a/docs/_templates/sidebar-nav-bs.html
+++ b/docs/_templates/sidebar-nav-bs.html
@@ -1,7 +1,7 @@
 {# Displays the TOC-subtree for pages nested under the currently active top-level TOCtree element. #}
 <nav class="bd-docs-nav bd-links" aria-label="{{ _('Section Navigation') }}">
   <p class="caption" role="heading" aria-level="1">
-    <span class="caption-text">>Section Navigation</span>
+    <span class="caption-text">Section Navigation</span>
   </p>
   <div class="bd-toc-item navbar-nav">
     {{- generate_toctree_html(
@@ -15,7 +15,7 @@
 
     -}}
     <p class="caption" role="heading" aria-level="2">
-      <span class="caption-text">>Resources</span>
+      <span class="caption-text">Resources</span>
     </p>
     <ul class="nav bd-sidenav">
       <li class="toctree-l1">


### PR DESCRIPTION
# Description

During the past few docs meetings and community meetings, we have been talking about ways to provide users information about using napari and engaging them in the napari community. One idea that kept coming up was how to provide users easy access to troubleshooting information and release notes.

After a recent docs meeting, @TimMonko came up with the idea to put a few frequently used links in the left sidebar. He made a PR that would add the links to the sidebar on the homepage. Someone else commented that it would be nice to have the links on other pages.

I had played around with the napari sphinx theme and its templates a couple of months ago. I had the idea to update the left sidebar's jinja template to include a persistent section of frequently used links. Here's a before and after view:

![Screenshot 2025-03-20 at 8 37 42 AM](https://github.com/user-attachments/assets/3b2b8568-9298-43af-bbe4-27f4badf0342)

![Screenshot 2025-03-20 at 8 46 27 AM](https://github.com/user-attachments/assets/65ac1e6f-0b17-4184-a862-ef2b8b574259)



