### PR TITLE
Fix information about `site-packages` directory

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -80,7 +80,7 @@ See [napari#7288](https://github.com/napari/napari/issues/7288).
 
 Since napari 0.6.2 we have added a check for the mix of [editable](https://setuptools.pypa.io/en/latest/userguide/development_mode.html) and non-editable napari installations in the same environment.
 This occurs when you install napari using `pip install -e path/to/napari` while napari related files are still 
-present in the typical conda installation directory (called `site-packages`).
+present in the typical python package installation directory (called `site-packages`).
 
 Because of how importing in python works, two installations from even slightly different versions of napari
 will often lead to a crash on startup or other unexpected behavior

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -80,7 +80,7 @@ See [napari#7288](https://github.com/napari/napari/issues/7288).
 
 Since napari 0.6.2 we have added a check for the mix of [editable](https://setuptools.pypa.io/en/latest/userguide/development_mode.html) and non-editable napari installations in the same environment.
 This occurs when you install napari using `pip install -e path/to/napari` while napari related files are still 
-present in the typical python package installation directory (called `site-packages`).
+present in the typical Python package installation directory (called `site-packages`).
 
 Because of how importing in python works, two installations from even slightly different versions of napari
 will often lead to a crash on startup or other unexpected behavior


### PR DESCRIPTION
# References and relevant issues

introduced in #752

# Description

I have not checked review suggestions enough, detailed and do not spot that `site-packages` is described as `conda` where it is used by all way to create python environment that I know. 

This PR fixes it. 
