### PR TITLE
Remove announcement banner

### DIFF
--- a/docs/_static/announcement.html
+++ b/docs/_static/announcement.html
@@ -1,8 +1,11 @@
 <!-- This will appear in the announcement banner at the top of the site.
 It needs to be activated by passing the link:
-"https://raw.githubusercontent.com/napari/docs/main/docs/_templates/announcement.html",
+"https://napari.org/dev/_static/announcement.html",
 in the html_theme_options section of conf.py using the key:
 "announcement"
+
+This file MUST live in the _static directory to allow for dynamic updates
+without a full site rebuild.
 -->
 <div class="sidebar-message">
     Need help? <a href="https://napari.zulipchat.com">Chat with us</a> or join us at one of our <a href="https://napari.org/stable/community/meeting_schedule.html">Community meetings</a>!

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,9 +71,6 @@ html_theme = "napari_sphinx_theme"
 html_title = "napari"
 html_sourcelink_suffix = ""
 
-# Define the json_url for our version switcher.
-json_url = "https://napari.org/dev/_static/version_switcher.json"
-
 # Check version and set version_match which is used by the version switcher
 if version == "dev":
     version_match = "dev"
@@ -131,7 +128,7 @@ html_theme_options = {
     "secondary_sidebar_items": ["page-toc"],
     "pygments_light_style": "napari",
     "pygments_dark_style": "napari",
-    "announcement": "https://raw.githubusercontent.com/napari/docs/refs/heads/main/docs/_templates/announcement.html",
+    "announcement": "",
     "back_to_top_button": False,
     "analytics": {
         # The domain you'd like to use for this analytics instance


### PR DESCRIPTION
# References and relevant issues
Related to #807 and #801

# Description

Deactivates the announcement banner and moves the template back to _static.

The reason the templates needs to live in _static is that we want to be able to do updates to the banner without rebuilding the full docs site (see https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/announcements.html#update-or-remove-announcement-banner)

Also remove redundant logic for the version switcher.