### PR TITLE
Revert "Squash deployed gh-pages, relying on this repo for history (#658)"

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -117,5 +117,4 @@ jobs:
           publish_dir: ./html
           publish_branch: gh-pages
           destination_dir: ${{ github.event.inputs.target_directory || 'dev' }}
-          force_orphan: true
           cname: napari.org


### PR DESCRIPTION
This reverts commit 5fc3cd73fcd558940b77f49199e0485795bc08fa.

See discussion starting at https://github.com/napari/docs/pull/658#issuecomment-2791396410
