### PR TITLE
Add draft NAP 10 - 0.6.0 release schedule

### DIFF
--- a/docs/naps/10-release-0.6.0.md
+++ b/docs/naps/10-release-0.6.0.md
@@ -34,7 +34,7 @@ Actual:
 
 - 0.5.6: Tuesday, 2025-01-21
 - 0.6.0 development begins:
-- 0.6.0a0 alpha 1:
+- 0.6.0a0 alpha 1: Friday, Mar 14, 2025
 
 Expected:
 

--- a/docs/naps/10-release-0.6.0.md
+++ b/docs/naps/10-release-0.6.0.md
@@ -1,0 +1,70 @@
+(nap10)=
+
+# NAP 10 — napari release 0.6.0 schedule
+
+```{eval-rst}
+:Author: "Carol Willing <mailto:willingc@gmail.com>"
+:Author: ""
+:Author: ""
+:Created: '2025-03-26'
+:Status: Draft
+:Type: Informational
+```
+
+## Abstract
+
+This document describes the development and release schedule for
+napari 0.6.0.
+
+## Release Manager
+
+- 0.6.0 Release Manager: Thomas Wouters
+- Windows bundle:
+- Mac bundle:
+- Documentation:
+
+## Release Schedule
+
+Note: The dates are subject to change to respond to unanticipated
+project needs.
+
+### 0.6.0 schedule
+
+Actual:
+
+- 0.5.6: Tuesday, 2025-01-21
+- 0.6.0 development begins:
+- 0.6.0a0 alpha 1:
+
+Expected:
+
+- 0.6.0a1 alpha 2: Wednesday, 2025-04-02
+  (No new features beyond this point.)
+- 0.6.0rc0 candidate 1: Wednesday, 2025-04-16
+- 0.6.0rc1 candidate 2: Wednesday, 2025-04-23 (if needed)
+- 0.6.0 final: Wednesday, 2025-04-30
+
+### Bugfix releases
+
+Expected:
+
+- 0.6.1: Wednesday, 2025-05-28
+- 0.6.2: Wednesday, 2025-07-30
+- 0.6.3: Wednesday, 2025-09-24
+- 0.6.4: Wednesday, 2025-11
+- 0.6.5: Wednesday, 2026-01
+- 0.6.6: Wednesday, 2026-03
+
+### Source-only security fix releases
+
+Provided irregularly on an as-needed basis.
+
+### 0.6.0 Lifespan
+
+0.6.0 will receive bugfix updates approximately every 2 months for
+approximately 12 months. Around the time of the release of 0.7.0 final, the
+final 0.6.0 bugfix update will be released.
+
+## Copyright
+
+This document has been placed in the public domain.


### PR DESCRIPTION
# References and relevant issues

Release 0.6.0

# Description

Adds a draft release schedule for 0.6.0 as an informational NAP.