### PR TITLE
Update roadmap index to highlight global roadmap 

### DIFF
--- a/docs/roadmaps/index.md
+++ b/docs/roadmaps/index.md
@@ -2,7 +2,7 @@
 
 # Roadmaps
 
-The [napari global roadmap](https://github.com/orgs/napari/projects/24/views/2?pane=info) is hosted on a Github Project board. This roadmap captures the current priorities of the napari core developer team. It is revisited every six months.
+The [**napari global roadmap**](https://github.com/orgs/napari/projects/24/views/2?pane=info) is hosted on a Github Project board. This roadmap captures the current priorities of the napari core developer team. It is revisited every six months.
 
 ## For contributors
 

--- a/docs/roadmaps/index.md
+++ b/docs/roadmaps/index.md
@@ -10,7 +10,7 @@ If a particular roadmap item is important to you and you want to help make it ha
 
 ## For funders
 
-If you have the resources and you are interested in bringing one or more of our roadmap items to life, you can write to us at [](napari-steering-council@googlegroups.com) and donate on our [NumFOCUS page](https://numfocus.org/donate-to-napari). For a limited time, CZI will kindly [match donations up to a total of $100,000 USD](https://chanzuckerberg.com/science/programs-resources/imaging/napari/seeding-sustainability-for-the-napari-project/).
+If you have the resources and you are interested in bringing one or more of our roadmap items to life, you can write to us at [napari-steering-council@googlegroups.com](napari-steering-council@googlegroups.com) and donate on our [NumFOCUS page](https://numfocus.org/donate-to-napari). For a limited time, CZI will kindly [match donations up to a total of $100,000 USD](https://chanzuckerberg.com/science/programs-resources/imaging/napari/seeding-sustainability-for-the-napari-project/).
 
 ### Past Roadmaps
 

--- a/docs/roadmaps/index.md
+++ b/docs/roadmaps/index.md
@@ -2,13 +2,17 @@
 
 # Roadmaps
 
-The current `napari` roadmap can be seen in the following GitHub board: [napari global roadmap](https://github.com/orgs/napari/projects/24/views/2?pane=info)
+The [napari global roadmap](https://github.com/orgs/napari/projects/24/views/2?pane=info) is hosted on a Github Project board. This roadmap captures the current priorities of the napari core developer team. It is revisited every six months.
 
-This roadmap captures the current priorities of the napari core developer team. It is revisited every six months.
+## For contributors
 
----
+If a particular roadmap item is important to you and you want to help make it happen sooner, please [chat with us](https://napari.zulipchat.com/)! You can help by [contributing code or documentation](https://napari.org/dev/developers/index.html)
 
-You can see past roadmaps below.
+## For funders
+
+If you have the resources and you are interested in bringing one or more of our roadmap items to life, you can write to us at [](napari-steering-council@googlegroups.com) and donate on our [NumFOCUS page](https://numfocus.org/donate-to-napari). For a limited time, CZI will kindly [match donations up to a total of $100,000 USD](https://chanzuckerberg.com/science/programs-resources/imaging/napari/seeding-sustainability-for-the-napari-project/).
+
+### Past Roadmaps
 
 - [](0_4.md)
 - [](0_3_retrospective.md)

--- a/docs/roadmaps/index.md
+++ b/docs/roadmaps/index.md
@@ -10,7 +10,7 @@ If a particular roadmap item is important to you and you want to help make it ha
 
 ## For funders
 
-If you have the resources and you are interested in bringing one or more of our roadmap items to life, you can write to us at [napari-steering-council@googlegroups.com](napari-steering-council@googlegroups.com) and donate on our [NumFOCUS page](https://numfocus.org/donate-to-napari). For a limited time, CZI will kindly [match donations up to a total of $100,000 USD](https://chanzuckerberg.com/science/programs-resources/imaging/napari/seeding-sustainability-for-the-napari-project/).
+If you have the resources and you are interested in bringing one or more of our roadmap items to life, you can write to us at [napari-steering-council@googlegroups.com](mailto:napari-steering-council@googlegroups.com) and donate on our [NumFOCUS page](https://numfocus.org/donate-to-napari). For a limited time, CZI will kindly [match donations up to a total of $100,000 USD](https://chanzuckerberg.com/science/programs-resources/imaging/napari/seeding-sustainability-for-the-napari-project/).
 
 ### Past Roadmaps
 


### PR DESCRIPTION
# References and relevant issues
I always thought the roadmap page was just out of date and there was not a roadmap since 0.4. Juan pointed out to me that its up to date on Github.

# Description
This PR emphasizes the global roadmap by moving it as the most immediate item. It also adds the For Contributors and For Funders part, which we can opt to remove since that will require keeping both the roadmap README and this up to date. This PR also tries to de-emphasize the previous roadmaps. 

Thank you Peter for slimfast-live. Made editing this such a breeze.

![image](https://github.com/user-attachments/assets/c921eb66-10d4-4599-a47e-0d79f0d6a541)

## Alternative

This removes for contributors and funders. I liked this less at first, but maybe like it more now...

![Screenshot 2025-04-03 084657](https://github.com/user-attachments/assets/cad47363-39d2-4cc7-94f5-4e22cc76324d)




