### PR TITLE
Update the version switcher for 0.6.0

### DIFF
--- a/docs/_static/version_switcher.json
+++ b/docs/_static/version_switcher.json
@@ -5,10 +5,15 @@
 		"url": "https://napari.org/dev/"
 	},
 	{
-		"name": "stable (0.5.6)",
-		"version": "0.5.6",
+		"name": "stable (0.6.0)",
+		"version": "0.6.0",
 		"preferred": true,
 		"url": "https://napari.org/stable/"
+	},
+	{
+		"name": "0.5.6",
+		"version": "0.5.6",
+		"url": "https://napari.org/0.5.6/"
 	},
 	{
 		"name": "0.5.5",


### PR DESCRIPTION
This is safe to merge because the 0.6.0 folder is already there. I'm
about to update the symlink on napari.github.io and the tag has just
been pushed. 🥳
