### PR TITLE
Update viewer.md to mention that you can rename axes using the roll dims popup

### DIFF
--- a/docs/tutorials/fundamentals/viewer.md
+++ b/docs/tutorials/fundamentals/viewer.md
@@ -481,6 +481,13 @@ Locking prevents a dimension from being rolled (reordered). This can be particul
 useful, for example, with a `3D+time` dataset where you may want to fix the time dimension,
 while being able to roll through the spatial dimensions.
 
+```{tip}
+The roll dimensions pop up also lets you rename the dimension axes used by the viewer.
+Just double click on the text to the right of the padlock icon. For example, for a 3D volume, double-click
+the default axis name `0` and change it to `z`. The change will be reflected in the slider in 2D view
+and the axis label overlay.
+```
+
 The dimension order can also be checked programmatically as follows:
 
 ```{code-cell} python

--- a/docs/tutorials/fundamentals/viewer.md
+++ b/docs/tutorials/fundamentals/viewer.md
@@ -484,8 +484,8 @@ while being able to roll through the spatial dimensions.
 ```{tip}
 The roll dimensions pop up also lets you rename the dimension axes used by the viewer.
 Just double click on the text to the right of the padlock icon. For example, for a 3D volume, double-click
-the default axis name `0` and change it to `z`. The change will be reflected in the slider in 2D view
-and the axis label overlay.
+the default axis name `0` and change it to `Z`. The change will be reflected in the slider in 2D view
+and the `axes` overlay.
 ```
 
 The dimension order can also be checked programmatically as follows:


### PR DESCRIPTION
# References and relevant issues
First noted in: https://github.com/napari/napari/pull/7928#pullrequestreview-2845668364


# Description
Turns out the roll dims popup lets you rename the dims axes from the GUI! Who knew?!
In this PR I add that as a tip to the viewer tutorial.