### PR TITLE
Bump python to 3.12 for build docs workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ orbs:
 jobs:
   build-docs:
     docker:
-      - image: cimg/python:3.10.17
+      - image: cimg/python:3.12.6
     environment:
       XDG_CACHE_HOME: /home/circleci/.cache
     parameters:
@@ -65,7 +65,7 @@ jobs:
             . .venv/bin/activate
             uv pip install -e "napari/[pyqt5,docs]"
           environment:
-            PIP_CONSTRAINT: napari/resources/constraints/constraints_py3.10_docs.txt
+            PIP_CONSTRAINT: napari/resources/constraints/constraints_py3.12_docs.txt
       - run:
           name: Build docs
           command: |
@@ -73,7 +73,7 @@ jobs:
             cd docs
             xvfb-run --auto-servernum make << parameters.make_target >>
           environment:
-            PIP_CONSTRAINT: ../napari/resources/constraints/constraints_py3.10_docs.txt
+            PIP_CONSTRAINT: ../napari/resources/constraints/constraints_py3.12_docs.txt
       - store_artifacts:
           path: docs/docs/_build/html/
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ orbs:
 jobs:
   build-docs:
     docker:
-      - image: cimg/python:3.12.6
+      - image: cimg/python:3.12.11
     environment:
       XDG_CACHE_HOME: /home/circleci/.cache
     parameters:

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -103,6 +103,15 @@ jobs:
           name: html
           path: docs/docs/_build/html/
 
