### PR TITLE
Fix pixi tasks for different environments

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -22,8 +22,8 @@ napari = { git = "https://github.com/napari/napari.git", branch = "main", extras
 # e.g., pixi run -e local-napari html,
 # where `-e local-napari` specifies this environment
 # if no environment is specified, the default is used (remote-napari)
-local-napari = { features = ["local-napari", "base"], no-default-feature = true }
-default = { features = ["remote-napari", "base"], no-default-feature = true}
+local-napari = { features = ["local-napari", "base"] }
+default = { features = ["remote-napari", "base"] }
 
 [tasks]
 # Clean tasks


### PR DESCRIPTION
# References and relevant issues
Follow-up to #900

# Description
After we merged https://github.com/napari/docs/pull/900, I can't build the docs locally with pixi. No tasks are shown when I run 

```
➜  napari-docs git:(main) pixi task list
Tasks that can run on this machine:
-----------------------------------

Task  Description
➜  napari-docs git:(main) 
```

which means pixi doesn't see any of the tasks defined in our pixi.toml file. Doing some research on the docs, it looks like removing the `no-default-feature = true` option from the environment solves it. Another option is to list each task again for each of the two environments, but I believe this PR is the simplest fix.
