### PR TITLE
[maint] fix circleCI branch naming in trigger action

### DIFF
--- a/.github/workflows/triggered_target_build.yml
+++ b/.github/workflows/triggered_target_build.yml
@@ -94,7 +94,7 @@ jobs:
         uses: CircleCI-Public/trigger-circleci-pipeline-action@v1.2.0
         with:
           GHA_Meta: ${{ needs.determine-make-target.outputs.target }}
-          target-branch: ${{ needs.determine-make-target.outputs.pr_ref || github.ref_name }}
+          target-branch: ${{ github.event_name == 'issue_comment' && format('pull/{0}/head', github.event.issue.number) || github.ref_name }}
         env:
           CCI_TOKEN: ${{ secrets.CIRCLECI_TOKEN }}
 


### PR DESCRIPTION
# References and relevant issues
CircleCI trigger is still failing: https://github.com/napari/docs/actions/runs/15769048532

# Description
CircleCI docs for PRs from forks:
https://support.circleci.com/hc/en-us/articles/360049841151-Trigger-Pipelines-on-Forked-Pull-Requests-with-CircleCI-API-v2
the branch name should be of format:
`"pull/${PR_BRANCH_NUM}/head"`
