### PR TITLE
Update installation.md to link to conda getting started not miniconda

### DIFF
--- a/docs/tutorials/fundamentals/installation.md
+++ b/docs/tutorials/fundamentals/installation.md
@@ -35,7 +35,7 @@ It requires:
 - the ability to install python packages via [pip](https://pypi.org/project/pip/) OR [conda-forge](https://conda-forge.org/docs/user/introduction.html)
 
 You may also want:
-- an environment manager like [conda](https://docs.conda.io/en/latest/miniconda.html) or
+- an environment manager like [conda](https://docs.conda.io/projects/conda/en/stable/user-guide/getting-started.html) or
 [venv](https://docs.python.org/3/library/venv.html) **(Highly recommended)**
 
 ```{note}


### PR DESCRIPTION
# References and relevant issues
The current `conda` link on the installation page links to miniconda docs, which go to anaconda.com
anaconda.com can be a blocked domain due to licensing issues

# Description
Instead of linking to the miniconda docs specifically, link to the conda "getting started guide"
https://docs.conda.io/projects/conda/en/stable/user-guide/getting-started.html
