### PR TITLE
Add website colors to community resources

### DIFF
--- a/docs/community/resources.md
+++ b/docs/community/resources.md
@@ -32,3 +32,13 @@ Below are several versions of the napari logo that you can use in your docs or p
         </th>
     </tr>
 </table>
+
+## Website colors
+
+Below is the list of colors used in the napari website. 
+
+- primary blue: #80d1ff
+- deep blue: #009bf2
+- light blue: #d2efff
+- dark gray: #686868
+- gray: #f7f7f7


### PR DESCRIPTION
# References and relevant issues
Closes #775 

# Description
This adds all of the Napari's color themes from the website to the community resources.

<!-- Previewing the Documentation Build
When you submit this PR, jobs that preview the documentation will be kicked off.
By default, they will use the `slimfast` build (`make` target), which is fast, because
it doesn't build any content from outside the `docs` repository and doesn't run notebook cells.
You can trigger other builds by commenting on the PR with:

@napari-bot make <target>

where <target> can be:
html : a full build, just like the deployment to napari.org
html-noplot : a full build, but without the gallery examples from `napari/napari`
docs : only the content from `napari/docs`, with notebook code cells executed
slimfast : the default, only the content from `napari/docs`, without code cell execution
slimgallery : `slimfast`, but with the gallery examples from `napari/napari` built
-->

<!-- Final Checklist
- If images included: I have added [alt text](https://webaim.org/techniques/alttext/)
If workflow, documentation build or deployment change:
- My PR is the minimum possible work for the desired functionality
- I have commented my code, to let others know what it does
-->
