### PR TITLE
Add draft of 0.6.2 release notes

### DIFF
--- a/docs/release/release_0_6_2.md
+++ b/docs/release/release_0_6_2.md
@@ -1,49 +1,48 @@
 # napari 0.6.2
 ⚠️ *Note: these release notes are still in draft while 0.6.2 is in release candidate testing.* ⚠️
 
-*Mon, Jun 23, 2025*
+*Wed, Jun 26, 2025*
 
+We’re happy to announce the release of napari 0.6.2!
 
-We're happy to announce the release of napari 0.6.2!
-napari is a fast, interactive, multi-dimensional image viewer for Python.
-It's designed for browsing, annotating, and analyzing large multi-dimensional
-images. It's built on top of Qt (for the GUI), vispy (for performant GPU-based
-rendering), and the scientific Python stack (numpy, scipy).
+napari is a fast, interactive, multi-dimensional image viewer for Python. It’s designed for exploring, annotating, and analyzing multi-dimensional images. It’s built on Qt (for the GUI), VisPy (for performant GPU-based rendering), and the scientific Python stack (NumPy, SciPy, and friends).
 
-For more information, examples, and documentation, please visit our website,
-https://napari.org.
+For more information, examples, and documentation, please visit our website: https://napari.org/
 
 ## Highlights
 
