### PR TITLE
Allow to use local copy of napari when using pixi

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -7,12 +7,24 @@ name = "napari-docs"
 platforms = ["win-64", "linux-64", "osx-64", "osx-arm64"]  # All platforms
 version = "0.1.0"
 
-[dependencies]
+[feature.base.dependencies]
 python = "3.13.*"
 make = "*"
 
 [pypi-dependencies]
 napari = { git = "https://github.com/napari/napari.git", branch = "main", extras = ["dev", "pyqt", "docs"] }
+
+[feature.local-napari.pypi-dependencies]
+napari = { path = "../napari", editable = true, extras = ["dev", "pyqt", "docs"]}
+
+[feature.remote-napari.pypi-dependencies]
+napari = { git = "https://github.com/napari/napari.git", branch = "main", extras = ["dev", "pyqt", "docs"] }
+
+[environments]
+# The 'dev' environment uses the local feature
+local-napari = { features = ["local-napari", "base"], no-default-feature = true }
+
+default = { features = ["remote-napari", "base"], no-default-feature = true}
 
 [tasks]
 # Clean tasks

--- a/pixi.toml
+++ b/pixi.toml
@@ -11,9 +11,6 @@ version = "0.1.0"
 python = "3.13.*"
 make = "*"
 
-[pypi-dependencies]
-napari = { git = "https://github.com/napari/napari.git", branch = "main", extras = ["dev", "pyqt", "docs"] }
-
 [feature.local-napari.pypi-dependencies]
 napari = { path = "../napari", editable = true, extras = ["dev", "pyqt", "docs"]}
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -18,9 +18,11 @@ napari = { path = "../napari", editable = true, extras = ["dev", "pyqt", "docs"]
 napari = { git = "https://github.com/napari/napari.git", branch = "main", extras = ["dev", "pyqt", "docs"] }
 
 [environments]
-# The 'dev' environment uses the local feature
+# to run with local napari source code, that is cloned alongside the docs
+# e.g., pixi run -e local-napari html,
+# where `-e local-napari` specifies this environment
+# if no environment is specified, the default is used (remote-napari)
 local-napari = { features = ["local-napari", "base"], no-default-feature = true }
-
 default = { features = ["remote-napari", "base"], no-default-feature = true}
 
 [tasks]


### PR DESCRIPTION
# References and relevant issues


# Description

The current pixi configuration works with the main branch of napari. So it cannot be easily used to debug problems with failing PR to the napari repo (like https://github.com/napari/napari/pull/8051#issuecomment-3700953859)

This PR adds an environment that installs napari from a local clone where the proper PR could be checked out. 
