### PR TITLE
Explore homepage reorg to bring cards further up

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -46,9 +46,10 @@ theme:
 # napari: a fast, interactive viewer for multi-dimensional images in Python
 
 ```{raw} html
-<figure>
 
-  <video width="90%" controls autoplay loop muted playsinline>
+<div style="display: flex; align-items: flex-start; gap: 1rem;">
+<figure style="flex: 2; max-width: 100%; margin-top: 0; padding: 0;">
+  <video width="100%" controls autoplay loop muted playsinline>
     <source src="_static/images/tribolium.webm" type="video/webm" />
     <source src="_static/images/tribolium.mp4" type="video/mp4" />
     <img src="_static/images/tribolium.jpg"
@@ -56,21 +57,18 @@ theme:
       alt="napari viewer showing a 4D image of a developing Tribolium embryo.  Dataset Fluo-N3DL-TRIF from the [cell tracking challenge](http://celltrackingchallenge.net/3d-datasets/) by Dr. A. Jain, MPI-CBG, Dresden, Germany."
     >
   </video>
-
   <figcaption><pre>napari.imshow(image4d)</pre></figcaption>
-
 </figure>
+<div style="flex: 1;">
+<ul>
+  <li><strong>view and explore</strong> 2D, 3D, and higher-dimensional arrays on a canvas;</li>
+  <li><strong>overlay</strong> derived data such as <em>points</em>, <em>polygons</em>, <em>segmentations</em>, and more;</li>
+  <li><strong>annotate</strong> and <strong>edit</strong> derived datasets, using standard data structures such as NumPy or Zarr arrays, allowing you to</li>
+  <li><strong>seamlessly weave</strong> exploration, computation, and annotation together in imaging data analysis.</li>
+</ul>
+</div>
+</div>
 ```
-
-Napari is a Python library for n-dimensional image visualisation, annotation,
-and analysis. With napari you can:
-- **view and explore** 2D, 3D, and higher-dimensional arrays on a canvas;
-- **overlay** derived data such as *points*, *polygons*, *segmentations*, and
-  more;
-- **annotate** and **edit** derived datasets, using standard data structures
-  such as NumPy or Zarr arrays, allowing you to
-- **seamlessly weave** exploration, computation, and annotation together in
-  imaging data analysis.
 
 ::::{grid}
 


### PR DESCRIPTION
# References and relevant issues

# Description
In discussion with @TimMonko we noted that the homepage cards are very far down the page and some folks don't even know they're there - on Tim's machine it looks like the homepage just ends.

This PR explores moving the video and the text into a two-column layout so we can bring the cards further up the page, above the fold.

<!-- Previewing the Documentation Build
When you submit this PR, jobs that preview the documentation will be kicked off.
By default, they will use the `slimfast` build (`make` target), which is fast, because
it doesn't build any content from outside the `docs` repository and doesn't run notebook cells.
You can trigger other builds by commenting on the PR with:

@napari-bot make <target>

where <target> can be:
html : a full build, just like the deployment to napari.org
html-noplot : a full build, but without the gallery examples from `napari/napari`
docs : only the content from `napari/docs`, with notebook code cells executed
slimfast : the default, only the content from `napari/docs`, without code cell execution
slimgallery : `slimfast`, but with the gallery examples from `napari/napari` built
-->

<!-- Final Checklist
- If images included: I have added [alt text](https://webaim.org/techniques/alttext/)
If workflow, documentation build or deployment change:
- My PR is the minimum possible work for the desired functionality
- I have commented my code, to let others know what it does
-->
