### PR TITLE
Explain accessing dock widget wrappers

### DIFF
--- a/docs/plugins/advanced_topics/widget_communication.md
+++ b/docs/plugins/advanced_topics/widget_communication.md
@@ -30,7 +30,7 @@ dock_widget.raise_()
 
 ```{important}
 Do not use `viewer.window._dock_widgets` to access `QtViewerDockWidget`.
-This is a private API that may be removed in any release.
+This is a private API that will be removed soon.
 ```
 
 *The `dock_widgets` property was added in napari 0.6.2.*

--- a/docs/plugins/advanced_topics/widget_communication.md
+++ b/docs/plugins/advanced_topics/widget_communication.md
@@ -17,7 +17,7 @@ If the goal is to access a target widget, without creating a widget, use the `do
 The `dock_widgets` property provides access to a read-only mapping of all docked widgets in the viewer. You can list available widget names with `viewer.window.dock_widgets.keys()`.
 
 This public API returns the (inner) widget, not the `QtViewerDockWidget` wrapper.
-To control the dock widget itself, access the `QtViewerDockWidget` wrapper using the `.parent()` method on the returned `QWidget`, or `.native.parent()` for magicgui `Widget`.
+To access the `QtViewerDockWidget` wrapper, use the `.parent()` method on the returned `QWidget`, or `.native.parent()` for a magicgui `Widget`.
 For example, to programmatically show the "Home" dock widget:
 
 ```python

--- a/docs/plugins/advanced_topics/widget_communication.md
+++ b/docs/plugins/advanced_topics/widget_communication.md
@@ -14,9 +14,24 @@ If the desired widget is absent, it will be created and added to the viewer.
 ## Access a widget by name with `viewer.window.dock_widgets`
 
 If the goal is to access a target widget, without creating a widget, use the `dock_widgets` property.
-The `dock_widgets` property provides access to a read-only mapping of all docked widgets in the viewer.
+The `dock_widgets` property provides access to a read-only mapping of all docked widgets in the viewer. You can list available widget names with `viewer.window.dock_widgets.keys()`.
 
-This method returns the widget itself, not the `QtViewerDockWidget` wrapper.
+This public API returns the (inner) widget, not the `QtViewerDockWidget` wrapper.
+To control the dock widget itself, access the `QtViewerDockWidget` wrapper using the `.parent()` method on the returned `QWidget`, or `.native.parent()` for magicgui `Widget`.
+For example, to programmatically show the "Home" dock widget:
+
+```python
+widget = viewer.window.dock_widgets["Home"]
+qt_widget = widget.native if hasattr(widget, "native") else widget
+dock_widget = qt_widget.parent()  # Get the QtViewerDockWidget wrapper
+dock_widget.show()
+dock_widget.raise_()
+```
+
+```{important}
+Do not use `viewer.window._dock_widgets` to access `QtViewerDockWidget`.
+This is a private API that may be removed in any release.
+```
 
 *The `dock_widgets` property was added in napari 0.6.2.*
 
@@ -24,10 +39,6 @@ This method returns the widget itself, not the `QtViewerDockWidget` wrapper.
 
 When a widget is added to the viewer via a plugin contribution (by using a menu or `add_plugin_dock_widget`), it is assigned a name.
 The name is created by concatenating the widget `display_name` from the plugin manifest and the plugin name in parentheses, like this: `"Widget name (plugin_name)"`. Note: this is the same name that is shown in the napari menus and the title bar of the widget.
-
-```{important}
-We don't recommend using the `viewer.window._dock_widgets` attribute to access `QtViewerDockWidget` widgets. This is a private, internal API and may stop working on any release. Please use the above described public API instead.
-```
 
 ## Shared state between widgets
 


### PR DESCRIPTION
## References and relevant issues

- Napari issue: https://github.com/napari/napari/issues/8459
- Napari PR: https://github.com/napari/napari/pull/8494
- Image.sc discussion: https://forum.image.sc/t/napari-0-6-2-is-now-released/114029/5

## Description

It was not clear how to avoid the private `viewer.window._dock_widgets` API when a plugin/app needs to control the *dock wrapper* (the `QtViewerDockWidget`/`QDockWidget`) to show/raise a docked tab.

This PR updates the documentation to clarify that `viewer.window.dock_widgets[name]` returns the **inner** widget, and that the dock wrapper can be accessed via the Qt parent (using `.parent()`, or `.native.parent()` for magicgui widgets). This provides a public, documented alternative to `_dock_widgets` for common use cases like bringing a docked widget to the front.

<img width="3732" height="2096" alt="Screenshot showing the updated dock_widgets guidance in the docs" src="https://github.com/user-attachments/assets/20b571e8-9663-4adf-94ff-e9380ae82f3f" />
