### PR TITLE
Add introductory paragraph to starting an event loop api doc

### DIFF
--- a/docs/api/event_loop.rst
+++ b/docs/api/event_loop.rst
@@ -1,6 +1,10 @@
 Starting the Event Loop
 -----------------------
 
+The `napari` module provides a function `run` to start the user interface's event loop.
+Currently, napari's user interface uses the Qt library.
+See the [event loop guide](intro-to-event-loop) for an explanation of the event loop's purpose and operation.
+
 .. autosummary::
 
    napari.run

--- a/docs/api/event_loop.rst
+++ b/docs/api/event_loop.rst
@@ -3,7 +3,7 @@ Starting the Event Loop
 
 The `napari` module provides a function `run` to start the user interface's event loop.
 Currently, napari's user interface uses the Qt library.
-See the :ref:`event loop guide <intro-to-event-loop>` for an explanation ofe the event loop's purpose and operation.
+See the :ref:`event loop guide <intro-to-event-loop>` for an explanation of the event loop's purpose and operation.
 
 .. autosummary::
 

--- a/docs/api/event_loop.rst
+++ b/docs/api/event_loop.rst
@@ -3,7 +3,7 @@ Starting the Event Loop
 
 The `napari` module provides a function `run` to start the user interface's event loop.
 Currently, napari's user interface uses the Qt library.
-See the [event loop guide](intro-to-event-loop) for an explanation of the event loop's purpose and operation.
+See the :ref:`event loop guide <intro-to-event-loop>` for an explanation ofe the event loop's purpose and operation.
 
 .. autosummary::
 


### PR DESCRIPTION
# References and relevant issues

Partially addresses #785

# Description

This adds a brief paragraph giving more context on `napari.run` for starting the event loop.

cc/ @ian-coccimiglio 