### PR TITLE
remove gui_qt since it is deprecated and will be removed in 0.6.0

### DIFF
--- a/docs/api/event_loop.rst
+++ b/docs/api/event_loop.rst
@@ -3,5 +3,4 @@ Starting the Event Loop
 
 .. autosummary::
 
-   napari.gui_qt
    napari.run


### PR DESCRIPTION
# References and relevant issues

Removal of deprecated gui_qt https://github.com/napari/napari/pull/7735

# Description

The removal of gui_qt impacts the autobuild of the docs since the api event page lists it. It is failing in CI in the PR open above. This PR removes gui_qt from the API docs.