### PR TITLE
Remove mention of outdated plugin from quick start

### DIFF
--- a/docs/getting_started/quick_start.md
+++ b/docs/getting_started/quick_start.md
@@ -170,10 +170,6 @@ the default keybinding {kbd}`m`.
 </figure>
 ```
 
-Several plugins can perform automatic segmentation that takes image layers as input and generates labels layers as output.
-
-Try [cellpose-napari](https://www.napari-hub.org/plugins/cellpose-napari) if you have cell images.
-
 +++
 
 ## Get the cell area measurement


### PR DESCRIPTION
# References and relevant issues

Follow-up to #881 

# Description

While reading through the new quickstart, I noticed this mention of an un-maintained plugin. For a while, the plugin did not work, but I do think it does appear to be fixed now https://github.com/MouseLand/cellpose-napari/pull/51#issuecomment-2351146003

I propose we remove this very small mention.

We can consider adding back plugins once we have our review system in place. My preference would be for us to make a "starter plugins" guide, rather than a short quip (that's hard to notice because of its placement!) in this quick start. There already is good detail here pointing people towards the hub :)