### PR TITLE
Update triggered_target_build.yml regex to ensure we match on hyphen

### DIFF
--- a/.github/workflows/triggered_target_build.yml
+++ b/.github/workflows/triggered_target_build.yml
@@ -59,7 +59,7 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             TARGET="${{ github.event.inputs.make_target }}"
           else
-            TARGET=$(echo "$COMMENT_BODY" | grep -oP '(?<=@napari-bot make\s)\w+' || echo "slimfast")
+            TARGET=$(echo "$COMMENT_BODY" | grep -oP '(?<=@napari-bot make\s)[\w-]+' || echo "slimfast")
           fi
 
           if ! echo "$ALLOWED_TARGETS" | grep -qw "$TARGET"; then


### PR DESCRIPTION

# References and relevant issues
Closes https://github.com/napari/docs/issues/763

# Description
Fixes the regex to include `-` so we can match `html-noplot`
