### PR TITLE
Test passing PR number instead of ref on triggered build

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -18,8 +18,8 @@ on:
         description: "Enter make target: html html-noplot docs slimfast slimgallery"
         type: string
         default: "slimfast"
-      pr_ref:
-        description: "PR branch reference"
+      pr_number:
+        description: "PR number"
         type: string
         required: false
 
@@ -37,7 +37,8 @@ jobs:
         with:
           # Check out to  '/home/runner/work/docs/docs/docs'
           path: docs
-          ref: ${{ inputs.pr_ref || github.ref }}
+          ref: ${{ inputs.pr_number && format('refs/pull/{0}/merge', inputs.pr_number) || github.ref }}
+
 
       - name: Clone main repo
         uses: actions/checkout@v4

--- a/.github/workflows/triggered_target_build.yml
+++ b/.github/workflows/triggered_target_build.yml
@@ -29,6 +29,7 @@ jobs:
       target: ${{ steps.determine-make-target.outputs.target }}
       pr_ref: ${{ steps.get-pr-info.outputs.pr_ref }}
       pr_sha: ${{ steps.get-pr-info.outputs.pr_sha }}
+      pr_number: ${{ steps.get-pr-info.outputs.pr_number }}
     if: |
       (github.event_name == 'issue_comment' &&
         github.event.issue.pull_request != '' &&
@@ -83,6 +84,7 @@ jobs:
             });
             core.setOutput('pr_ref', pr.data.head.ref);
             core.setOutput('pr_sha', pr.data.head.sha);
+            core.setOutput('pr_number', context.issue.number);
 
   trigger-circleci:
     needs: determine-make-target
@@ -101,7 +103,7 @@ jobs:
     uses: ./.github/workflows/build_docs.yml
     with:
       make_target: ${{ needs.determine-make-target.outputs.target }}
-      pr_ref: ${{ needs.determine-make-target.outputs.pr_ref || github.ref_name }}
+      pr_number: ${{ needs.determine-make-target.outputs.pr_number }}
 
   report-artifact-status:
     # reusable workflows can't be a step in a job


### PR DESCRIPTION
# References and relevant issues
See https://github.com/napari/docs/pull/736#issuecomment-2989423609

# Description
Testing a hunch that @actions/checkout can't find the ref because it's looking for it in _this_ repo, but it belongs to the fork the PR is coming from.