### PR TITLE
Add pooch cache for build docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,8 @@ jobs:
   build-docs:
     docker:
       - image: cimg/python:3.10.17
+    environment:
+      XDG_CACHE_HOME: /home/circleci/.cache
     parameters:
       # Set make target for the job
       make_target:
@@ -43,6 +45,9 @@ jobs:
     steps:
       - checkout:
           path: docs
+      - restore_cache:
+          keys:
+            - pooch
       - run:
           name: Clone main repo into a subdirectory
           command: git clone git@github.com:napari/napari.git napari
@@ -71,6 +76,12 @@ jobs:
             PIP_CONSTRAINT: ../napari/resources/constraints/constraints_py3.10_docs.txt
       - store_artifacts:
           path: docs/docs/_build/html/
+      - save_cache:
+          key: pooch
+          paths:
+            - ~/.cache/scikit-image
+            - ~/.cache/napari-*
+            - ~/.cache/pooch
       - persist_to_workspace:
           root: .
           paths:

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -28,6 +28,8 @@ jobs:
   build-and-upload:
     name: Build & Upload Artifact
     runs-on: ubuntu-latest
+    env:
+      XDG_CACHE_HOME: ${{ github.workspace }}/.cache
     steps:
       - name: Clone docs repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -49,6 +51,15 @@ jobs:
           python-version: "3.10"
           cache-dependency-path: |
             napari/pyproject.toml
+
+      - name: Cache pooch downloads
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
+        with:
+          path: |
+            ${{ github.workspace }}/.cache/scikit-image
+            ${{ github.workspace }}/.cache/napari-*
+            ${{ github.workspace }}/.cache/pooch
+          key: pooch
 
       - uses: tlambert03/setup-qt-libs@19e4ef2d781d81f5f067182e228b54ec90d23b76 # v1.8
 

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -31,6 +31,8 @@ jobs:
   build-and-upload:
     name: Build & Upload Artifact
     runs-on: ubuntu-latest
+    env:
+      XDG_CACHE_HOME: ${{ github.workspace }}/.cache
     steps:
       - name: Clone docs repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -54,6 +56,15 @@ jobs:
           python-version: "3.10"
           cache-dependency-path: |
             napari/pyproject.toml
+
+      - name: Cache pooch downloads
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
+        with:
+          path: |
+            ${{ github.workspace }}/.cache/scikit-image
+            ${{ github.workspace }}/.cache/napari-*
+            ${{ github.workspace }}/.cache/pooch
+          key: pooch
 
       - uses: tlambert03/setup-qt-libs@19e4ef2d781d81f5f067182e228b54ec90d23b76 # v1.8
 


### PR DESCRIPTION
# References and relevant issues

same as https://github.com/napari/napari/pull/8235

# Description

Add cache for resources required for CI. In docs we are using only Linux, so it will work for all workflows. 