### PR TITLE
Remove trailing comma in version switcher json

### DIFF
--- a/docs/_static/version_switcher.json
+++ b/docs/_static/version_switcher.json
@@ -13,7 +13,7 @@
     {
         "name": "0.6.4",
         "version": "0.6.4",
-        "url": "https://napari.org/0.6.4/",
+        "url": "https://napari.org/0.6.4/"
     },
     {
         "name": "0.6.3",


### PR DESCRIPTION
This was a syntax error in json and causing the version switcher to fail
altogether on the deployed site.
