### PR TITLE
Allow to redeploy docs after merge new commits to main branch

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -19,6 +19,14 @@ on:
         description: 'The directory to deploy the docs to'
         required: true
         default: 'dev'
+      napari_ref:
+        description: 'The napari/napari ref to build the docs against'
+        required: true
+        default: 'main'
+      docs_ref:
+        description: 'The napari/docs ref to build'
+        required: false
+        default: ''
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -31,9 +39,9 @@ jobs:
     secrets: inherit
     with:
       main-repo: "napari/napari"
-      main-ref: "main"
+      main-ref: ${{ github.event.inputs.napari_ref || 'main' }}
       docs-repo: ${{ github.repository }}
-      docs-ref: ${{ github.ref }}
+      docs-ref: ${{ github.event.inputs.docs_ref || github.ref }}
       make_target: "html"
 
   deploy:


### PR DESCRIPTION
# References and relevant issues

https://napari.zulipchat.com/#narrow/channel/215289-release/topic/0.2E6.2E6/near/545709087

# Description

This PR is to modify the build and deploy workflow to enforce the same results of docs build if restarting build docs after merging something to napari/napari@main.

Using the optional docs_ref argument, it is possible to rebuild older docs version.