### PR TITLE
Group event docs in order

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -63,8 +63,6 @@ subtrees:
       - file: guides/index
         subtrees:
         - entries:
-          - file: guides/event_loop
-          - file: guides/threading
           - file: guides/3D_interactivity
           - file: guides/handedness
           - file: guides/triangulation
@@ -72,6 +70,8 @@ subtrees:
           - file: guides/performance
           - file: guides/preferences
           - file: guides/contexts_expressions
+          - file: guides/event_loop
+          - file: guides/threading
           - file: guides/events_reference
       - file: further-resources/glossary
       - file: further-resources/napari-workshops


### PR DESCRIPTION
# References and relevant issues

Partially addresses #785.

# Description

This PR groups event related docs to be in order so that they are easier to discover.

No content is changed in this PR.

FYI @ian-coccimiglio 