### PR TITLE
064 notes

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -82,6 +82,7 @@ subtrees:
       - file: release/index
         subtrees:
         - entries:
+          - file: release/release_0_6_4
           - file: release/release_0_6_3
           - file: release/release_0_6_2
           - file: release/release_0_6_1

--- a/docs/release/release_0_6_4.md
+++ b/docs/release/release_0_6_4.md
@@ -45,7 +45,7 @@ As a follow-up to the ability to drag-n-drop scripts into the napari window from
 - [pre-commit.ci] pre-commit autoupdate ([#8204](https://github.com/napari/napari/pull/8204))
 - Pin `pytest-qt` for python 3.10 to fix pyapp-kit projects tests ([#8205](https://github.com/napari/napari/pull/8205))
 - Retry second fullscreen test ([#8206](https://github.com/napari/napari/pull/8206))
-- Fix script for checking for updated dependecies. ([#8207](https://github.com/napari/napari/pull/8207))
+- Fix script for checking for updated dependencies. ([#8207](https://github.com/napari/napari/pull/8207))
 - Update Version Switcher to 0.6.3 ([docs#808](https://github.com/napari/docs/pull/808))
 - ci(dependabot): bump napari/napari from 0.6.2 to 0.6.3 in the github-actions group ([docs#810](https://github.com/napari/docs/pull/810))
 

--- a/docs/release/release_0_6_4.md
+++ b/docs/release/release_0_6_4.md
@@ -21,7 +21,7 @@ If you have `uv` you can even run a script without installing napari by using `u
 
 ### Toggling the napari console now places focus on the console
 
-Toggling the napari console (with the keyboard (`Cmd/Ctrl+Shift+C`), GUI, or command pallete) will now transfer focus on the console, allowing you to immediately start typing commands without needing to click into the console first ([#8182](https://github.com/napari/napari/pull/8182)). We have found this to be a very useful feature for a keyboard-centric workflow combining the power of the command palette and console together.
+Toggling the napari console (with the keyboard (`Cmd/Ctrl+Shift+C`), GUI, or command pallete) will now transfer focus on the console, allowing you to immediately start typing commands without needing to click into the console first ([#8182](https://github.com/napari/napari/pull/8182)). We have found this to be a very useful feature for a keyboard-centric workflow combining the power of the command pallete and console together.
 
 ## Improvements
 

--- a/docs/release/release_0_6_4.md
+++ b/docs/release/release_0_6_4.md
@@ -1,6 +1,6 @@
 # napari 0.6.4
 
-*Fri, Aug 15, 2025*
+*Sat, Aug 16, 2025*
 
 We’re happy to announce the release of napari 0.6.4!
 
@@ -12,16 +12,26 @@ For more information, examples, and documentation, please visit our website: htt
 
 ### Run scripts with napari from the command line
 
-As a follow-up to the ability to drag-n-drop scripts into the napari window from 0.6.3, you can now run scripts directly from the command line using the `napari` command and the path to the script ([#8185](https://github.com/napari/napari/pull/8185) and [#8187](https://github.com/napari/napari/pull/8187)). For example `napari examples/magic_immage_arithmetic.py` will open napari and run the local script.
+As a follow-up to the ability to drag-n-drop scripts into the napari window from 0.6.3, you can now run scripts directly from the command line using the `napari` command and the path to the script ([#8185](https://github.com/napari/napari/pull/8185) and [#8187](https://github.com/napari/napari/pull/8187)).
+`napari examples/magic_immage_arithmetic.py` will open a local napari and run the local script.
+You can also run scripts from a remote location ([#8208](https://github.com/napari/napari/pull/8208)), including Github, Gist, Gitlab, and the napari gallery.
+For example, you can run `napari https://github.com/napari/napari/blob/main/examples/grid_mode.py`.
+If you have `uv` you can even run a script without installing napari by using `uvx --with "napari[gallery,all]" napari https://napari.org/stable/_downloads/55f878f7d41dc4c7c2e28483653273cb/affine_coffee_cup.py`, serving as a clever way to trial napari or share your script. As always with remote connections, only use this feature with scripts you trust.
+
+### Toggling the napari console now places focus on the console
+
+Toggling the napari console (with the keyboard (`Cmd/Ctrl+Shift+C`), GUI, or command pallete) will now transfer focus on the console, allowing you to immediately start typing commands without needing to click into the console first ([#8182](https://github.com/napari/napari/pull/8182)). We have found this to be a very useful feature for a keyboard-centric workflow combining the power of the command palette and console together.
 
 ## Improvements
 
 - Remove old path handle in napari start ([#8185](https://github.com/napari/napari/pull/8185))
 - Prevent `napari.run` from being executed when running scripts from napari ([#8187](https://github.com/napari/napari/pull/8187))
+- Add option to load script from a remote location ([#8208](https://github.com/napari/napari/pull/8208))
 
 ## Bug Fixes
 
 - Set focus after toggling dockwidget via `DockWidgetToggleAction` ([#8182](https://github.com/napari/napari/pull/8182))
+- Fix slider label shifted down, by overrwite QLineEdit qss rules ([#8184](https://github.com/napari/napari/pull/8184))
 - Fix feature table widget sorting and editing of floats ([#8190](https://github.com/napari/napari/pull/8190))
 - Add check if selected label is out of data range. ([#8202](https://github.com/napari/napari/pull/8202))
 - Explicit copy of layers data for balls example ([#8203](https://github.com/napari/napari/pull/8203))
@@ -29,16 +39,14 @@ As a follow-up to the ability to drag-n-drop scripts into the napari window from
 ## Documentation
 
 - Reorganize bundle instructions page to make it easier to navigate and provide download links ([docs#813](https://github.com/napari/docs/pull/813))
-- Simplify installation guide & better highlight bundle ([docs#814](https://github.com/napari/docs/pull/814))
 - Update codespell config and minor corrections ([docs#816](https://github.com/napari/docs/pull/816))
 - Add contracted roles to team page and rename core dev -> core TM ([docs#817](https://github.com/napari/docs/pull/817))
 - Pre-release notes for 0.6.4 ([docs#820](https://github.com/napari/docs/pull/820))
+- Final 0.6.4 Release Notes ([docs#822](https://github.com/napari/docs/pull/822))
 
 ## Other Pull Requests
 
 - Pin Github Actions actions to their hashes ([#8140](https://github.com/napari/napari/pull/8140))
-- Move test that requires `make_napari_viewer` from `test_qt_viewer` ([#8176](https://github.com/napari/napari/pull/8176))
-- Fix slider label shifted down, by overrwite QLineEdit qss rules ([#8184](https://github.com/napari/napari/pull/8184))
 - [pre-commit.ci] pre-commit autoupdate ([#8193](https://github.com/napari/napari/pull/8193))
 - Fix fallback version in setuptools_scm to pass schema validation ([#8196](https://github.com/napari/napari/pull/8196))
 - Use napari url for test rather than Fiji ([#8198](https://github.com/napari/napari/pull/8198))
@@ -46,9 +54,7 @@ As a follow-up to the ability to drag-n-drop scripts into the napari window from
 - Pin `pytest-qt` for python 3.10 to fix pyapp-kit projects tests ([#8205](https://github.com/napari/napari/pull/8205))
 - Retry second fullscreen test ([#8206](https://github.com/napari/napari/pull/8206))
 - Fix script for checking for updated dependencies. ([#8207](https://github.com/napari/napari/pull/8207))
-- Add option to load script from a remote location ([#8208](https://github.com/napari/napari/pull/8208))
 - Update `certifi`, `coverage`, `hypothesis`, `matplotlib`, `psygnal`, `pytest-rerunfailures`, `rich`, `scipy`, `superqt`, `virtualenv`, `wrapt` ([#8209](https://github.com/napari/napari/pull/8209))
-- Bump `superqt` min version ([#8212](https://github.com/napari/napari/pull/8212))
 - Update Version Switcher to 0.6.3 ([docs#808](https://github.com/napari/docs/pull/808))
 - ci(dependabot): bump napari/napari from 0.6.2 to 0.6.3 in the github-actions group ([docs#810](https://github.com/napari/docs/pull/810))
 

--- a/docs/release/release_0_6_4.md
+++ b/docs/release/release_0_6_4.md
@@ -21,7 +21,7 @@ If you have `uv` you can even run a script without installing napari by using `u
 
 ### Toggling the napari console now places focus on the console
 
-Toggling the napari console (with the keyboard (`Cmd/Ctrl+Shift+C`), GUI, or command pallete) will now transfer focus on the console, allowing you to immediately start typing commands without needing to click into the console first ([#8182](https://github.com/napari/napari/pull/8182)). We have found this to be a very useful feature for a keyboard-centric workflow combining the power of the command pallete and console together.
+Toggling the napari console (with the keyboard (`Cmd/Ctrl+Shift+C`), GUI, or command palette) will now transfer focus on the console, allowing you to immediately start typing commands without needing to click into the console first ([#8182](https://github.com/napari/napari/pull/8182)). We have found this to be a very useful feature for a keyboard-centric workflow combining the power of the command palette and console together.
 
 ## Improvements
 

--- a/docs/release/release_0_6_4.md
+++ b/docs/release/release_0_6_4.md
@@ -20,7 +20,7 @@ If you have `uv` you can even run a script without installing napari by using `u
 
 ### Toggling the napari console now places focus on the console
 
-Toggling the napari console (with the keyboard (`Cmd/Ctrl+Shift+C`), GUI, or command pallete) will now transfer focus on the console, allowing you to immediately start typing commands without needing to click into the console first ([#8182](https://github.com/napari/napari/pull/8182)). We have found this to be a very useful feature for a keyboard-centric workflow combining the power of the command palette and console together.
+Toggling the napari console (with the keyboard (`Cmd/Ctrl+Shift+C`), GUI, or command palette) will now transfer focus on the console, allowing you to immediately start typing commands without needing to click into the console first ([#8182](https://github.com/napari/napari/pull/8182)). We have found this to be a very useful feature for a keyboard-centric workflow combining the power of the command palette and console together.
 
 ## Improvements
 

--- a/docs/release/release_0_6_4.md
+++ b/docs/release/release_0_6_4.md
@@ -1,7 +1,6 @@
 # napari 0.6.4
-⚠️ *Note: these release notes are still in draft while 0.6.4 is in release candidate testing.* ⚠️
 
-*Fri, Aug 15, 2025*
+*Sat, Aug 16, 2025*
 
 We’re happy to announce the release of napari 0.6.4!
 
@@ -14,9 +13,9 @@ For more information, examples, and documentation, please visit our website: htt
 ### Run scripts with napari from the command line
 
 As a follow-up to the ability to drag-n-drop scripts into the napari window from 0.6.3, you can now run scripts directly from the command line using the `napari` command and the path to the script ([#8185](https://github.com/napari/napari/pull/8185) and [#8187](https://github.com/napari/napari/pull/8187)).
-`napari examples/magic_immage_arithmetic.py` will open a local napari and run the local script.
+To open a local napari and run a local script, enter: `napari examples/magic_immage_arithmetic.py`.
 You can also run scripts from a remote location ([#8208](https://github.com/napari/napari/pull/8208)), including Github, Gist, Gitlab, and the napari gallery.
-For example, you can run `napari https://github.com/napari/napari/blob/main/examples/grid_mode.py`.
+To run a remote script, for example, enter: `napari https://github.com/napari/napari/blob/main/examples/grid_mode.py`.
 If you have `uv` you can even run a script without installing napari by using `uvx --with "napari[gallery,all]" napari https://napari.org/stable/_downloads/55f878f7d41dc4c7c2e28483653273cb/affine_coffee_cup.py`, serving as a clever way to trial napari or share your script. As always with remote connections, only use this feature with scripts you trust.
 
 ### Toggling the napari console now places focus on the console

--- a/docs/release/release_0_6_4.md
+++ b/docs/release/release_0_6_4.md
@@ -1,0 +1,78 @@
+# napari 0.6.4
+⚠️ *Note: these release notes are still in draft while 0.6.4 is in release candidate testing.* ⚠️
+
+*Tue, Aug 12, 2025*
+
+We’re happy to announce the release of napari 0.6.4!
+
+napari is a fast, interactive, multi-dimensional image viewer for Python. It’s designed for exploring, annotating, and analyzing multi-dimensional images. It’s built on Qt (for the GUI), VisPy (for performant GPU-based rendering), and the scientific Python stack (NumPy, SciPy, and friends).
+
+For more information, examples, and documentation, please visit our website: https://napari.org/
+
+## Highlights
+
+### Run scripts with napari from the command line
+
+As a follow-up to the ability to drag-n-drop scripts into the napari window from 0.6.3, you can now run scripts directly from the command line using the `napari` command and the path to the script ([#8185](https://github.com/napari/napari/pull/8185) and [#8187](https://github.com/napari/napari/pull/8187)). For example `napari examples/magic_immage_arithmetic.py` will open napari and run the local script.
+
+
+## Improvements
+
+- Remove old path handle in napari start ([#8185](https://github.com/napari/napari/pull/8185))
+- Prevent `napari.run` from being executed when running scripts from napari ([#8187](https://github.com/napari/napari/pull/8187))
+
+## Bug Fixes
+
+- Set focus after toggling dockwidget via `DockWidgetToggleAction` ([#8182](https://github.com/napari/napari/pull/8182))
+- Fix feature table widget sorting and editing of floats ([#8190](https://github.com/napari/napari/pull/8190))
+- Explicit copy of layers data for balls example ([#8203](https://github.com/napari/napari/pull/8203))
+
+## Documentation
+
+- Reorganize bundle instructions page to make it easier to navigate and provide download links ([docs#813](https://github.com/napari/docs/pull/813))
+- Simplify installation guide & better highlight bundle ([docs#814](https://github.com/napari/docs/pull/814))
+- Update codespell config and minor corrections ([docs#816](https://github.com/napari/docs/pull/816))
+- Add contracted roles to team page and rename core dev -> core TM ([docs#817](https://github.com/napari/docs/pull/817))
+
+## Other Pull Requests
+
+- Pin Github Actions actions to their hashes ([#8140](https://github.com/napari/napari/pull/8140))
+- Move test that requires `make_napari_viewer` from `test_qt_viewer` ([#8176](https://github.com/napari/napari/pull/8176))
+- Fix slider label shifted down, by overrwite QLineEdit qss rules ([#8184](https://github.com/napari/napari/pull/8184))
+- [pre-commit.ci] pre-commit autoupdate ([#8193](https://github.com/napari/napari/pull/8193))
+- Fix fallback version in setuptools_scm to pass schema validation ([#8196](https://github.com/napari/napari/pull/8196))
+- Use napari url for test rather than Fiji ([#8198](https://github.com/napari/napari/pull/8198))
+- [pre-commit.ci] pre-commit autoupdate ([#8204](https://github.com/napari/napari/pull/8204))
+- Pin `pytest-qt` for python 3.10 to fix pyapp-kit projects tests ([#8205](https://github.com/napari/napari/pull/8205))
+- Retry second fullscreen test ([#8206](https://github.com/napari/napari/pull/8206))
+- Fix script for checking for updated dependecies. ([#8207](https://github.com/napari/napari/pull/8207))
+- Update Version Switcher to 0.6.3 ([docs#808](https://github.com/napari/docs/pull/808))
+- ci(dependabot): bump napari/napari from 0.6.2 to 0.6.3 in the github-actions group ([docs#810](https://github.com/napari/docs/pull/810))
+
+
+## 8 authors added to this release (alphabetical)
+
+(+) denotes first-time contributors 🥳
+
+- [Carol Willing](https://github.com/napari/docs/commits?author=willingc) - @willingc
+- [Daniel Althviz Moré](https://github.com/napari/napari/commits?author=dalthviz) - @dalthviz
+- [Draga Doncila Pop](https://github.com/napari/docs/commits?author=DragaDoncila) - @DragaDoncila
+- [Grzegorz Bokota](https://github.com/napari/napari/commits?author=Czaki) - @Czaki
+- [jaime rodraguez-guerra](https://github.com/napari/napari/commits?author=jaimergp) - @jaimergp
+- [Lorenzo Gaifas](https://github.com/napari/napari/commits?author=brisvag) - @brisvag
+- [Peter Sobolewski](https://github.com/napari/docs/commits?author=psobolewskiPhD) - @psobolewskiPhD
+- [Tim Monko](https://github.com/napari/napari/commits?author=TimMonko) ([docs](https://github.com/napari/docs/commits?author=TimMonko))  - @TimMonko
+
+
+## 7 reviewers added to this release (alphabetical)
+
+(+) denotes first-time contributors 🥳
+
+- [Carol Willing](https://github.com/napari/docs/commits?author=willingc) - @willingc
+- [Grzegorz Bokota](https://github.com/napari/napari/commits?author=Czaki) - @Czaki
+- [Juan Nunez-Iglesias](https://github.com/napari/docs/commits?author=jni) - @jni
+- [Lorenzo Gaifas](https://github.com/napari/napari/commits?author=brisvag) - @brisvag
+- [Melissa Weber Mendonça](https://github.com/napari/docs/commits?author=melissawm) - @melissawm
+- [Peter Sobolewski](https://github.com/napari/docs/commits?author=psobolewskiPhD) - @psobolewskiPhD
+- [Tim Monko](https://github.com/napari/napari/commits?author=TimMonko) ([docs](https://github.com/napari/docs/commits?author=TimMonko))  - @TimMonko
+

--- a/docs/release/release_0_6_4.md
+++ b/docs/release/release_0_6_4.md
@@ -1,6 +1,7 @@
 # napari 0.6.4
+⚠️ *Note: these release notes are still in draft while 0.6.4 is in release candidate testing.* ⚠️
 
-*Sat, Aug 16, 2025*
+*Fri, Aug 15, 2025*
 
 We’re happy to announce the release of napari 0.6.4!
 
@@ -20,7 +21,7 @@ If you have `uv` you can even run a script without installing napari by using `u
 
 ### Toggling the napari console now places focus on the console
 
-Toggling the napari console (with the keyboard (`Cmd/Ctrl+Shift+C`), GUI, or command palette) will now transfer focus on the console, allowing you to immediately start typing commands without needing to click into the console first ([#8182](https://github.com/napari/napari/pull/8182)). We have found this to be a very useful feature for a keyboard-centric workflow combining the power of the command palette and console together.
+Toggling the napari console (with the keyboard (`Cmd/Ctrl+Shift+C`), GUI, or command pallete) will now transfer focus on the console, allowing you to immediately start typing commands without needing to click into the console first ([#8182](https://github.com/napari/napari/pull/8182)). We have found this to be a very useful feature for a keyboard-centric workflow combining the power of the command palette and console together.
 
 ## Improvements
 
@@ -39,6 +40,7 @@ Toggling the napari console (with the keyboard (`Cmd/Ctrl+Shift+C`), GUI, or com
 ## Documentation
 
 - Reorganize bundle instructions page to make it easier to navigate and provide download links ([docs#813](https://github.com/napari/docs/pull/813))
+- Simplify installation guide & better highlight bundle ([docs#814](https://github.com/napari/docs/pull/814))
 - Update codespell config and minor corrections ([docs#816](https://github.com/napari/docs/pull/816))
 - Add contracted roles to team page and rename core dev -> core TM ([docs#817](https://github.com/napari/docs/pull/817))
 - Pre-release notes for 0.6.4 ([docs#820](https://github.com/napari/docs/pull/820))

--- a/docs/release/release_0_6_4.md
+++ b/docs/release/release_0_6_4.md
@@ -1,7 +1,6 @@
 # napari 0.6.4
-⚠️ *Note: these release notes are still in draft while 0.6.4 is in release candidate testing.* ⚠️
 
-*Tue, Aug 12, 2025*
+*Fri, Aug 15, 2025*
 
 We’re happy to announce the release of napari 0.6.4!
 
@@ -15,7 +14,6 @@ For more information, examples, and documentation, please visit our website: htt
 
 As a follow-up to the ability to drag-n-drop scripts into the napari window from 0.6.3, you can now run scripts directly from the command line using the `napari` command and the path to the script ([#8185](https://github.com/napari/napari/pull/8185) and [#8187](https://github.com/napari/napari/pull/8187)). For example `napari examples/magic_immage_arithmetic.py` will open napari and run the local script.
 
-
 ## Improvements
 
 - Remove old path handle in napari start ([#8185](https://github.com/napari/napari/pull/8185))
@@ -25,6 +23,7 @@ As a follow-up to the ability to drag-n-drop scripts into the napari window from
 
 - Set focus after toggling dockwidget via `DockWidgetToggleAction` ([#8182](https://github.com/napari/napari/pull/8182))
 - Fix feature table widget sorting and editing of floats ([#8190](https://github.com/napari/napari/pull/8190))
+- Add check if selected label is out of data range. ([#8202](https://github.com/napari/napari/pull/8202))
 - Explicit copy of layers data for balls example ([#8203](https://github.com/napari/napari/pull/8203))
 
 ## Documentation
@@ -33,6 +32,7 @@ As a follow-up to the ability to drag-n-drop scripts into the napari window from
 - Simplify installation guide & better highlight bundle ([docs#814](https://github.com/napari/docs/pull/814))
 - Update codespell config and minor corrections ([docs#816](https://github.com/napari/docs/pull/816))
 - Add contracted roles to team page and rename core dev -> core TM ([docs#817](https://github.com/napari/docs/pull/817))
+- Pre-release notes for 0.6.4 ([docs#820](https://github.com/napari/docs/pull/820))
 
 ## Other Pull Requests
 
@@ -46,6 +46,9 @@ As a follow-up to the ability to drag-n-drop scripts into the napari window from
 - Pin `pytest-qt` for python 3.10 to fix pyapp-kit projects tests ([#8205](https://github.com/napari/napari/pull/8205))
 - Retry second fullscreen test ([#8206](https://github.com/napari/napari/pull/8206))
 - Fix script for checking for updated dependencies. ([#8207](https://github.com/napari/napari/pull/8207))
+- Add option to load script from a remote location ([#8208](https://github.com/napari/napari/pull/8208))
+- Update `certifi`, `coverage`, `hypothesis`, `matplotlib`, `psygnal`, `pytest-rerunfailures`, `rich`, `scipy`, `superqt`, `virtualenv`, `wrapt` ([#8209](https://github.com/napari/napari/pull/8209))
+- Bump `superqt` min version ([#8212](https://github.com/napari/napari/pull/8212))
 - Update Version Switcher to 0.6.3 ([docs#808](https://github.com/napari/docs/pull/808))
 - ci(dependabot): bump napari/napari from 0.6.2 to 0.6.3 in the github-actions group ([docs#810](https://github.com/napari/docs/pull/810))
 
@@ -64,11 +67,12 @@ As a follow-up to the ability to drag-n-drop scripts into the napari window from
 - [Tim Monko](https://github.com/napari/napari/commits?author=TimMonko) ([docs](https://github.com/napari/docs/commits?author=TimMonko))  - @TimMonko
 
 
-## 7 reviewers added to this release (alphabetical)
+## 8 reviewers added to this release (alphabetical)
 
 (+) denotes first-time contributors 🥳
 
 - [Carol Willing](https://github.com/napari/docs/commits?author=willingc) - @willingc
+- [Draga Doncila Pop](https://github.com/napari/docs/commits?author=DragaDoncila) - @DragaDoncila
 - [Grzegorz Bokota](https://github.com/napari/napari/commits?author=Czaki) - @Czaki
 - [Juan Nunez-Iglesias](https://github.com/napari/docs/commits?author=jni) - @jni
 - [Lorenzo Gaifas](https://github.com/napari/napari/commits?author=brisvag) - @brisvag


### PR DESCRIPTION
# References and relevant issues
<!-- What relevant resources were used in the creation of this PR?
If this PR addresses an existing issue on the repo,
please link to that issue here as "Closes #(issue-number)".
If this PR adds docs for a napari PR please add a "Depends on <napari PR link>" -->

# Description
<!-- What does this pull request (PR) do? Does it add new content, improve/fix existing
context, improve/fix workflow/documentation build/deployment or something else?
<!-- If relevant, please include a screenshot or a screen capture in your content
change: "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations. -->
<!-- You can also see a preview of the documentation changes you are submitting by
clicking on "Details" to the right of the "Check the rendered docs here!" check on your PR.-->

<!-- Previewing the Documentation Build
When you submit this PR, jobs that preview the documentation will be kicked off.
By default, they will use the `slimfast` build (`make` target), which is fast, because
it doesn't build any content from outside the `docs` repository and doesn't run notebook cells.
You can trigger other builds by commenting on the PR with:

@napari-bot make <target>

where <target> can be:
html : a full build, just like the deployment to napari.org
html-noplot : a full build, but without the gallery examples from `napari/napari`
docs : only the content from `napari/docs`, with notebook code cells executed
slimfast : the default, only the content from `napari/docs`, without code cell execution
slimgallery : `slimfast`, but with the gallery examples from `napari/napari` built
-->

<!-- Final Checklist
- If images included: I have added [alt text](https://webaim.org/techniques/alttext/)
If workflow, documentation build or deployment change:
- My PR is the minimum possible work for the desired functionality
- I have commented my code, to let others know what it does
-->
