### PR TITLE
Overwrite pooch downloader to fix Zenodo access problems

### DIFF
--- a/docs/_scripts/update_ui_sections_docs.py
+++ b/docs/_scripts/update_ui_sections_docs.py
@@ -71,6 +71,7 @@ The output was reviewed and edited for accuracy and clarity.
 
 # ---- Standard library imports
 import json
+import time
 from pathlib import Path
 
 import seedir as sd
@@ -756,6 +757,8 @@ def main(stubs=False):
         pydeps_args,
         mermaid_graph_base_settings,
     ) in ui_sections:
+        begin  = time.time()
+        print("generating docs for UI section:", section_name)
         if stubs:
             # Generate stubs content
             if not output_page.exists():  # Avoid overwriting existing files
@@ -772,6 +775,7 @@ def main(stubs=False):
                 pydeps_args,
                 mermaid_graph_base_settings,
             )
+        print("completed in %.2f seconds" % (time.time() - begin))
 
 
 if __name__ == '__main__':

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -511,4 +511,5 @@ def setup(app):
     ]
     warning_handler.filters.insert(0, FilterSphinxWarnings(app))
 
-pooch.core.choose_downloader = napari_choose_downloader
+if: pooch.core.choose_downloader != napari_choose_downloader
+    pooch.core.choose_downloader = napari_choose_downloader

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,6 +27,9 @@ from sphinx.highlighting import lexers
 from sphinx.util import logging as sphinx_logging
 from sphinx_gallery import gen_rst, scrapers
 from sphinx_gallery.sorting import ExampleTitleSortKey
+import pooch.core
+
+from napari.utils._examples_data import napari_choose_downloader
 
 # -- Version information ---------------------------------------------------
 
@@ -507,3 +510,5 @@ def setup(app):
         h for h in logger.handlers if isinstance(h, sphinx_logging.WarningStreamHandler)
     ]
     warning_handler.filters.insert(0, FilterSphinxWarnings(app))
+
+pooch.core.choose_downloader = napari_choose_downloader

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -511,5 +511,5 @@ def setup(app):
     ]
     warning_handler.filters.insert(0, FilterSphinxWarnings(app))
 
-if: pooch.core.choose_downloader != napari_choose_downloader
+if pooch.core.choose_downloader != napari_choose_downloader:
     pooch.core.choose_downloader = napari_choose_downloader


### PR DESCRIPTION
# References and relevant issues
<!-- What relevant resources were used in the creation of this PR?
If this PR addresses an existing issue on the repo,
please link to that issue here as "Closes #(issue-number)".
If this PR adds docs for a napari PR please add a "Depends on <napari PR link>" -->

# Description
<!-- What does this pull request (PR) do? Does it add new content, improve/fix existing
context, improve/fix workflow/documentation build/deployment or something else?
<!-- If relevant, please include a screenshot or a screen capture in your content
change: "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations. -->
<!-- You can also see a preview of the documentation changes you are submitting by
clicking on "Details" to the right of the "Check the rendered docs here!" check on your PR.-->

<!-- Previewing the Documentation Build
When you submit this PR, jobs that preview the documentation will be kicked off.
By default, they will use the `slimfast` build (`make` target), which is fast, because
it doesn't build any content from outside the `docs` repository and doesn't run notebook cells.
You can trigger other builds by commenting on the PR with:

@napari-bot make <target>

where <target> can be:
html : a full build, just like the deployment to napari.org
html-noplot : a full build, but without the gallery examples from `napari/napari`
docs : only the content from `napari/docs`, with notebook code cells executed
slimfast : the default, only the content from `napari/docs`, without code cell execution
slimgallery : `slimfast`, but with the gallery examples from `napari/napari` built
-->

<!-- Final Checklist
- If images included: I have added [alt text](https://webaim.org/techniques/alttext/)
If workflow, documentation build or deployment change:
- My PR is the minimum possible work for the desired functionality
- I have commented my code, to let others know what it does
-->