-- Qt controls for thick slicing ([#6146](https://github.com/napari/napari/pull/6146))
-- Add grid overlay ([#7827](https://github.com/napari/napari/pull/7827))
-- Grid mode using vispy ViewBox and linked cameras ([#7870](https://github.com/napari/napari/pull/7870))
-- Features table widget as builtin ([#7877](https://github.com/napari/napari/pull/7877))
-- Move napari into `src` layout ([#7952](https://github.com/napari/napari/pull/7952))
-- Add public API to get access to docked widgets ([#7965](https://github.com/napari/napari/pull/7965))
+### The amazing new Grid mode! 🗺️
+
+The visualization of Grid mode has been redone from the ground up! This new Grid mode [(#7870)](https://github.com/napari/napari/pull/7870) now puts each layer into its own view (a VisPy Viewbox) with cameras linked together. Now, you can pan and zoom one view, and all other views in the grid will follow along. No longer are layers awkwardly transformed into the same world space and displayed in a grid, only to make comparing the details of each a challenge. Grid based exploration is now fluid, fast, and intuitive, especially when working with large images and 3D+ data! The mouse can even be used over one View, while updating the data, such as a label or shape annotation, in the selected layer of a different view. The usual napari overlays can now also be added to each grid, instead of just the canvas (i.e. `viewer.scale_bar.gridded = True`).
+
+### The Features Table Widget is now a napari builtin! 📊
+
+The features table from [napari-properties-viewer](https://github.com/kevinyamauchi/napari-properties-viewer) is now a builtin widget in napari [(#7877)](https://github.com/napari/napari/pull/7877) *and* greatly improved! This widget allows you to view (and even edit) the properties of Points, Shapes, and Labels layers in a table widget. The widget can be opened from the `Layers` menu -> `Visualize` -> `Features table widget (napari builtins)` or from the command palette.  You can also save the properties table to a CSV file. Check out the [Features table widget]([https://napari.org/dev/gallery/features_table_widget.html]) example to learn more.
+
+### Some big changes for developers! 🛠️
+
+1. **The organization of the napari repo has been updated by moving into a `src/` directory [(#7952)](https://github.com/napari/napari/pull/7952).** This is modern best practice in Python projects (and what has long been standard in our [napari-plugin-template](https://github.com/napari/napari-plugin-template)) to avoid issues with relative imports and *should* now always result in importing the napari version installed in the current environment. For developers, especially of pull requests prior to this release, you may have many merge conflicts to resolve. Please ping the napari team if you would like help resolving these conflicts.
+2. **There is now public API to access widgets docked in the viewer [(#7965)](https://github.com/napari/napari/pull/7965).** Check out the new documentation on the napari website to learn more about using this API to [communicate between widgets](https://napari.org/dev/plugins/advanced_topics/widget_communication.html). If you previously used `viewer.window._dock_widgets`, you should now use `viewer.window.dock_widgets`.
 
 ## New Features
 
-- Qt controls for thick slicing ([#6146](https://github.com/napari/napari/pull/6146))
-- Add automatic area and perimeter measurement for shapes + action ([#7262](https://github.com/napari/napari/pull/7262))
-- Add canvas color to public API ([#7778](https://github.com/napari/napari/pull/7778))
-- Add grid overlay ([#7827](https://github.com/napari/napari/pull/7827))
-- Tiling canvas overlays ([#7836](https://github.com/napari/napari/pull/7836))
 - Features table widget as builtin ([#7877](https://github.com/napari/napari/pull/7877))
+- Add 'zoom-box' to the viewer ([#8004](https://github.com/napari/napari/pull/8004))
 
 ## Improvements
 
-- Allow use functions from PartSegCore-compiled-backend as numba alternative for data to texture mapping  ([#6617](https://github.com/napari/napari/pull/6617))
 - Reduce warmup of numba if non numba backend is selected ([#7917](https://github.com/napari/napari/pull/7917))
 - Optional rotation handle for selection box overlay + simplify inheritance for Vispy overlays ([#7958](https://github.com/napari/napari/pull/7958))
 - Add public API to get access to docked widgets ([#7965](https://github.com/napari/napari/pull/7965))
-- Implement pasting spatial information into higher dimensions ([#7973](https://github.com/napari/napari/pull/7973))
 - Allow to use ViewerModel as annotation of plugin constructor argument ([#8002](https://github.com/napari/napari/pull/8002))
 - speedup edge width set by use `batched_updates` context manager ([#8006](https://github.com/napari/napari/pull/8006))
+- Update [shapes]: 'make select_all_shapes' keybinding a toggle ([#8014](https://github.com/napari/napari/pull/8014))
+- Update[shortcuts]: add Ctrl/Cmd-A as secondary keybinding for select_all_shapes ([#8015](https://github.com/napari/napari/pull/8015))
+- "Reverse" ordering of layers in grid mode, now matching LayerList index ([#8044](https://github.com/napari/napari/pull/8044))
+- Fix Shapes layer to work with Features Table ([#8048](https://github.com/napari/napari/pull/8048))
 
 ## Performance
 
-- Allow use functions from PartSegCore-compiled-backend as numba alternative for data to texture mapping  ([#6617](https://github.com/napari/napari/pull/6617))
 - [Shapes] Use the plural methods to update colors of all selected shapes at once ([#7995](https://github.com/napari/napari/pull/7995))
 
 ## Bug Fixes
@@ -57,34 +56,36 @@ https://napari.org.
 - [Points] Fix events.data_indices for ActionType.ADDED event when adding single point ([#7983](https://github.com/napari/napari/pull/7983))
 - Fix interaction box initialization ([#8011](https://github.com/napari/napari/pull/8011))
 - Fix angles not showing correctly in UI ([#8013](https://github.com/napari/napari/pull/8013))
+- Bugfix: ensure multiscale images can be merged using contextual action ([#8025](https://github.com/napari/napari/pull/8025))
+- Fix Shapes layer to work with Features Table ([#8048](https://github.com/napari/napari/pull/8048))
 
-## API Changes
+## Build Tools
 
-- Expose force_sync context manager ([#7908](https://github.com/napari/napari/pull/7908))
+- Bump requests from 2.32.3 to 2.32.4 in /resources ([#8010](https://github.com/napari/napari/pull/8010))
 
 ## Documentation
 
-- Add example linking the cameras of two viewers ([#6881](https://github.com/napari/napari/pull/6881))
 - Update README to use `imshow` and add example to generate image ([#7989](https://github.com/napari/napari/pull/7989))
+- Update docstring in `mouse_drag_callback.py` ([#8019](https://github.com/napari/napari/pull/8019))
 - Update version switcher for 0.6.1 ([docs#713](https://github.com/napari/docs/pull/713))
 - Update contributing docs page ([docs#715](https://github.com/napari/docs/pull/715))
 - Update code of conduct committee members ([docs#716](https://github.com/napari/docs/pull/716))
+- Add features table widget ([docs#718](https://github.com/napari/docs/pull/718))
+- Update docker build links ([docs#720](https://github.com/napari/docs/pull/720))
 - Add initial documentation about widget communication ([docs#721](https://github.com/napari/docs/pull/721))
 - Update installation.md to link to conda getting started not miniconda ([docs#726](https://github.com/napari/docs/pull/726))
 - Update governance docs ([docs#729](https://github.com/napari/docs/pull/729))
 - Initial release notes for alpha of 0.6.2 ([docs#734](https://github.com/napari/docs/pull/734))
+- Add active roadmap document ([docs#735](https://github.com/napari/docs/pull/735))
+- Use darker blue for community meetings in napari calendar ([docs#736](https://github.com/napari/docs/pull/736))
 
 ## Other Pull Requests
 
-- Layer controls widgets refactor ([#7355](https://github.com/napari/napari/pull/7355))
-- Add codespell support (config, workflow to detect/not fix) and make it fix few typos ([#7619](https://github.com/napari/napari/pull/7619))
 - Add docs constraints for python 3.12 ([#7714](https://github.com/napari/napari/pull/7714))
 - Include Qt PyPI server for pre-releases ([#7803](https://github.com/napari/napari/pull/7803))
 - Refactor layer overlays visuals from VispyLayer to VispyCanvas ([#7835](https://github.com/napari/napari/pull/7835))
-- Use information about units when calculate scale of layers when render ([#7889](https://github.com/napari/napari/pull/7889))
 - Add cron check to update reader extensions ([#7907](https://github.com/napari/napari/pull/7907))
 - Update `dask`, `hypothesis`, `numpy`, `tensorstore`, `vispy` ([#7948](https://github.com/napari/napari/pull/7948))
-- Move export ROI implementation into qt_viewer ([#7950](https://github.com/napari/napari/pull/7950))
 - [pre-commit.ci] pre-commit autoupdate ([#7951](https://github.com/napari/napari/pull/7951))
 - Add cron check to update reader extensions v2 ([#7957](https://github.com/napari/napari/pull/7957))
 - Restore image in Readme ([#7959](https://github.com/napari/napari/pull/7959))
@@ -96,23 +97,36 @@ https://napari.org.
 - [maintenance] Use Wandalen/wretry.action to auto-retry fail in --pre tests ([#7986](https://github.com/napari/napari/pull/7986))
 - Update `hypothesis`, `ipython`, `jsonschema`, `tifffile` ([#7987](https://github.com/napari/napari/pull/7987))
 - [pre-commit.ci] pre-commit autoupdate ([#7988](https://github.com/napari/napari/pull/7988))
+- Remove the reset_scroll_progress action and keybinding ([#7990](https://github.com/napari/napari/pull/7990))
 - Stop status thread on Keyboard Interruption (Ctrl+C) ([#7994](https://github.com/napari/napari/pull/7994))
 - Update `hypothesis`, `magicgui`, `pandas`, `pyqt6`, `pytest`, `pytest-pretty` ([#8000](https://github.com/napari/napari/pull/8000))
 - Update pyproject.toml to fix coverage paths (alt) ([#8001](https://github.com/napari/napari/pull/8001))
 - [Maintenance] Remove redundant initialization in Points layer and restructure for clarity ([#8005](https://github.com/napari/napari/pull/8005))
-- Update[shortcuts]: add Ctrl/Cmd-A as secondary keybinding for select_all_shapes ([#8015](https://github.com/napari/napari/pull/8015))
+- Fix numba fail of compile on GHA macOS runners ([#8018](https://github.com/napari/napari/pull/8018))
+- Update `certifi`, `coverage`, `hypothesis`, `pydantic`, `superqt`, `tifffile`, `xarray` ([#8029](https://github.com/napari/napari/pull/8029))
+- [Update] Added `remove` , `remove_selected` and `pop` in Shapes and Points ([#8031](https://github.com/napari/napari/pull/8031))
+- Update `hypothesis`, `pytest`, `superqt` ([#8036](https://github.com/napari/napari/pull/8036))
+- Stop benchmark reporting if benchmark action is skipped ([#8037](https://github.com/napari/napari/pull/8037))
+- Update `app-model`, `hypothesis`, `pygments`, `scipy` ([#8040](https://github.com/napari/napari/pull/8040))
+- Update `app-model` pin to >=0.4.0, update `hypothesis`, `pygments`, `scipy` ([#8041](https://github.com/napari/napari/pull/8041))
+- [pre-commit.ci] pre-commit autoupdate ([#8042](https://github.com/napari/napari/pull/8042))
 - Fix comment and manual dispatch triggered build jobs ([docs#723](https://github.com/napari/docs/pull/723))
+- Test passing PR number instead of ref on triggered build ([docs#738](https://github.com/napari/docs/pull/738))
+- [maint] fix circleCI branch naming in trigger action ([docs#739](https://github.com/napari/docs/pull/739))
 
 
-## 10 authors added to this release (alphabetical)
+## 13 authors added to this release (alphabetical)
 
 (+) denotes first-time contributors 🥳
 
+- [Ashley Anderson](https://github.com/napari/docs/commits?author=aganders3) - @aganders3
+- [Carol Willing](https://github.com/napari/docs/commits?author=willingc) - @willingc
 - [Draga Doncila Pop](https://github.com/napari/napari/commits?author=DragaDoncila) ([docs](https://github.com/napari/docs/commits?author=DragaDoncila))  - @DragaDoncila
 - [Grzegorz Bokota](https://github.com/napari/napari/commits?author=Czaki) ([docs](https://github.com/napari/docs/commits?author=Czaki))  - @Czaki
 - [Jacopo Abramo](https://github.com/napari/napari/commits?author=jacopoabramo) - @jacopoabramo +
 - [Juan Nunez-Iglesias](https://github.com/napari/docs/commits?author=jni) - @jni
-- [Lorenzo Gaifas](https://github.com/napari/napari/commits?author=brisvag) - @brisvag
+- [Lorenzo Gaifas](https://github.com/napari/napari/commits?author=brisvag) ([docs](https://github.com/napari/docs/commits?author=brisvag))  - @brisvag
+- [Lukasz Migas](https://github.com/napari/napari/commits?author=lukasz-migas) - @lukasz-migas
 - [Maximilian Mayrhauser](https://github.com/napari/napari/commits?author=Llewi) - @Llewi +
 - [Melissa Weber Mendonça](https://github.com/napari/docs/commits?author=melissawm) - @melissawm
 - [Peter Sobolewski](https://github.com/napari/napari/commits?author=psobolewskiPhD) ([docs](https://github.com/napari/docs/commits?author=psobolewskiPhD))  - @psobolewskiPhD
@@ -120,21 +134,20 @@ https://napari.org.
 - [Tim Monko](https://github.com/napari/napari/commits?author=TimMonko) ([docs](https://github.com/napari/docs/commits?author=TimMonko))  - @TimMonko
 
 
-## 13 reviewers added to this release (alphabetical)
+## 12 reviewers added to this release (alphabetical)
 
 (+) denotes first-time contributors 🥳
 
 - [Ashley Anderson](https://github.com/napari/docs/commits?author=aganders3) - @aganders3
 - [Carol Willing](https://github.com/napari/docs/commits?author=willingc) - @willingc
-- [Daniel Althviz Moré](https://github.com/napari/docs/commits?author=dalthviz) - @dalthviz
 - [Draga Doncila Pop](https://github.com/napari/napari/commits?author=DragaDoncila) ([docs](https://github.com/napari/docs/commits?author=DragaDoncila))  - @DragaDoncila
 - [Grzegorz Bokota](https://github.com/napari/napari/commits?author=Czaki) ([docs](https://github.com/napari/docs/commits?author=Czaki))  - @Czaki
 - [Jacopo Abramo](https://github.com/napari/napari/commits?author=jacopoabramo) - @jacopoabramo +
 - [Juan Nunez-Iglesias](https://github.com/napari/docs/commits?author=jni) - @jni
-- [Lorenzo Gaifas](https://github.com/napari/napari/commits?author=brisvag) - @brisvag
+- [Lorenzo Gaifas](https://github.com/napari/napari/commits?author=brisvag) ([docs](https://github.com/napari/docs/commits?author=brisvag))  - @brisvag
+- [Lukasz Migas](https://github.com/napari/napari/commits?author=lukasz-migas) - @lukasz-migas
 - [Melissa Weber Mendonça](https://github.com/napari/docs/commits?author=melissawm) - @melissawm
 - [Peter Sobolewski](https://github.com/napari/napari/commits?author=psobolewskiPhD) ([docs](https://github.com/napari/docs/commits?author=psobolewskiPhD))  - @psobolewskiPhD
 - [Tim Monko](https://github.com/napari/napari/commits?author=TimMonko) ([docs](https://github.com/napari/docs/commits?author=TimMonko))  - @TimMonko
 - [Wouter-Michiel Vierdag](https://github.com/napari/docs/commits?author=melonora) - @melonora
-- [Yaroslav Halchenko](https://github.com/napari/docs/commits?author=yarikoptic) - @yarikoptic
 

--- a/docs/release/release_0_6_2.md
+++ b/docs/release/release_0_6_2.md
@@ -1,7 +1,7 @@
 # napari 0.6.2
 ⚠️ *Note: these release notes are still in draft while 0.6.2 is in release candidate testing.* ⚠️
 
-*Wed, Jun 26, 2025*
+*Wed, Jun 25, 2025*
 
 We’re happy to announce the release of napari 0.6.2!
 
@@ -13,16 +13,21 @@ For more information, examples, and documentation, please visit our website: htt
 
 ### The amazing new Grid mode! 🗺️
 
-The visualization of Grid mode has been redone from the ground up! This new Grid mode [(#7870)](https://github.com/napari/napari/pull/7870) now puts each layer into its own view (a VisPy Viewbox) with cameras linked together. Now, you can pan and zoom one view, and all other views in the grid will follow along. No longer are layers awkwardly transformed into the same world space and displayed in a grid, only to make comparing the details of each a challenge. Grid based exploration is now fluid, fast, and intuitive, especially when working with large images and 3D+ data! The mouse can even be used over one View, while updating the data, such as a label or shape annotation, in the selected layer of a different view. The usual napari overlays can now also be added to each grid, instead of just the canvas (i.e. `viewer.scale_bar.gridded = True`).
+The visualization of Grid mode has been redone from the ground up! This new Grid mode [(#7870)](https://github.com/napari/napari/pull/7870) now puts each layer into its own view (a VisPy Viewbox) with cameras linked together. Now, you can pan and zoom one view, and all other views in the grid will follow along. No longer are layers awkwardly transformed into the same world space and displayed in a grid, only to make comparing the details of each a challenge. Grid based exploration is now fluid, fast, and intuitive, especially when working with large images and 3D+ data! The mouse can even be used over one View, while updating the data, such as a label or shape annotation, in the selected layer of a different view. The usual napari overlays can now also be added to each grid, instead of just the canvas (eg. `viewer.scale_bar.gridded = True`).
 
 ### The Features Table Widget is now a napari builtin! 📊
 
-The features table from [napari-properties-viewer](https://github.com/kevinyamauchi/napari-properties-viewer) is now a builtin widget in napari [(#7877)](https://github.com/napari/napari/pull/7877) *and* greatly improved! This widget allows you to view (and even edit) the properties of Points, Shapes, and Labels layers in a table widget. The widget can be opened from the `Layers` menu -> `Visualize` -> `Features table widget (napari builtins)` or from the command palette.  You can also save the properties table to a CSV file. Check out the [Features table widget]([https://napari.org/dev/gallery/features_table_widget.html]) example to learn more.
+The features table from [napari-properties-viewer](https://github.com/kevinyamauchi/napari-properties-viewer) is now a builtin widget in napari [(#7877)](https://github.com/napari/napari/pull/7877) *and* greatly improved! This widget allows you to view (and even edit) the properties of Points, Shapes, and Labels layers in a table widget. The widget can be opened from the `Layers` menu -> `Visualize` -> `Features table widget (napari builtins)` or from the command palette.  You can also save the properties table to a CSV file. Check out the [Features table widget](https://napari.org/dev/gallery/features_table_widget.html) example to learn more.
 
-### Some big changes for developers! 🛠️
+### Community developments! 📅
 
-1. **The organization of the napari repo has been updated by moving into a `src/` directory [(#7952)](https://github.com/napari/napari/pull/7952).** This is modern best practice in Python projects (and what has long been standard in our [napari-plugin-template](https://github.com/napari/napari-plugin-template)) to avoid issues with relative imports and *should* now always result in importing the napari version installed in the current environment. For developers, especially of pull requests prior to this release, you may have many merge conflicts to resolve. Please ping the napari team if you would like help resolving these conflicts.
-2. **There is now public API to access widgets docked in the viewer [(#7965)](https://github.com/napari/napari/pull/7965).** Check out the new documentation on the napari website to learn more about using this API to [communicate between widgets](https://napari.org/dev/plugins/advanced_topics/widget_communication.html). If you previously used `viewer.window._dock_widgets`, you should now use `viewer.window.dock_widgets`.
+We are excited to share our new [active roadmap](https://napari.org/stable/roadmaps/active_roadmap.html) which is a living document that will be updated as we continue to develop napari. This document is intended to help the community understand the priorities of the napari team and to help us all work together to make napari better. We are also now including all napari related events in the [community calendar](https://napari.org/stable/community/meeting_schedule.html) and as an [image.sc post](https://forum.image.sc/t/napari-community-meetings-and-events/113689), including conferences, tutorials, sprints, virtual seminars, and more. If you have an event you would like to add, please reach out to us!
+
+### Some big changes for contributors! 🛠️
+
+1. **Contributing documentation is now a much smoother experience!** By default, new documentation will build in around 3 minutes, instead of the previous 20 minutes. This speed is thanks to new, slimmer `make` commands (`slimfast` by default) that can also be triggered in PRs with a bot (eg. `@napari-bot make docs`). Read our updated [docs contribution guide](https://napari.org/dev/developers/contributing/documentation/index.html) and reach out for help.
+2. **The organization of the napari repo has been updated by moving into a `src/` directory [(#7952)](https://github.com/napari/napari/pull/7952).** This is modern best practice in Python projects (and what has long been standard in our [napari-plugin-template](https://github.com/napari/napari-plugin-template)) to avoid issues with relative imports and *should* now always result in importing the napari version installed in the current environment. For developers, especially of pull requests prior to this release, you may have many merge conflicts to resolve. Please ping the napari team if you would like help resolving these conflicts.
+3. **There is now public API to access widgets docked in the viewer [(#7965)](https://github.com/napari/napari/pull/7965).** Check out the new documentation on the napari website to learn more about using this API to [communicate between widgets](https://napari.org/dev/plugins/advanced_topics/widget_communication.html). If you previously used `viewer.window._dock_widgets`, you should now use `viewer.window.dock_widgets`.
 
 ## New Features
 

--- a/docs/release/release_0_6_2.md
+++ b/docs/release/release_0_6_2.md
@@ -13,17 +13,25 @@ For more information, examples, and documentation, please visit our website: htt
 
 ### The amazing new Grid mode! 🗺️
 
-The visualization of Grid mode has been redone from the ground up! This new Grid mode [(#7870)](https://github.com/napari/napari/pull/7870) now puts each layer into its own view (a VisPy Viewbox) with cameras linked together. Now, you can pan and zoom one view, and all other views in the grid will follow along. No longer are layers awkwardly transformed into the same world space and displayed in a grid, only to make comparing the details of each a challenge. Grid based exploration is now fluid, fast, and intuitive, especially when working with large images and 3D+ data! The mouse can even be used over one View, while updating the data, such as a label or shape annotation, in the selected layer of a different view. The usual napari overlays can now also be added to each grid, instead of just the canvas (eg. `viewer.scale_bar.gridded = True`).
+The visualization of Grid mode has been redone from the ground up! This new Grid mode [(#7870)](https://github.com/napari/napari/pull/7870) now puts each layer into its own view (a VisPy Viewbox) with cameras linked together. Now, you can pan and zoom one view, and all other views in the grid will follow along. Layers are no longer awkwardly transformed into the same world space and displayed in a grid, only to make comparing the details of each a challenge. 
+
+Grid based exploration is now fluid, fast, and intuitive, especially when working with large images and 3D+ data! The mouse can even be used over one View, while updating the data, such as a label or shape annotation, in the selected layer of a different view. The usual napari overlays can now also be added to each grid, instead of just the canvas (eg. `viewer.scale_bar.gridded = True`). 
+
+Grid mode spacing now works proportionally to the layer extents (i.e. [0,1), as in 0.6.0) or as a pixel value (1,1500] and will automatically adjust if needed.
+
+![new Grid mode in napari](https://github.com/user-attachments/assets/f49c38e0-2cce-4729-a2d1-7b9c0023574c)
 
 ### The Features Table Widget is now a napari builtin! 📊
 
 The features table from [napari-properties-viewer](https://github.com/kevinyamauchi/napari-properties-viewer) is now a builtin widget in napari [(#7877)](https://github.com/napari/napari/pull/7877) *and* greatly improved! This widget allows you to view (and even edit) the properties of Points, Shapes, and Labels layers in a table widget. The widget can be opened from the `Layers` menu -> `Visualize` -> `Features table widget (napari builtins)` or from the command palette.  You can also save the properties table to a CSV file. Check out the [Features table widget](https://napari.org/dev/gallery/features_table_widget.html) example to learn more.
 
+![Features table widget in napari](https://github.com/user-attachments/assets/2c218f05-6510-4192-b5c8-fb6d135e4863)
+
 ### Community developments! 📅
 
 We are excited to share our new [active roadmap](https://napari.org/stable/roadmaps/active_roadmap.html) which is a living document that will be updated as we continue to develop napari. This document is intended to help the community understand the priorities of the napari team and to help us all work together to make napari better. We are also now including all napari related events in the [community calendar](https://napari.org/stable/community/meeting_schedule.html) and as an [image.sc post](https://forum.image.sc/t/napari-community-meetings-and-events/113689), including conferences, tutorials, sprints, virtual seminars, and more. If you have an event you would like to add, please reach out to us!
 
-### Some big changes for contributors! 🛠️
+### Some great features for contributors! 🛠️
 
 1. **Contributing documentation is now a much smoother experience!** By default, new documentation will build in around 3 minutes, instead of the previous 20 minutes. This speed is thanks to new, slimmer `make` commands (`slimfast` by default) that can also be triggered in PRs with a bot (eg. `@napari-bot make docs`). Read our updated [docs contribution guide](https://napari.org/dev/developers/contributing/documentation/index.html) and reach out for help.
 2. **The organization of the napari repo has been updated by moving into a `src/` directory [(#7952)](https://github.com/napari/napari/pull/7952).** This is modern best practice in Python projects (and what has long been standard in our [napari-plugin-template](https://github.com/napari/napari-plugin-template)) to avoid issues with relative imports and *should* now always result in importing the napari version installed in the current environment. For developers, especially of pull requests prior to this release, you may have many merge conflicts to resolve. Please ping the napari team if you would like help resolving these conflicts.

--- a/docs/release/release_0_6_2.md
+++ b/docs/release/release_0_6_2.md
@@ -1,7 +1,7 @@
 # napari 0.6.2
 ⚠️ *Note: these release notes are still in draft while 0.6.2 is in release candidate testing.* ⚠️
 
-*Wed, Jun 25, 2025*
+*Thurs, Jun 26, 2025*
 
 We’re happy to announce the release of napari 0.6.2!
 
@@ -13,9 +13,9 @@ For more information, examples, and documentation, please visit our website: htt
 
 ### The amazing new Grid mode! 🗺️
 
-The visualization of Grid mode has been redone from the ground up! This new Grid mode [(#7870)](https://github.com/napari/napari/pull/7870) now puts each layer into its own view (a VisPy Viewbox) with cameras linked together. Now, you can pan and zoom one view, and all other views in the grid will follow along. Layers are no longer awkwardly transformed into the same world space and displayed in a grid, only to make comparing the details of each a challenge. 
+The visualization of Grid mode has been redone from the ground up! This new Grid mode [(#7870)](https://github.com/napari/napari/pull/7870) now puts each layer into its own view (a VisPy Viewbox) with cameras linked together. Now, you can pan and zoom one view, and all other views in the grid will follow along. Layers are no longer awkwardly transformed into the same world space and displayed in a grid, only to make comparing the details of each a challenge.
 
-Grid based exploration is now fluid, fast, and intuitive, especially when working with large images and 3D+ data! The mouse can even be used over one View, while updating the data, such as a label or shape annotation, in the selected layer of a different view. The usual napari overlays can now also be added to each grid, instead of just the canvas (eg. `viewer.scale_bar.gridded = True`). 
+Grid based exploration is now fluid, fast, and intuitive, especially when working with large images and 3D+ data! The mouse can even be used over one View, while updating the data, such as a label or shape annotation, in the selected layer of a different view. The usual napari overlays can now also be added to each grid, instead of just the canvas (eg. `viewer.scale_bar.gridded = True`).
 
 Grid mode spacing now works proportionally to the layer extents (i.e. [0,1), as in 0.6.0) or as a pixel value (1,1500] and will automatically adjust if needed.
 
@@ -23,13 +23,17 @@ Grid mode spacing now works proportionally to the layer extents (i.e. [0,1), as 
 
 ### The Features Table Widget is now a napari builtin! 📊
 
-The features table from [napari-properties-viewer](https://github.com/kevinyamauchi/napari-properties-viewer) is now a builtin widget in napari [(#7877)](https://github.com/napari/napari/pull/7877) *and* greatly improved! This widget allows you to view (and even edit) the properties of Points, Shapes, and Labels layers in a table widget. The widget can be opened from the `Layers` menu -> `Visualize` -> `Features table widget (napari builtins)` or from the command palette.  You can also save the properties table to a CSV file. Check out the [Features table widget](https://napari.org/dev/gallery/features_table_widget.html) example to learn more.
+The features table from [napari-properties-viewer](https://github.com/kevinyamauchi/napari-properties-viewer) is now a builtin widget in napari [(#7877)](https://github.com/napari/napari/pull/7877) *and* greatly improved! This widget allows you to view and edit the properties of Points, Shapes, and Labels layers in a table widget.
+
+The widget can be opened from the `Layers` menu -> `Visualize` -> `Features table widget (napari builtins)` or from the command palette.  You can also save the properties table to a CSV file. Check out the [Features table widget](https://napari.org/dev/gallery/features_table_widget.html) example to learn more.
 
 ![Features table widget in napari](https://github.com/user-attachments/assets/2c218f05-6510-4192-b5c8-fb6d135e4863)
 
 ### Community developments! 📅
 
-We are excited to share our new [active roadmap](https://napari.org/stable/roadmaps/active_roadmap.html) which is a living document that will be updated as we continue to develop napari. This document is intended to help the community understand the priorities of the napari team and to help us all work together to make napari better. We are also now including all napari related events in the [community calendar](https://napari.org/stable/community/meeting_schedule.html) and as an [image.sc post](https://forum.image.sc/t/napari-community-meetings-and-events/113689), including conferences, tutorials, sprints, virtual seminars, and more. If you have an event you would like to add, please reach out to us!
+We are excited to share our new [active roadmap](https://napari.org/stable/roadmaps/active_roadmap.html) which is a living document that will be updated as we continue to develop napari. This document is intended to help the community understand the priorities of the napari team and to help us all work together to make napari better. 
+
+We are also now including all napari related events in the [community calendar](https://napari.org/stable/community/meeting_schedule.html) and as an [image.sc post](https://forum.image.sc/t/napari-community-meetings-and-events/113689), including conferences, tutorials, sprints, virtual seminars, and more. If you have an event you would like to add, please reach out to us!
 
 ### Some great features for contributors! 🛠️
 
@@ -39,6 +43,7 @@ We are excited to share our new [active roadmap](https://napari.org/stable/roadm
 
 ## New Features
 
+- Grid mode using vispy ViewBox and linked cameras ([#7870](https://github.com/napari/napari/pull/7870))
 - Features table widget as builtin ([#7877](https://github.com/napari/napari/pull/7877))
 - Add 'zoom-box' to the viewer ([#8004](https://github.com/napari/napari/pull/8004))
 
@@ -91,6 +96,7 @@ We are excited to share our new [active roadmap](https://napari.org/stable/roadm
 - Initial release notes for alpha of 0.6.2 ([docs#734](https://github.com/napari/docs/pull/734))
 - Add active roadmap document ([docs#735](https://github.com/napari/docs/pull/735))
 - Use darker blue for community meetings in napari calendar ([docs#736](https://github.com/napari/docs/pull/736))
+- Add draft of 0.6.2 release notes ([docs#743](https://github.com/napari/docs/pull/743))
 
 ## Other Pull Requests
 
@@ -147,7 +153,7 @@ We are excited to share our new [active roadmap](https://napari.org/stable/roadm
 - [Tim Monko](https://github.com/napari/napari/commits?author=TimMonko) ([docs](https://github.com/napari/docs/commits?author=TimMonko))  - @TimMonko
 
 
-## 12 reviewers added to this release (alphabetical)
+## 13 reviewers added to this release (alphabetical)
 
 (+) denotes first-time contributors 🥳
 
@@ -161,6 +167,7 @@ We are excited to share our new [active roadmap](https://napari.org/stable/roadm
 - [Lukasz Migas](https://github.com/napari/napari/commits?author=lukasz-migas) - @lukasz-migas
 - [Melissa Weber Mendonça](https://github.com/napari/docs/commits?author=melissawm) - @melissawm
 - [Peter Sobolewski](https://github.com/napari/napari/commits?author=psobolewskiPhD) ([docs](https://github.com/napari/docs/commits?author=psobolewskiPhD))  - @psobolewskiPhD
+- [Rahul Kumar](https://github.com/napari/napari/commits?author=rahul713rk) - @rahul713rk +
 - [Tim Monko](https://github.com/napari/napari/commits?author=TimMonko) ([docs](https://github.com/napari/docs/commits?author=TimMonko))  - @TimMonko
 - [Wouter-Michiel Vierdag](https://github.com/napari/docs/commits?author=melonora) - @melonora
 


### PR DESCRIPTION
# References and relevant issues
<!-- What relevant resources were used in the creation of this PR?
If this PR addresses an existing issue on the repo,
please link to that issue here as "Closes #(issue-number)".
If this PR adds docs for a napari PR please add a "Depends on <napari PR link>" -->

# Description
<!-- What does this pull request (PR) do? Does it add new content, improve/fix existing
context, improve/fix workflow/documentation build/deployment or something else?
<!-- If relevant, please include a screenshot or a screen capture in your content
change: "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations. -->
<!-- You can also see a preview of the documentation changes you are submitting by
clicking on "Details" to the right of the "Check the rendered docs here!" check on your PR.-->

Adds draft of most hopeful features for 0.6.2. Just trying to have this ready so people can investigate for rc0

Needs (perhaps follow up PR) extra spice to highlight the great work of our newest contributors, _especially_ if we get the zoom box PR in. 

Will add in follow-up videos of grid mode, an image or video of features table widget, and if we have it ready, the zoom-box PR.

<!-- Previewing the Documentation Build
When you submit this PR, jobs that preview the documentation will be kicked off.
By default, they will use the `slimfast` build (`make` target), which is fast, because
it doesn't build any content from outside the `docs` repository and doesn't run notebook cells.
You can trigger other builds by commenting on the PR with:

@napari-bot make <target>

where <target> can be:
html : a full build, just like the deployment to napari.org
html-noplot : a full build, but without the gallery examples from `napari/napari`
docs : only the content from `napari/docs`, with notebook code cells executed
slimfast : the default, only the content from `napari/docs`, without code cell execution
slimgallery : `slimfast`, but with the gallery examples from `napari/napari` built
-->

<!-- Final Checklist
- If images included: I have added [alt text](https://webaim.org/techniques/alttext/)
If workflow, documentation build or deployment change:
- My PR is the minimum possible work for the desired functionality
- I have commented my code, to let others know what it does
-->
