### PR TITLE
Fix version switcher URL to prevent problems with unversioned pages

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,12 +74,14 @@ html_sourcelink_suffix = ""
 # Check version and set version_match which is used by the version switcher
 if version == "dev":
     version_match = "dev"
-    # Use the local json file in dev mode
-    json_url = "_static/version_switcher.json"
 else:
     version_match = str(release)
-    # Define the json_url for our version switcher.
-    json_url = "https://napari.org/dev/_static/version_switcher.json"
+
+# Define the json_url for our version switcher. When developing locally, you
+# can change this to match the local version i.e. "_static/version_switcher.json"
+# However, this must be the absolute URL for deployed versions. See
+# https://github.com/napari/napari.github.io/issues/427 for details.
+json_url = "https://napari.org/dev/_static/version_switcher.json"
 
 # Path to static files, images, favicons, logos, css, and extra templates
 html_static_path = ["_static"]


### PR DESCRIPTION
# References and relevant issues
Addresses https://github.com/napari/napari.github.io/issues/427

# Description
Because of this setting, the following happens:

- The latest (dev) version gets build by a PR to napari/napari or napari/docs;
- It is deployed to napari.github.io
- The unversioned action runs, copies over a few pages from the latest version into stable. These pages were built as "dev" so they point to a relative location of version_switcher.json

This relative location does not get updated in the future, and thus the version switcher used for this version of the pages is frozen to be the current version.

I tried adding a comment to explain this problem, hopefully this helps.