### PR TITLE
Fix sidebar roadmap link

### DIFF
--- a/docs/_templates/sidebar-link-items.html
+++ b/docs/_templates/sidebar-link-items.html
@@ -18,7 +18,7 @@
                 {% endif %}
             </li>
             <li class="toctree-l1">
-                <a class="reference internal" href="active_roadmap.html">Roadmap</a>
+                <a class="reference internal" href="roadmaps/active_roadmap.html">Roadmap</a>
             </li>
             <li class="toctree-l1">
                 <a class="reference external" href="https://napari.org/island-dispatch">Blog</a>

--- a/docs/_templates/sidebar-nav-bs.html
+++ b/docs/_templates/sidebar-nav-bs.html
@@ -35,6 +35,9 @@
           {% endif %}
       </li>
       <li class="toctree-l1">
+          <a class="reference internal" href="{{ pathto('roadmaps/active_roadmap.html', 1) }}">Roadmap</a>
+      </li>
+      <li class="toctree-l1">
           <a class="reference external" href="https://napari.org/island-dispatch">Blog</a>
       </li>
     </ul>


### PR DESCRIPTION
# References and relevant issues

Currently sidebar roadmap link 404s,
This should point it to the correct path


