### PR TITLE
Fix ready-to-merge label action to use `pull_request_target`

### DIFF
--- a/.github/workflows/label_triggered_build.yml
+++ b/.github/workflows/label_triggered_build.yml
@@ -23,6 +23,7 @@ jobs:
     uses: ./.github/workflows/build_docs.yml
     with:
       make_target: "html"
+      pr_number: ${{ github.event.pull_request.number }}
 
   report-artifact-status:
     # reusable workflows can't be a step in a job

--- a/.github/workflows/label_triggered_build.yml
+++ b/.github/workflows/label_triggered_build.yml
@@ -1,7 +1,7 @@
 name: Ready-to-merge Build
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - labeled
 
@@ -14,6 +14,7 @@ jobs:
         uses: CircleCI-Public/trigger-circleci-pipeline-action@v1.2.0
         with:
           GHA_Meta: "ready-to-merge"
+          target-branch: ${{ github.event.pull_request.head.ref }}
         env:
           CCI_TOKEN: ${{ secrets.CIRCLECI_TOKEN }}
 
@@ -35,6 +36,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           status: ${{ needs.full-artifact-build.result }}
+          sha: ${{ github.event.pull_request.head.sha }}
           context: "Docs Full Artifact Build"
           description: ${{ needs.full-artifact-build.result == 'success' && 'Full Docs built successfully' || 'Full Docs build failed' }}
           targetUrl: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
# References and relevant issues
The CircleCI run meant to trigger by ready-to-merge label is failing:
https://github.com/napari/docs/actions/runs/15928380029/job/44931156980?pr=744
This is due to tokens not being passed when using `pull_request` as the action trigger.
So it works only for people who have a CircleCI token in their fork, the token from napari/docs is not passed to the CircleCI job. You can see that the CCI_TOKEN is empty.
Apparently the automagically triggered job from PR pushes bypasses this limitation, because it uses a different route to trigger.

# Description
The approach here is to use `pull_request_target` which will run the action in the context of napari/docs. This way it has access to the CircleCI token. The build will use the branch from the contributor, so there is a risk here, but this will only run on the label, which can only be applied by maintainers and after review, so I think we're ok.
