### PR TITLE
Fix Image Annotation example

### DIFF
--- a/docs/howtos/extending/magicgui.md
+++ b/docs/howtos/extending/magicgui.md
@@ -280,8 +280,8 @@ from magicgui.widgets import Container, create_widget
 
 class ImageWidget(Container):
     def __init__(self, viewer: "napari.viewer.Viewer"):
-        super().__init__()
-        self._viewer = viewer
+        super().__init__() # This initializes the magicgui.Container class such that widgets can be added to it.
+        self._viewer = viewer # Enables widgets to reference the attached viewer.
         # use create_widget to generate widgets from type annotations
         self._image_layer_combo = create_widget(
             label="Image", annotation="napari.layers.Image"

--- a/docs/howtos/extending/magicgui.md
+++ b/docs/howtos/extending/magicgui.md
@@ -288,8 +288,6 @@ class ImageWidget(Container):
         )
         # append the child widget to the container
         self.append(self._image_layer_combo)
-
-
 ```
 
 Here's a complete example:

--- a/docs/howtos/extending/magicgui.md
+++ b/docs/howtos/extending/magicgui.md
@@ -286,6 +286,10 @@ class ImageWidget(Container):
         self._image_layer_combo = create_widget(
             label="Image", annotation="napari.layers.Image"
         )
+        # append the child widget to the container
+        self.append(self._image_layer_combo)
+
+
 ```
 
 Here's a complete example:


### PR DESCRIPTION
# References and relevant issues
No pre-existing issue

# Description
Fixes Image Annotation example located in the "Creating widgets" documentation in the "Annotating as a Layer subclass" section. This PR adds the missing `append()` method to properly bind the widget to the container.

<!-- Previewing the Documentation Build
When you submit this PR, jobs that preview the documentation will be kicked off.
By default, they will use the `slimfast` build (`make` target), which is fast, because
it doesn't build any content from outside the `docs` repository and doesn't run notebook cells.
You can trigger other builds by commenting on the PR with:

@napari-bot make <target>

where <target> can be:
html : a full build, just like the deployment to napari.org
html-noplot : a full build, but without the gallery examples from `napari/napari`
docs : only the content from `napari/docs`, with notebook code cells executed
slimfast : the default, only the content from `napari/docs`, without code cell execution
slimgallery : `slimfast`, but with the gallery examples from `napari/napari` built
-->

<!-- Final Checklist
- If images included: I have added [alt text](https://webaim.org/techniques/alttext/)
If workflow, documentation build or deployment change:
- My PR is the minimum possible work for the desired functionality
- I have commented my code, to let others know what it does
-->