### PR TITLE
Withdraw NAP-5 new logo proposal

### DIFF
--- a/docs/naps/5-new-logo.md
+++ b/docs/naps/5-new-logo.md
@@ -5,7 +5,7 @@
 ```{eval-rst}
 :Author: Juan Nunez-Iglesias <jni@fastmail.com>
 :Created: 2022-09-08
-:Resolution: <url> (required for Accepted | Rejected | Withdrawn)
+:Resolution: https://github.com/napari/docs/pull/644
 :Resolved: 2025-03-26
 :Status: Withdrawn
 :Type: Standards Track

--- a/docs/naps/5-new-logo.md
+++ b/docs/naps/5-new-logo.md
@@ -6,8 +6,8 @@
 :Author: Juan Nunez-Iglesias <jni@fastmail.com>
 :Created: 2022-09-08
 :Resolution: <url> (required for Accepted | Rejected | Withdrawn)
-:Resolved: <date resolved, in yyyy-mm-dd format>
-:Status: Draft
+:Resolved: 2025-03-26
+:Status: Withdrawn
 :Type: Standards Track
 :Version effective: 0.5
 ```


### PR DESCRIPTION
There wasn't much enthusiasm for this logo. Additionally, after a bit more
time and consideration, I think "fully flat" is actually a few years behind
the 8-ball, and folks are (correctly) going back to more textured logos. I
also read a lot more from e.g. the [macOS app logo design guidelines][1],
which suggest adding a 3D tool on top of the logo to depict what the app
does. There's some ideas we could explore in this vein for napari; for
example, I often introduce napari as a tool to "explore, annotate, and
analyse" image data, so we could have a tool bundle with a magnifying glass,
a pen or pencil, and a ruler or calipers.

Either way, these directions are incompatible with the code presented in the
NAP, so I'm withdrawing it.


[1]: https://developer.apple.com/design/human-interface-guidelines/app-icons/#macOS
