### PR TITLE
Point opengraph preview location to 'stable'

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -211,7 +211,7 @@ suppress_warnings = ["myst.header", "etoc.toctree", "config.cache"]
 # OpenGraph configuration for link previews
 
 ogp_site_url = "https://napari.org/"
-ogp_image = "_static/opengraph_image.png" 
+ogp_image = "stable/_static/opengraph_image.png" 
 ogp_use_first_image = False
 ogp_description_length = 300
 ogp_type = "website"


### PR DESCRIPTION
# References and relevant issues
<!-- What relevant resources were used in the creation of this PR?
If this PR addresses an existing issue on the repo,
please link to that issue here as "Closes #(issue-number)".
If this PR adds docs for a napari PR please add a "Depends on <napari PR link>" -->

Closes #698 

# Description
<!-- What does this pull request (PR) do? Does it add new content, improve/fix existing
context, improve/fix workflow/documentation build/deployment or something else?
<!-- If relevant, please include a screenshot or a screen capture in your content
change: "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations. -->
<!-- You can also see a preview of the documentation changes you are submitting by
clicking on "Details" to the right of the "Check the rendered docs here!" check on your PR.-->

Currently, opengraph preview is broken as https://napari.org/_static/opengraph_image.png does not exist, but https://napari.org/stable/_static/opengraph_image.png does now after 0.6.0 release. I mixed up versioning. 
I thought it would base it off ogp_canonical_url, but I was wrong! It bases it off of ogp_site_url

Maybe this fixes all metadata? we can check previews now that the images actually live on the live website. 

<!-- Previewing the Documentation Build
When you submit this PR, jobs that preview the documentation will be kicked off.
By default, they will use the `slimfast` build (`make` target), which is fast, because
it doesn't build any content from outside the `docs` repository and doesn't run notebook cells.
You can trigger other builds by commenting on the PR with:

@napari-bot make <target>

where <target> can be:
html : a full build, just like the deployment to napari.org
html-noplot : a full build, but without the gallery examples from `napari/napari`
docs : only the content from `napari/docs`, with notebook code cells executed
slimfast : the default, only the content from `napari/docs`, without code cell execution
slimgallery : `slimfast`, but with the gallery examples from `napari/napari` built
-->

<!-- Final Checklist
- If images included: I have added [alt text](https://webaim.org/techniques/alttext/)
If workflow, documentation build or deployment change:
- My PR is the minimum possible work for the desired functionality
- I have commented my code, to let others know what it does
-->
