### PR TITLE
Add active roadmap document

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -249,6 +249,7 @@ subtrees:
       - file: roadmaps/index
         subtrees:
         - entries:
+          - file: roadmaps/active_roadmap
           - file: roadmaps/0_4
           - file: roadmaps/0_3_retrospective
           - file: roadmaps/0_3

--- a/docs/roadmaps/active_roadmap.md
+++ b/docs/roadmaps/active_roadmap.md
@@ -1,52 +1,8 @@
 # **Napari Roadmap**
 
-## April 10, 2025
+## June 22, 2025
 
-[**Project vision and foundation	1**](#project-vision-and-foundation)
-
-[Vision	2](#vision)
-
-[Founding principles	2](#founding-principles)
-
-[Mission and purpose	2](#mission-and-purpose)
-
-[**Roadmap strategy	3**](#roadmap-strategy)
-
-[Approach and philosophy	3](#approach-and-philosophy)
-
-[Potential challenges	3](#potential-challenges)
-
-[Risk mitigation strategies	4](#risk-mitigation-strategies)
-
-[**Roadmap focus areas	4**](#roadmap-focus-areas)
-
-[Core technology	4](#core-technology)
-
-[User experience	5](#user-experience)
-
-[Project sustainability and community	5](#project-sustainability-and-community)
-
-[**Strategic deliverables	5**](#strategic-deliverables)
-
-[Core technology	5](#core-technology-1)
-
-[API evolution	6](#api-evolution)
-
-[Core library	6](#core-library)
-
-[Performance	7](#performance)
-
-[User experience	7](#user-experience-1)
-
-[Project sustainability and community	8](#project-sustainability-and-community-1)
-
-[**Timeline	8**](#timeline)
-
-[2025	8](#2025)
-
-[2026 milestones and beyond	9](#2026-milestones-and-beyond)
-
-# **Project vision and foundation** {#project-vision-and-foundation}
+# **Project vision and foundation**
 
 [napari](https://napari.org/) is a fast, interactive, multi-dimensional image viewer for Python. It's designed for browsing, annotating, analyzing, and processing large multi-dimensional images.
 
@@ -70,7 +26,7 @@ The napari team came together around a shared vision for a Python-based image vi
 
 * provides native 2D and 3D views.
 
-## Mission and purpose {#mission-and-purpose}
+## Mission and purpose
 
 napari aims to be the multi-dimensional image viewer for Python and to provide GUI access to a plugin ecosystem of image analysis tools for scientists to use in their daily work. We hope to accomplish this by:
 
@@ -88,9 +44,9 @@ napari aims to be the multi-dimensional image viewer for Python and to provide G
 
 Our documentation provides more information about [napari's mission and values](https://napari.org/stable/community/mission_and_values.html).
 
-# **Roadmap strategy** {#roadmap-strategy}
+# **Roadmap strategy**
 
-## Approach and philosophy {#approach-and-philosophy}
+## Approach and philosophy
 
 **This roadmap is a living document** that the team adapts as needed to meet changing priorities, technology shifts, and scientific opportunities. napari's roadmap focuses on expanded core functionality, performance improvements, new features, and compatibility with other scientific tools. 
 
@@ -100,7 +56,7 @@ This roadmap **is not a detailed project plan** with milestones and assignments.
 
 We welcome **input from the community** about needs and priorities. This document will be publicly posted and be easily discoverable from the napari website.
 
-## Potential challenges {#potential-challenges}
+## Potential challenges
 
 Common risks associated with roadmaps are:
 
@@ -112,7 +68,7 @@ Common risks associated with roadmaps are:
 
 * **Estimation Difficulties:** Accurately estimating project timelines and resource requirements is challenging.
 
-## Risk mitigation strategies {#risk-mitigation-strategies}
+## Risk mitigation strategies
 
 These practices reduce risk and increase the likelihood of completing strategic deliverables:
 
@@ -126,9 +82,9 @@ These practices reduce risk and increase the likelihood of completing strategic 
 
 * **Visible Refactoring Plan:** Establish a clear plan for refactoring efforts and track progress beyond individual issues and pull requests.
 
-# **Roadmap focus areas** {#roadmap-focus-areas}
+# **Roadmap focus areas**
 
-## Core technology {#core-technology}
+## Core technology
 
 * **API (Code interface):** The interface to the external scientific Python world, enabling extensibility, customization, and integration into pipelines and workflows.
 
@@ -138,13 +94,13 @@ These practices reduce risk and increase the likelihood of completing strategic 
 
 * **Evolution:** Ongoing development and improvement of the core components.
 
-## User experience {#user-experience}
+## User experience
 
 * **User Interfaces and Interaction Modes:** The bundled application (using Qt), new applications (NapariLite, browser, WebAssembly), notebook, and programmatic use cases.
 
 * **Plugin Ecosystem:** The engine for extensibility, input/output plugins, domain-specific functionality, and discoverability of plugins.
 
-## Project sustainability and community {#project-sustainability-and-community}
+## Project sustainability and community
 
 * **Bug Fixes:** Addressing reported issues and ensuring software stability.
 
@@ -154,11 +110,11 @@ These practices reduce risk and increase the likelihood of completing strategic 
 
 * **Community Engagement:** Fostering communication, outreach, and collaboration through conferences and core team meetings.
 
-# **Strategic deliverables** {#strategic-deliverables}
+# **Strategic deliverables**
 
 This section provides a roadmap of strategic deliverables for these three project focus areas: Core, UX, and Project Health. These items are not ordered by priority.
 
-## Core technology {#core-technology-1}
+## Core technology
 
 Since its first commit in 2018, napari has grown organically as functionality was added and improved by a growing community of scientists. Now over 175 contributors have added to the napari code base. However, during this growth, we have accumulated significant technical debt, both in internal architecture and in API inconsistencies.
 
@@ -166,7 +122,7 @@ Since 2020, CZI has helped napari by conducting user surveys. Although responden
 
 This roadmap outlines our plans to simplify the napari code base to allow greater flexibility, improve the API's consistency and ease of use, and improve rendering performance.
 
-### API evolution  {#api-evolution}
+### API evolution
 
 ***The napari core public API should enable support of new visualization libraries and enable research teams to develop domain-specific front-end user interfaces.***
 
@@ -176,7 +132,7 @@ This roadmap outlines our plans to simplify the napari code base to allow greate
 
 * Identify where **decoupling of existing code from Vispy and Qt** is needed to support the core API
 
-### Core library {#core-library}
+### Core library
 
 **The napari core library aims to be a foundation for cutting-edge visualization for research.**
 
@@ -206,7 +162,7 @@ This roadmap outlines our plans to simplify the napari code base to allow greate
 
 *Benefits: Web browser application support, composable user interfaces, efficient data pipeline, experimentation tools, and scripting for automated workflows.*
 
-### Performance {#performance}
+### Performance
 
 ***As data size and volume increase, napari must remain blazing fast.***
 
@@ -226,7 +182,7 @@ This roadmap outlines our plans to simplify the napari code base to allow greate
 
 * Improve performance when **slicing layers**. [\#4795](https://github.com/napari/napari/issues/4795), [\#5957](https://github.com/napari/napari/issues/5957)
 
-## User experience {#user-experience-1}
+## User experience
 
 * Improve application **GUI**.
 
@@ -250,7 +206,7 @@ This roadmap outlines our plans to simplify the napari code base to allow greate
 
 * Create a **highly performant, minimal functionality viewer** (**napari-lite, ndv,** or similar) [\#5940](https://github.com/napari/napari/issues/5940)
 
-## Project sustainability and community {#project-sustainability-and-community-1}
+## Project sustainability and community
 
 This section lists high-priority items for documentation, issue/pr management, community engagement, project health, and day-to-day sustaining work:
 
@@ -282,11 +238,11 @@ This section lists high-priority items for documentation, issue/pr management, c
 
   * Build a suite of high quality reusable workshop and tutorial materials
 
-# **Timeline** {#timeline}
+# **Timeline**
 
 The timeline includes ideas that we have firm commitments to deliver. Over time, this section will cover priorities for the current year, the following year, and the next three to five years.
 
-## 2025 {#2025}
+## 2025
 
 The following items are active priorities for the project:
 
@@ -305,6 +261,6 @@ Our next priorities are:
 * Performance under core library   
 * Additional performance optimization and memory management.
 
-## 2026 milestones and beyond {#2026-milestones-and-beyond}
+## 2026 milestones and beyond
 
 This section will list commitments for 2026 and beyond. 

--- a/docs/roadmaps/active_roadmap.md
+++ b/docs/roadmaps/active_roadmap.md
@@ -1,0 +1,310 @@
+# **Napari Roadmap**
+
+## April 10, 2025
+
+[**Project vision and foundation	1**](#project-vision-and-foundation)
+
+[Vision	2](#vision)
+
+[Founding principles	2](#founding-principles)
+
+[Mission and purpose	2](#mission-and-purpose)
+
+[**Roadmap strategy	3**](#roadmap-strategy)
+
+[Approach and philosophy	3](#approach-and-philosophy)
+
+[Potential challenges	3](#potential-challenges)
+
+[Risk mitigation strategies	4](#risk-mitigation-strategies)
+
+[**Roadmap focus areas	4**](#roadmap-focus-areas)
+
+[Core technology	4](#core-technology)
+
+[User experience	5](#user-experience)
+
+[Project sustainability and community	5](#project-sustainability-and-community)
+
+[**Strategic deliverables	5**](#strategic-deliverables)
+
+[Core technology	5](#core-technology-1)
+
+[API evolution	6](#api-evolution)
+
+[Core library	6](#core-library)
+
+[Performance	7](#performance)
+
+[User experience	7](#user-experience-1)
+
+[Project sustainability and community	8](#project-sustainability-and-community-1)
+
+[**Timeline	8**](#timeline)
+
+[2025	8](#2025)
+
+[2026 milestones and beyond	9](#2026-milestones-and-beyond)
+
+# **Project vision and foundation** {#project-vision-and-foundation}
+
+[napari](https://napari.org/) is a fast, interactive, multi-dimensional image viewer for Python. It's designed for browsing, annotating, analyzing, and processing large multi-dimensional images.
+
+napari has been adopted globally and across scientific disciplines. More information on downloads and project metrics can be found on [our dashboard](https://napari.org/weather-report).
+
+## Vision {#vision}
+
+napari's vision is to make exploration, annotation, and analysis of multidimensional data seamless for both Python experts and non-Python users alike.
+
+## Founding principles {#founding-principles}
+
+The napari team came together around a shared vision for a Python-based image viewer that:
+
+* is n-dimensional first,
+
+* native (no browser required),
+
+* blazing fast (GPU-powered),
+
+* layered, allowing easy visualisation of data in a common space, and
+
+* provides native 2D and 3D views.
+
+## Mission and purpose {#mission-and-purpose}
+
+napari aims to be the multi-dimensional image viewer for Python and to provide GUI access to a plugin ecosystem of image analysis tools for scientists to use in their daily work. We hope to accomplish this by:
+
+* being easy to use and install. We are careful in taking on new dependencies, sometimes making them optional, and will support a fully packaged installation that works cross-platform.
+
+* being well-documented with comprehensive tutorials and examples. All functions in our API have thorough docstrings clarifying expected inputs and outputs, and we maintain [tutorials and examples on our website](https://napari.org/) to explain different use cases and working modes.
+
+* providing GUI access to all critical functionality so napari can be used by people with no coding experience.
+
+* being interactive and highly performant in order to support very large data sets.
+
+* providing a consistent and stable API to enable plugin developers to build on top of napari without their code constantly breaking and to enable advanced users to build out sophisticated Python workflows.
+
+* ensuring scientific accuracy. We prioritise bug fixes and feature development that affect the scientific interpretation of the displayed data. For example, a bug in which point coordinates are offset by one pixel from the overlaid image coordinates is higher priority than one in which a UI button doesn’t work.
+
+Our documentation provides more information about [napari's mission and values](https://napari.org/stable/community/mission_and_values.html).
+
+# **Roadmap strategy** {#roadmap-strategy}
+
+## Approach and philosophy {#approach-and-philosophy}
+
+**This roadmap is a living document** that the team adapts as needed to meet changing priorities, technology shifts, and scientific opportunities. napari's roadmap focuses on expanded core functionality, performance improvements, new features, and compatibility with other scientific tools. 
+
+This roadmap **is a high-level view of the project's priorities**. It offers a compass for the core team, contributors, users, and funders to guide us as the project evolves. This roadmap is a relatively "jargon-free" view of essential efforts planned for napari's future. The roadmap should contain strategic deliverables to carry out the project's mission. 
+
+This roadmap **is not a detailed project plan** with milestones and assignments. Project plans will be captured in GitHub issues and projects, and the work will be discussed in the project's workgroup meetings. Focusing on strategic deliverables makes the roadmap easier to understand and prioritize than a collection of issues in a project table.
+
+We welcome **input from the community** about needs and priorities. This document will be publicly posted and be easily discoverable from the napari website.
+
+## Potential challenges {#potential-challenges}
+
+Common risks associated with roadmaps are:
+
+* **Scope Creep:** The influx of issues and pull requests can lead to scope creep, diverting focus from the core objectives.
+
+* **Lack of Clarity:** Ambiguous communication between the team and contributors can hinder progress and lead to misunderstandings.
+
+* **"How" Before "Why":** Prioritizing implementation details ("how") over the underlying rationale ("why") can cause misaligned efforts.
+
+* **Estimation Difficulties:** Accurately estimating project timelines and resource requirements is challenging.
+
+## Risk mitigation strategies {#risk-mitigation-strategies}
+
+These practices reduce risk and increase the likelihood of completing strategic deliverables:
+
+* **Transparent Roadmap:** Maintain a clear and easily discoverable roadmap to guide development and manage expectations.
+
+* **Regular Reviews:** Conduct quarterly reviews and updates to ensure the roadmap remains relevant and aligned with current priorities.
+
+* **Annual Deep Dives:** Perform a yearly in-depth analysis of each focus area to assess progress and identify areas for improvement.
+
+* **Iterative Development:** Embrace an iterative approach to development, incorporating lessons learned into future iterations.
+
+* **Visible Refactoring Plan:** Establish a clear plan for refactoring efforts and track progress beyond individual issues and pull requests.
+
+# **Roadmap focus areas** {#roadmap-focus-areas}
+
+## Core technology {#core-technology}
+
+* **API (Code interface):** The interface to the external scientific Python world, enabling extensibility, customization, and integration into pipelines and workflows.
+
+* **Library (Implementation):** The API implementation; new useful features across all interaction modes.
+
+* **Performance:** Optimization efforts to enhance speed and efficiency.
+
+* **Evolution:** Ongoing development and improvement of the core components.
+
+## User experience {#user-experience}
+
+* **User Interfaces and Interaction Modes:** The bundled application (using Qt), new applications (NapariLite, browser, WebAssembly), notebook, and programmatic use cases.
+
+* **Plugin Ecosystem:** The engine for extensibility, input/output plugins, domain-specific functionality, and discoverability of plugins.
+
+## Project sustainability and community {#project-sustainability-and-community}
+
+* **Bug Fixes:** Addressing reported issues and ensuring software stability.
+
+* **Documentation:** Maintaining comprehensive and up-to-date documentation.
+
+* **Website:** Providing a central hub for information and resources.
+
+* **Community Engagement:** Fostering communication, outreach, and collaboration through conferences and core team meetings.
+
+# **Strategic deliverables** {#strategic-deliverables}
+
+This section provides a roadmap of strategic deliverables for these three project focus areas: Core, UX, and Project Health. These items are not ordered by priority.
+
+## Core technology {#core-technology-1}
+
+Since its first commit in 2018, napari has grown organically as functionality was added and improved by a growing community of scientists. Now over 175 contributors have added to the napari code base. However, during this growth, we have accumulated significant technical debt, both in internal architecture and in API inconsistencies.
+
+Since 2020, CZI has helped napari by conducting user surveys. Although respondents consistently find our community welcoming (\~90% in 2022, \~80% in 2023), less than 30% found it easy to contribute to napari in 2023 — down from just over 50% in 2022\. This demonstrates the need to decrease the complexity of the napari codebase to help practicing scientists improve napari for their needs — a common pattern for napari development in prior years.
+
+This roadmap outlines our plans to simplify the napari code base to allow greater flexibility, improve the API's consistency and ease of use, and improve rendering performance.
+
+### API evolution  {#api-evolution}
+
+***The napari core public API should enable support of new visualization libraries and enable research teams to develop domain-specific front-end user interfaces.***
+
+*Benefits: Timely support of new frontend frameworks and web assembly in the browser, unlock integration into existing research tools, and provide support for new visualization engines.* 
+
+* Create a new **napari core API specification** version to support **declarative visualization**, **viewer serialization**, and **front-end agnostic user interfaces**.
+
+* Identify where **decoupling of existing code from Vispy and Qt** is needed to support the core API
+
+### Core library {#core-library}
+
+**The napari core library aims to be a foundation for cutting-edge visualization for research.**
+
+**Architecture improvements**
+
+* Adopt the psygnal **event signaling library** throughout to enable different user interfaces to work performantly with the napari core library.
+
+* Add **viewer serialization**. The entire viewer state should be saveable and recoverable. We should provide support for deep links to data \+ views.
+
+* **Decouple rendering state** from layer model.
+
+* **Decouple library from application design** by using app-model. [\#7059](https://github.com/napari/napari/issues/7059)
+
+**User-facing improvements**
+
+* Establish a consistent physical model of **data and scene spaces** [\#5949](https://github.com/napari/napari/issues/5949)
+
+* Develop core library to enable a UI-agnostic **multi-canvas viewer,** enabling orthogonal slices, multichannel viewing, and even VR [\#5348](https://github.com/napari/napari/issues/5348)
+
+* Implement highly-requested functionality that improves **visualizations and overlays** [\#7587](https://github.com/napari/napari/issues/7587) [\#5957](https://github.com/napari/napari/issues/5957)
+
+* Improve **file opening and saving** to better support complex scientific data formats
+
+* Refactor the layer models to consistently support **tabular data visualization across layers**. [\#2866](https://github.com/napari/napari/issues/2866)
+
+* Implement core functionality needed to enable **grouping of layers**. [\#5950](https://github.com/napari/napari/issues/5950)
+
+*Benefits: Web browser application support, composable user interfaces, efficient data pipeline, experimentation tools, and scripting for automated workflows.*
+
+### Performance {#performance}
+
+***As data size and volume increase, napari must remain blazing fast.***
+
+*Benefits: Providing separation of computation from the user interfaces will keep the core library speedy. Focusing on in-memory optimizations and profiling core library modules will deliver benefits to both code-centric workflows and GUI workflows.*
+
+* Improve **3D rendering of larger-than-memory data** for all layer types. [\#5942](https://github.com/napari/napari/issues/5942)
+
+* Improve performance in **viewing and annotating** **multiscale 2D data**. [\#3630](https://github.com/napari/napari/issues/3630)
+
+  * Large in-memory 2D viewing performance
+
+  * Larger than memory 2D data
+
+  * Larger than memory 2D annotation e.g. in Shapes layer
+
+* **Speed up rendering performance for in-memory data**, even small data. Prioritize fast visualization interactivity over letting async and lazy loading do all the work. [\#5941](https://github.com/napari/napari/issues/5941), [\#5943](https://github.com/napari/napari/issues/5943), [\#5956](https://github.com/napari/napari/issues/5956), [\#6046](https://github.com/napari/napari/issues/6046)
+
+* Improve performance when **slicing layers**. [\#4795](https://github.com/napari/napari/issues/4795), [\#5957](https://github.com/napari/napari/issues/5957)
+
+## User experience {#user-experience-1}
+
+* Improve application **GUI**.
+
+  * Add and improve tools for 3D annotation (core library and application work). [\#5955](https://github.com/napari/napari/issues/5955)
+
+  * Add parity support for all API functions in GUI. [\#5959](https://github.com/napari/napari/issues/5959)
+
+  * Add rich import/export dialog to simplify user workflows.
+
+  * Improve display of task execution and progress information.
+
+  * Improve export of GUI and console sessions.
+
+* Implement **"napari headless is Just Python"** vision so napari can run anywhere that Python can. [\#5958](https://github.com/napari/napari/issues/5958)
+
+* Implement a **new version of the plugin manifest** that addresses current pain points, deduplicates parts of the specification, and includes richer contribution types [\#6227](https://github.com/napari/napari/issues/6227)
+
+* Add support for **composable plugin workflows**. Enable data, including layers and non-layers, to be streamed from one plugin to another. [\#5965](https://github.com/napari/napari/issues/5965)
+
+* Create a **simplified plugin discovery site** to replace the napari hub.
+
+* Create a **highly performant, minimal functionality viewer** (**napari-lite, ndv,** or similar) [\#5940](https://github.com/napari/napari/issues/5940)
+
+## Project sustainability and community {#project-sustainability-and-community-1}
+
+This section lists high-priority items for documentation, issue/pr management, community engagement, project health, and day-to-day sustaining work:
+
+* Create an **ImageJ/Fiji migration guide** for napari. [\#134](https://github.com/napari/docs/issues/134)
+
+* Increase **documentation coverage of all  GUI and API** **features**. [\#180](https://github.com/napari/docs/issues/180)
+
+  * Improve discoverability of all feature documentation
+
+* **Auto-generate images and videos** in our documentation to streamline contribution process and ensure up-to-date visualizations [\#289](https://github.com/napari/docs/issues/289)
+
+* Curate a **plugin reference** to aid discoverability  long-term maintenance of useful plugins
+
+  * Maintain a list off high-quality, well-maintained plugins useful for scientific research.
+
+  * Implement and surface workflows to assist plugin developers in maintaining plugins
+
+* Update **PR workflows** to emphasize smaller PRs and iterative best practices.
+
+* Increase community engagement by focusing more attention on **domain-specific use cases** (a natural progression from the examples we already have for features)
+
+* Manage **issues and PR triage**. Archive all the unactionable problems and PRs.
+
+* Burn down the **high-priority bugs** list. [\#5973](https://github.com/napari/napari/issues/5973)
+
+* Improve **test coverage** for napari bundled application. [\#5951](https://github.com/napari/napari/issues/5951)
+
+* Host **workshops and tutorials** at a regular cadence
+
+  * Build a suite of high quality reusable workshop and tutorial materials
+
+# **Timeline** {#timeline}
+
+The timeline includes ideas that we have firm commitments to deliver. Over time, this section will cover priorities for the current year, the following year, and the next three to five years.
+
+## 2025 {#2025}
+
+The following items are active priorities for the project:
+
+* Shape triangulation performance  
+* Hub-lite: a community built and managed alternative to the napari hub  
+* Modular canvas (API foundational work)  
+* Decoupling library from application design  
+* Sustaining the project
+
+Our next priorities are:
+
+* Multi-canvas (foundational work)  
+* Improvements to the plugin manifest (technical design)  
+* Core functionality for grouping of layers  
+* Instanced rendering performance  
+* Performance under core library   
+* Additional performance optimization and memory management.
+
+## 2026 milestones and beyond {#2026-milestones-and-beyond}
+
+This section will list commitments for 2026 and beyond. 

--- a/docs/roadmaps/active_roadmap.md
+++ b/docs/roadmaps/active_roadmap.md
@@ -1,18 +1,18 @@
-# **Napari Roadmap**
+# Napari Roadmap
 
-## June 22, 2025
+Updated: **June 22, 2025**
 
-# **Project vision and foundation**
+## Project vision and foundation
 
 [napari](https://napari.org/) is a fast, interactive, multi-dimensional image viewer for Python. It's designed for browsing, annotating, analyzing, and processing large multi-dimensional images.
 
 napari has been adopted globally and across scientific disciplines. More information on downloads and project metrics can be found on [our dashboard](https://napari.org/weather-report).
 
-## Vision {#vision}
+### Vision
 
 napari's vision is to make exploration, annotation, and analysis of multidimensional data seamless for both Python experts and non-Python users alike.
 
-## Founding principles {#founding-principles}
+### Founding principles
 
 The napari team came together around a shared vision for a Python-based image viewer that:
 
@@ -26,7 +26,7 @@ The napari team came together around a shared vision for a Python-based image vi
 
 * provides native 2D and 3D views.
 
-## Mission and purpose
+### Mission and purpose
 
 napari aims to be the multi-dimensional image viewer for Python and to provide GUI access to a plugin ecosystem of image analysis tools for scientists to use in their daily work. We hope to accomplish this by:
 
@@ -44,9 +44,9 @@ napari aims to be the multi-dimensional image viewer for Python and to provide G
 
 Our documentation provides more information about [napari's mission and values](https://napari.org/stable/community/mission_and_values.html).
 
-# **Roadmap strategy**
+## Roadmap strategy
 
-## Approach and philosophy
+### Approach and philosophy
 
 **This roadmap is a living document** that the team adapts as needed to meet changing priorities, technology shifts, and scientific opportunities. napari's roadmap focuses on expanded core functionality, performance improvements, new features, and compatibility with other scientific tools. 
 
@@ -56,7 +56,7 @@ This roadmap **is not a detailed project plan** with milestones and assignments.
 
 We welcome **input from the community** about needs and priorities. This document will be publicly posted and be easily discoverable from the napari website.
 
-## Potential challenges
+### Potential challenges
 
 Common risks associated with roadmaps are:
 
@@ -68,7 +68,7 @@ Common risks associated with roadmaps are:
 
 * **Estimation Difficulties:** Accurately estimating project timelines and resource requirements is challenging.
 
-## Risk mitigation strategies
+### Risk mitigation strategies
 
 These practices reduce risk and increase the likelihood of completing strategic deliverables:
 
@@ -82,9 +82,9 @@ These practices reduce risk and increase the likelihood of completing strategic 
 
 * **Visible Refactoring Plan:** Establish a clear plan for refactoring efforts and track progress beyond individual issues and pull requests.
 
-# **Roadmap focus areas**
+## Roadmap focus areas
 
-## Core technology
+### Core technology
 
 * **API (Code interface):** The interface to the external scientific Python world, enabling extensibility, customization, and integration into pipelines and workflows.
 
@@ -94,13 +94,13 @@ These practices reduce risk and increase the likelihood of completing strategic 
 
 * **Evolution:** Ongoing development and improvement of the core components.
 
-## User experience
+### User experience
 
 * **User Interfaces and Interaction Modes:** The bundled application (using Qt), new applications (NapariLite, browser, WebAssembly), notebook, and programmatic use cases.
 
 * **Plugin Ecosystem:** The engine for extensibility, input/output plugins, domain-specific functionality, and discoverability of plugins.
 
-## Project sustainability and community
+### Project sustainability and community
 
 * **Bug Fixes:** Addressing reported issues and ensuring software stability.
 
@@ -110,11 +110,11 @@ These practices reduce risk and increase the likelihood of completing strategic 
 
 * **Community Engagement:** Fostering communication, outreach, and collaboration through conferences and core team meetings.
 
-# **Strategic deliverables**
+## Strategic deliverables
 
 This section provides a roadmap of strategic deliverables for these three project focus areas: Core, UX, and Project Health. These items are not ordered by priority.
 
-## Core technology
+### Core technology
 
 Since its first commit in 2018, napari has grown organically as functionality was added and improved by a growing community of scientists. Now over 175 contributors have added to the napari code base. However, during this growth, we have accumulated significant technical debt, both in internal architecture and in API inconsistencies.
 
@@ -122,7 +122,7 @@ Since 2020, CZI has helped napari by conducting user surveys. Although responden
 
 This roadmap outlines our plans to simplify the napari code base to allow greater flexibility, improve the API's consistency and ease of use, and improve rendering performance.
 
-### API evolution
+#### API evolution
 
 ***The napari core public API should enable support of new visualization libraries and enable research teams to develop domain-specific front-end user interfaces.***
 
@@ -132,7 +132,7 @@ This roadmap outlines our plans to simplify the napari code base to allow greate
 
 * Identify where **decoupling of existing code from Vispy and Qt** is needed to support the core API
 
-### Core library
+#### Core library
 
 **The napari core library aims to be a foundation for cutting-edge visualization for research.**
 
@@ -162,7 +162,7 @@ This roadmap outlines our plans to simplify the napari code base to allow greate
 
 *Benefits: Web browser application support, composable user interfaces, efficient data pipeline, experimentation tools, and scripting for automated workflows.*
 
-### Performance
+#### Performance
 
 ***As data size and volume increase, napari must remain blazing fast.***
 
@@ -182,7 +182,7 @@ This roadmap outlines our plans to simplify the napari code base to allow greate
 
 * Improve performance when **slicing layers**. [\#4795](https://github.com/napari/napari/issues/4795), [\#5957](https://github.com/napari/napari/issues/5957)
 
-## User experience
+### User experience
 
 * Improve application **GUI**.
 
@@ -206,7 +206,7 @@ This roadmap outlines our plans to simplify the napari code base to allow greate
 
 * Create a **highly performant, minimal functionality viewer** (**napari-lite, ndv,** or similar) [\#5940](https://github.com/napari/napari/issues/5940)
 
-## Project sustainability and community
+### Project sustainability and community
 
 This section lists high-priority items for documentation, issue/pr management, community engagement, project health, and day-to-day sustaining work:
 
@@ -238,11 +238,11 @@ This section lists high-priority items for documentation, issue/pr management, c
 
   * Build a suite of high quality reusable workshop and tutorial materials
 
-# **Timeline**
+## Timeline
 
 The timeline includes ideas that we have firm commitments to deliver. Over time, this section will cover priorities for the current year, the following year, and the next three to five years.
 
-## 2025
+### 2025
 
 The following items are active priorities for the project:
 
@@ -261,6 +261,6 @@ Our next priorities are:
 * Performance under core library   
 * Additional performance optimization and memory management.
 
-## 2026 milestones and beyond
+### 2026 milestones and beyond
 
 This section will list commitments for 2026 and beyond. 

--- a/docs/roadmaps/index.md
+++ b/docs/roadmaps/index.md
@@ -5,9 +5,6 @@
 The [**napari global roadmap**](active_roadmap.md) is a living document, and we revisit it every three months. It contains a summary of our vision, our mission and values, and our key focus areas
 for the project. It also details strategic deliverables and key priorities for each focus area within a horizon of 3-5 years.
 
-As a companion to the roadmap, we manage a [Github Project board](https://github.com/orgs/napari/projects/24/views/2?pane=info) that contains more technical details, issues and Pull-Requests
-for tracking progress towards the roadmap deliverables.
-
 ## For contributors
 
 If a particular roadmap item is important to you and you want to help make it happen sooner, please [chat with us](https://napari.zulipchat.com/)! You can help by [contributing code or documentation](https://napari.org/dev/developers/index.html)

--- a/docs/roadmaps/index.md
+++ b/docs/roadmaps/index.md
@@ -2,7 +2,11 @@
 
 # Roadmaps
 
-The [**napari global roadmap**](https://github.com/orgs/napari/projects/24/views/2?pane=info) is hosted on a Github Project board. This roadmap captures the current priorities of the napari core developer team. It is revisited every six months.
+The [**napari global roadmap**](active_roadmap.md) is a living document, and we revisit it every three months. It contains a summary of our vision, our mission and values, and our key focus areas
+for the project. It also details strategic deliverables and key priorities for each focus area within a horizon of 3-5 years.
+
+As a companion to the roadmap, we manage a [Github Project board](https://github.com/orgs/napari/projects/24/views/2?pane=info) that contains more technical details, issues and Pull-Requests
+for tracking progress towards the roadmap deliverables.
 
 ## For contributors
 


### PR DESCRIPTION
# References and relevant issues
<!-- What relevant resources were used in the creation of this PR?
If this PR addresses an existing issue on the repo,
please link to that issue here as "Closes #(issue-number)".
If this PR adds docs for a napari PR please add a "Depends on <napari PR link>" -->

# Description
This PR adds our active roadmap to the website under the `Roadmaps` section and links to it from the `Roadmaps` index page.

<!-- Previewing the Documentation Build
When you submit this PR, jobs that preview the documentation will be kicked off.
By default, they will use the `slimfast` build (`make` target), which is fast, because
it doesn't build any content from outside the `docs` repository and doesn't run notebook cells.
You can trigger other builds by commenting on the PR with:

@napari-bot make <target>

where <target> can be:
html : a full build, just like the deployment to napari.org
html-noplot : a full build, but without the gallery examples from `napari/napari`
docs : only the content from `napari/docs`, with notebook code cells executed
slimfast : the default, only the content from `napari/docs`, without code cell execution
slimgallery : `slimfast`, but with the gallery examples from `napari/napari` built
-->

<!-- Final Checklist
- If images included: I have added [alt text](https://webaim.org/techniques/alttext/)
If workflow, documentation build or deployment change:
- My PR is the minimum possible work for the desired functionality
- I have commented my code, to let others know what it does
-->
