### PR TITLE
Update title of event loop api page for discoverability of napari.run

### DIFF
--- a/docs/api/event_loop.rst
+++ b/docs/api/event_loop.rst
@@ -1,5 +1,5 @@
-Starting the Event Loop
------------------------
+napari.run() - Start the Event Loop
+-----------------------------------
 
 The `napari` module provides a function `run` to start the user interface's event loop.
 Currently, napari's user interface uses the Qt library.


### PR DESCRIPTION
Update the page title per Tim's suggestion.

Follow-up to #797. Related to #785.
