### PR TITLE
Only build artifact on ready-to-merge label

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,9 +98,3 @@ workflows:
     jobs:
       - build-docs:
           make_target: << pipeline.parameters.GHA_Meta >>
-  triggered-by-label:
-    when:
-      equal: ["ready-to-merge", << pipeline.parameters.GHA_Meta >>]
-    jobs:
-      - build-docs:
-          make_target: "html"

--- a/.github/workflows/label_triggered_build.yml
+++ b/.github/workflows/label_triggered_build.yml
@@ -6,17 +6,6 @@ on:
       - labeled
 
 jobs:
-  full-circleci-build:
-    if: contains(github.event.pull_request.labels.*.name, 'ready to merge')
-    runs-on: ubuntu-latest
-    steps:
-      - name: Run CircleCI pipeline
-        uses: CircleCI-Public/trigger-circleci-pipeline-action@v1.2.0
-        with:
-          GHA_Meta: "ready-to-merge"
-        env:
-          CCI_TOKEN: ${{ secrets.CIRCLECI_TOKEN }}
-
   full-artifact-build:
     if: contains(github.event.pull_request.labels.*.name, 'ready to merge')
     uses: ./.github/workflows/build_docs.yml


### PR DESCRIPTION
# References and relevant issues
Alternative to https://github.com/napari/docs/pull/748

# Description
To avoid using the less secure pull_request_target trigger, we can just avoid building the CircleCi preview.
The idea is that when reviewing, you would do the bot trigger to build the needed preview. The ready-to-merge build would just be there to verify that a full build doesn't fail.
Note: because a reusable action is used, it will be triggered from the fork, but that should be ok as long as the fork branch is up to date with napari/docs `main`, which is easy to ensure with the update button in PRs.
