### PR TITLE
Fix version switcher for 0.6.5

### DIFF
--- a/docs/_static/version_switcher.json
+++ b/docs/_static/version_switcher.json
@@ -14,7 +14,6 @@
         "name": "0.6.4",
         "version": "0.6.4",
         "url": "https://napari.org/0.6.4/",
-        "preferred": true
     },
     {
         "name": "0.6.3",


### PR DESCRIPTION
Removed the 'preferred' field from version 0.6.4 entry. Should move to 0.6.5 now
[#release > 0.6.5 @ 💬](https://napari.zulipchat.com/#narrow/channel/215289-release/topic/0.2E6.2E5/near/542785387)

Currently stable points back to 0.6.4. 
Symlink is correct.