### PR TITLE
[bugfix] Fix linkcheck.yml for change to dependencies and removal of req.txt

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install "napari/[all]"
+          python -m pip install "napari/[pyqt5, docs]"
         env:
           PIP_CONSTRAINT: ${{ github.workspace }}/napari/resources/constraints/constraints_py3.10_docs.txt
 
@@ -51,7 +51,6 @@ jobs:
           # Runs in '/home/runner/work/docs/docs/docs'
           # Built HTML pages in '/home/runner/work/docs/docs/docs/docs/_build/html'
           run:  |
-            python -m pip install -r docs/requirements.txt
             make -C docs linkcheck-files
           # skipping setup stops the action from running the default (tiling) window manager
           # the window manager is not necessary for docs builds at this time and it was causing


### PR DESCRIPTION
# References and relevant issues
Fixes https://github.com/napari/docs/actions/runs/14276189925/job/40019459874
With the changes to dependencies (all moved to napari/napari) and removal of requirements.txt the linkcheck action is failing.

# Description
Update the action to install napari[docs] and remove the req.txt step.
