### PR TITLE
[Enh] When `ready-to-merge` is applied, do a full build of docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@
 version: 2.1
 
 # in addition to the default circleCI triggering, we have a GitHub Action:
-# .github/triggered_target_build.yml 
+# .github/triggered_target_build.yml
 # This Action has a job that uses CircleCI-Public/trigger-circleci-pipeline-action.
 # This allows triggering a CircleCI pipeline from any event on GitHub with GitHub Actions.
 # Right now we are using comments on PRs to trigger the workflow "triggered-by-pr-comment"
@@ -98,3 +98,9 @@ workflows:
     jobs:
       - build-docs:
           make_target: << pipeline.parameters.GHA_Meta >>
+  triggered-by-label:
+    when:
+      equal: ["ready-to-merge", << pipeline.parameters.GHA_Meta >>]
+    jobs:
+      - build-docs:
+          make_target: "html"

--- a/.github/workflows/label_triggered_build.yml
+++ b/.github/workflows/label_triggered_build.yml
@@ -1,4 +1,4 @@
-name: Trigger Full Build on ready-to-merge label
+name: Trigger Full Build on ready to merge label
 
 on:
   pull_request:
@@ -7,7 +7,7 @@ on:
 
 jobs:
   trigger-full-circleci-build:
-    if: contains(github.event.pull_request.labels.*.name, 'ready-to-merge')
+    if: contains(github.event.pull_request.labels.*.name, 'ready to merge')
     runs-on: ubuntu-latest
     steps:
       - name: Run CircleCI pipeline
@@ -18,7 +18,7 @@ jobs:
           CCI_TOKEN: ${{ secrets.CIRCLECI_TOKEN }}
 
   trigger-full-artifact-build:
-    if: contains(github.event.pull_request.labels.*.name, 'ready-to-merge')
+    if: contains(github.event.pull_request.labels.*.name, 'ready to merge')
     uses: ./.github/workflows/build_docs.yml
     with:
       make_target: "html"

--- a/.github/workflows/label_triggered_build.yml
+++ b/.github/workflows/label_triggered_build.yml
@@ -28,7 +28,7 @@ jobs:
     # so to get the status of the artifact build, we need a separate job
     needs: trigger-full-artifact-build
     runs-on: ubuntu-latest
-    if: always()
+    if: always() && needs.trigger-artifact-build.result != 'skipped'
     steps:
       - name: Set build job status
         uses: myrotvorets/set-commit-status-action@master

--- a/.github/workflows/label_triggered_build.yml
+++ b/.github/workflows/label_triggered_build.yml
@@ -28,7 +28,7 @@ jobs:
     # so to get the status of the artifact build, we need a separate job
     needs: trigger-full-artifact-build
     runs-on: ubuntu-latest
-    if: always() && needs.trigger-artifact-build.result != 'skipped'
+    if: always() && needs.trigger-full-artifact-build.result != 'skipped'
     steps:
       - name: Set build job status
         uses: myrotvorets/set-commit-status-action@master

--- a/.github/workflows/label_triggered_build.yml
+++ b/.github/workflows/label_triggered_build.yml
@@ -1,0 +1,41 @@
+name: Trigger Full Build on ready-to-merge label
+
+on:
+  pull_request:
+    types:
+      - labeled
+
+jobs:
+  trigger-full-circleci-build:
+    if: contains(github.event.pull_request.labels.*.name, 'ready-to-merge')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run CircleCI pipeline
+        uses: CircleCI-Public/trigger-circleci-pipeline-action@v1.2.0
+        with:
+          GHA_Meta: "ready-to-merge"
+          target-branch: ${{ github.event.pull_request.head.ref }}
+        env:
+          CCI_TOKEN: ${{ secrets.CIRCLECI_TOKEN }}
+
+  trigger-full-artifact-build:
+    if: contains(github.event.pull_request.labels.*.name, 'ready-to-merge')
+    uses: ./.github/workflows/build_docs.yml
+    with:
+      make_target: "html"
+
+  report-artifact-status:
+    # reusable workflows can't be a step in a job
+    # so to get the status of the artifact build, we need a separate job
+    needs: trigger-full-artifact-build
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Set build job status
+        uses: myrotvorets/set-commit-status-action@master
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          status: ${{ needs.trigger-full-artifact-build.result }}
+          context: "Docs Full Artifact Build"
+          description: ${{ needs.trigger-full-artifact-build.result == 'success' && 'Full Docs built successfully' || 'Full Docs build failed' }}
+          targetUrl: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/label_triggered_build.yml
+++ b/.github/workflows/label_triggered_build.yml
@@ -14,7 +14,6 @@ jobs:
         uses: CircleCI-Public/trigger-circleci-pipeline-action@v1.2.0
         with:
           GHA_Meta: "ready-to-merge"
-          target-branch: ${{ github.event.pull_request.head.ref }}
         env:
           CCI_TOKEN: ${{ secrets.CIRCLECI_TOKEN }}
 

--- a/.github/workflows/label_triggered_build.yml
+++ b/.github/workflows/label_triggered_build.yml
@@ -1,4 +1,4 @@
-name: Trigger Full Build on ready to merge label
+name: Ready-to-merge Build
 
 on:
   pull_request:
@@ -6,7 +6,7 @@ on:
       - labeled
 
 jobs:
-  trigger-full-circleci-build:
+  full-circleci-build:
     if: contains(github.event.pull_request.labels.*.name, 'ready to merge')
     runs-on: ubuntu-latest
     steps:
@@ -17,7 +17,7 @@ jobs:
         env:
           CCI_TOKEN: ${{ secrets.CIRCLECI_TOKEN }}
 
-  trigger-full-artifact-build:
+  full-artifact-build:
     if: contains(github.event.pull_request.labels.*.name, 'ready to merge')
     uses: ./.github/workflows/build_docs.yml
     with:

--- a/.github/workflows/label_triggered_build.yml
+++ b/.github/workflows/label_triggered_build.yml
@@ -26,15 +26,15 @@ jobs:
   report-artifact-status:
     # reusable workflows can't be a step in a job
     # so to get the status of the artifact build, we need a separate job
-    needs: trigger-full-artifact-build
+    needs: full-artifact-build
     runs-on: ubuntu-latest
-    if: always() && needs.trigger-full-artifact-build.result != 'skipped'
+    if: always() && needs.full-artifact-build.result != 'skipped'
     steps:
       - name: Set build job status
         uses: myrotvorets/set-commit-status-action@master
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          status: ${{ needs.trigger-full-artifact-build.result }}
+          status: ${{ needs.full-artifact-build.result }}
           context: "Docs Full Artifact Build"
-          description: ${{ needs.trigger-full-artifact-build.result == 'success' && 'Full Docs built successfully' || 'Full Docs build failed' }}
+          description: ${{ needs.full-artifact-build.result == 'success' && 'Full Docs built successfully' || 'Full Docs build failed' }}
           targetUrl: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
# References and relevant issues
Followup to https://github.com/napari/docs/pull/723 and https://github.com/napari/docs/pull/669
This came up in a meeting and zulip, plus maybe a PR reviews?

# Description
Adds an action to check for ready-to-merge label and trigger a full build when tagged.
This is simpler than the comment action because it should use the PR context by default.
fingers crossed.
Note it's just a one-time full build. Pushes will still use the default, slimfast.

I did testing in my fork:
https://github.com/psobolewskiPhD/napari-docs/pull/89
But as we saw before isn't guaranteed to work here! So we may need to merge optimistically and then fix if it doesn't trigger correctly. 😬 