### PR TITLE
Update codespell config and minor corrections

### DIFF
--- a/.codespell/ignore-words.txt
+++ b/.codespell/ignore-words.txt
@@ -1,0 +1,5 @@
+nd
+recuse
+Ganes
+Tru
+Tung

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,7 +1,4 @@
 [codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = .git*,*.svg,*.css,.codespellrc,*.ai
-check-hidden = true
-# lines with é -- non-English; names
-ignore-regex = (.*[àéç].*|\b(Tung|Tru|Ganes)\b)
-ignore-words-list = nd,ontop,recuse
+skip = *.ai,*.css,*.ipynb,*.py,*.svg,.git*,./ruff_cache/,./.venv_*,gallery,.codespellrc,EULA.md
+ignore-words = .codespell/ignore-words.txt

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean clean-gallery clean-prep clean-full
+.PHONY: clean clean-gallery clean-prep clean-full spellcheck
 
 SPHINXOPTS =
 
@@ -83,7 +83,7 @@ html-noplot: clean prep-docs
 # does run notebook cells
 # will not remove existing gallery files
 docs: clean prep-stubs
-	NAPARI_APPLICATION_IPY_INTERACTIVE=0 sphinx-build -M html docs/ docs/_build -WT --keep-going -D plot_gallery=0 -D sphinx_gallery_conf.examples_dirs=$(GALLERY_PATH) $(SPHINXOPTS) 
+	NAPARI_APPLICATION_IPY_INTERACTIVE=0 sphinx-build -M html docs/ docs/_build -WT --keep-going -D plot_gallery=0 -D sphinx_gallery_conf.examples_dirs=$(GALLERY_PATH) $(SPHINXOPTS)
 
 # live variant of `docs`
 docs-live: prep-stubs
@@ -209,3 +209,6 @@ fallback-videos:
 
 fallback-videos-clean:
 	rm -f docs/_static/images/*.mp4
+
+spellcheck:
+	pre-commit run --all-files codespell

--- a/docs/roadmaps/0_4.md
+++ b/docs/roadmaps/0_4.md
@@ -12,7 +12,7 @@ The [mission](our-mission) of napari is to be a foundational multi-dimensional i
 
 - Add accessible **documentation**, tutorials, and demos.
 
-You can read more about how this roadmap builds on and continues the work in our `0.3` series of releases in our [0.3 retrospective](https://napari.org/roadmaps/0_3_retrospective.html). We're continuing to prioritize the robustness and polish of the core viewer to ensure that plugin development happens against a solid foundation, and because we believe that looking at and annotating your data should be a bug free and delighful experience, regardless of how large it is. We want to build on the success of our reader / writer plugins to provide the ability to add functional and interactive plugins and further empower a lot of the great work being built ontop of napari.
+You can read more about how this roadmap builds on and continues the work in our `0.3` series of releases in our [0.3 retrospective](https://napari.org/roadmaps/0_3_retrospective.html). We're continuing to prioritize the robustness and polish of the core viewer to ensure that plugin development happens against a solid foundation, and because we believe that looking at and annotating your data should be a bug free and delighful experience, regardless of how large it is. We want to build on the success of our reader / writer plugins to provide the ability to add functional and interactive plugins and further empower a lot of the great work being built on top of napari.
 
 ## Make the data viewing and annotation capabilities bug-free, fast, and delightful to use
 


### PR DESCRIPTION
# References and relevant issues

Make more consistent with Scientific Python recommended practice:
https://learn.scientific-python.org/development/guides/style/#spelling

# Description

This PR simplifies the codespell configuration to be more explicit. It adds `make spelling` option for easier testing in development. It adds an `ignore-words.txt` since it is more readable than the regex in the current config. It skips some additional files and folders.