### PR TITLE
Update conf.py to try to fix opengraph image for dev and future deployments

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -211,7 +211,7 @@ suppress_warnings = ["myst.header", "etoc.toctree", "config.cache"]
 # OpenGraph configuration for link previews
 
 ogp_site_url = "https://napari.org/"
-ogp_image = "_static/opengraph_image.png" 
+ogp_image = "dev/_static/opengraph_image.png" 
 ogp_use_first_image = False
 ogp_description_length = 300
 ogp_type = "website"


### PR DESCRIPTION
# References and relevant issues
Part of: #698 

# Description
Based on my reasoning in the issue, I think this should fix things. We only deploy to /dev or a versioned folder.
So I think the image should be in /dev and then it should be available properly.

