### PR TITLE
Squash deployed gh-pages, relying on this repo for history

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -117,4 +117,5 @@ jobs:
           publish_dir: ./html
           publish_branch: gh-pages
           destination_dir: ${{ github.event.inputs.target_directory || 'dev' }}
+          force_orphan: true
           cname: napari.org


### PR DESCRIPTION
In #621 and elsewhere, we are discussing the issue of autogenerating
screenshots in the docs. @Czaki brought up the issue that git is very
bad at handling binary blobs, so autogenerating images each time we
build the docs would rapidly blow up the repo clone size.

I think it's clear that we *do* want to autogenerate images, so the
cleanest solution in my opinion is to always squash when pushing to
our gh-pages site (napari.github.io). That history is not particularly
valuable, and indeed we have squashed it once before when it was getting
far too big to work with. Doing it automatically is actually an
improvement.

This PR achieves that by using the `force_orphan` option in the
peaceiris/actions-gh-pages action to always squash the edit history
before pushing to the gh-pages branch.

## References

Zulip discussion:
https://napari.zulipchat.com/#narrow/channel/298358-working-group-documentation/topic/Meeting.202025-03-13.2F14/near/505543160

`force_orphan` documentation:
https://github.com/peaceiris/actions-gh-pages?tab=readme-ov-file#%EF%B8%8F-force-orphan-force_orphan
