### PR TITLE
Always upload build artifacts in build_docs.yml workflow

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -79,6 +79,7 @@ jobs:
 
       - name: Upload artifact
         id: upload
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: docs


### PR DESCRIPTION
# References and relevant issues


# Description

Always upload build artifacts, as sphinx is writing logs to uploaded path. 