+      - name: Upload logs
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+
+        with:
+          name: Upload Logs
+          path: |
+            /tmp/*.log
+
   deploy:
     name: Download & Deploy Artifact
     needs: build-and-upload

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -61,7 +61,11 @@ jobs:
             ${{ github.workspace }}/.cache/pooch
           key: pooch
 
-      - uses: tlambert03/setup-qt-libs@19e4ef2d781d81f5f067182e228b54ec90d23b76 # v1.8
+      - name: Setup headless display
+        uses: pyvista/setup-headless-display-action@7d84ae825e6d9297a8e99bdbbae20d1b919a0b19 # v4.2
+        with:
+          qt: true
+          wm: herbstluftwm
 
       - name: Install Dependencies
         run: |
@@ -82,20 +86,11 @@ jobs:
           make fallback-videos
 
       - name: Build Docs
-        uses: aganders3/headless-gui@f85dd6316993505dfc5f21839d520ae440c84816 # v2.2
+        run:  make -C docs html
         env:
           GOOGLE_CALENDAR_ID: ${{ secrets.GOOGLE_CALENDAR_ID }}
           GOOGLE_CALENDAR_API_KEY: ${{ secrets.GOOGLE_CALENDAR_API_KEY }}
           PIP_CONSTRAINT: ${{ github.workspace }}/napari/resources/constraints/constraints_py3.12_docs.txt
-        with:
-          # Runs in '/home/runner/work/docs/docs/docs'
-          # Built HTML pages in '/home/runner/work/docs/docs/docs/docs/_build/html'
-          run:  make -C docs html
-          # skipping setup stops the action from running the default (tiling) window manager
-          # the window manager is not necessary for docs builds at this time and it was causing
-          # problems with screenshots (https://github.com/napari/docs/issues/285)
-          linux-setup: "echo 'skip setup'"
-          linux-teardown: "echo 'skip teardown'"
 
       - name: Upload artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -48,7 +48,7 @@ jobs:
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: "3.10"
+          python-version: "3.12"
           cache-dependency-path: |
             napari/pyproject.toml
 
@@ -68,7 +68,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install "napari/[pyqt5, docs]"
         env:
-          PIP_CONSTRAINT: ${{ github.workspace }}/napari/resources/constraints/constraints_py3.10_docs.txt
+          PIP_CONSTRAINT: ${{ github.workspace }}/napari/resources/constraints/constraints_py3.12_docs.txt
 
       - name: Testing
         run: |
@@ -86,7 +86,7 @@ jobs:
         env:
           GOOGLE_CALENDAR_ID: ${{ secrets.GOOGLE_CALENDAR_ID }}
           GOOGLE_CALENDAR_API_KEY: ${{ secrets.GOOGLE_CALENDAR_API_KEY }}
-          PIP_CONSTRAINT: ${{ github.workspace }}/napari/resources/constraints/constraints_py3.10_docs.txt
+          PIP_CONSTRAINT: ${{ github.workspace }}/napari/resources/constraints/constraints_py3.12_docs.txt
         with:
           # Runs in '/home/runner/work/docs/docs/docs'
           # Built HTML pages in '/home/runner/work/docs/docs/docs/docs/_build/html'

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -53,7 +53,7 @@ jobs:
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: "3.10"
+          python-version: "3.12"
           cache-dependency-path: |
             napari/pyproject.toml
 
@@ -73,7 +73,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install "napari/[pyqt5, docs]"
         env:
-          PIP_CONSTRAINT: ${{ github.workspace }}/napari/resources/constraints/constraints_py3.10_docs.txt
+          PIP_CONSTRAINT: ${{ github.workspace }}/napari/resources/constraints/constraints_py3.12_docs.txt
 
       - name: Check napari can be imported
         run: |
@@ -85,7 +85,7 @@ jobs:
         env:
           GOOGLE_CALENDAR_ID: ${{ secrets.GOOGLE_CALENDAR_ID }}
           GOOGLE_CALENDAR_API_KEY: ${{ secrets.GOOGLE_CALENDAR_API_KEY }}
-          PIP_CONSTRAINT: ${{ github.workspace }}/napari/resources/constraints/constraints_py3.10_docs.txt
+          PIP_CONSTRAINT: ${{ github.workspace }}/napari/resources/constraints/constraints_py3.12_docs.txt
         with:
           run: make -C docs ${{ inputs.make_target || 'slimfast' }}
           # skipping setup stops the action from running the default (tiling) window manager

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -66,7 +66,11 @@ jobs:
             ${{ github.workspace }}/.cache/pooch
           key: pooch
 
-      - uses: tlambert03/setup-qt-libs@19e4ef2d781d81f5f067182e228b54ec90d23b76 # v1.8
+      - name: Setup headless display
+        uses: pyvista/setup-headless-display-action@7d84ae825e6d9297a8e99bdbbae20d1b919a0b19 # v4.2
+        with:
+          qt: true
+          wm: herbstluftwm
 
       - name: Install Dependencies
         run: |
@@ -81,18 +85,11 @@ jobs:
           python -c 'import napari.layers; print(napari.layers.__doc__)'
 
       - name: Build Docs
-        uses: aganders3/headless-gui@f85dd6316993505dfc5f21839d520ae440c84816 # v2.2
+        run: make -C docs ${{ inputs.make_target || 'slimfast' }}
         env:
           GOOGLE_CALENDAR_ID: ${{ secrets.GOOGLE_CALENDAR_ID }}
           GOOGLE_CALENDAR_API_KEY: ${{ secrets.GOOGLE_CALENDAR_API_KEY }}
           PIP_CONSTRAINT: ${{ github.workspace }}/napari/resources/constraints/constraints_py3.12_docs.txt
-        with:
-          run: make -C docs ${{ inputs.make_target || 'slimfast' }}
-          # skipping setup stops the action from running the default (tiling) window manager
-          # the window manager is not necessary for docs builds at this time and it was causing
-          # problems with screenshots (https://github.com/napari/docs/issues/285)
-          linux-setup: "echo 'skip setup'"
-          linux-teardown: "echo 'skip teardown'"
 
       - name: Upload artifact
         id: upload
@@ -101,7 +98,7 @@ jobs:
         with:
           name: docs
           path: docs/docs/_build/html
-          
+
       - name: Upload logs
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -101,3 +101,12 @@ jobs:
         with:
           name: docs
           path: docs/docs/_build/html
+          
+      - name: Upload logs
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+
+        with:
+          name: Upload Logs
+          path: |
+            /tmp/*.log


### PR DESCRIPTION
# References and relevant issues


# Description

Follow the main repo and change from Python 3.10 to python 3.12 