### PR TITLE
Update governance documentation

### DIFF
--- a/docs/community/governance.md
+++ b/docs/community/governance.md
@@ -16,12 +16,12 @@ resolved.
 
 ## Roles and responsibilities
 
-The napari organization and software ecosystem is supported by a broad community
-of users, our contributors, and the napari team. The napari team is responsible
-for all project governance and is anchored by two bodies: the napari core
-team members, and the napari steering council. In this section, we define
-the different bodies supporting the project, and describe the roles and responsibilies
-of the napari core team members and the steering council.
+The napari organization and software ecosystem is supported by a broad
+community of users, our contributors, and the napari team. The napari team is
+responsible for all project governance and is anchored by two bodies: the
+napari core team members, and the napari steering council. In this section, we
+define the different bodies supporting the project, and describe the roles and
+responsibilies of the napari core team members and the steering council.
 
 ### The community
 
@@ -48,16 +48,25 @@ project in concrete ways, such as:
 
 among other possibilities.
 
-Note that community members proposing code changes, reporting issues, discussing design,
-or reviewing pull requests for **any** project in the [napari GitHub organization](https://github.com/napari) are also deemed contributors.
-Some of the associated projects community members may be interested in are:
+Note that community members proposing code changes, reporting issues,
+discussing design, or reviewing pull requests for **any** project in the
+[napari GitHub organization](https://github.com/napari) are also deemed
+contributors. Some of the associated projects community members may be
+interested in are:
 
-- The [napari plugin manager](https://github.com/napari/napari-plugin-manager) for installing plugins within the viewer
-- The [napari packaging](https://github.com/napari/packaging) project that handles our one-click bundled installer
-- The [napari hub](https://github.com/napari/hub-lite) website for browsing available plugins
-- The [napari plugin template](https://github.com/napari/napari-plugin-template) for quickly generating a plugin from scratch
-- Plugins maintained by the napari team such as [napari-tiff](https://github.com/napari/napari-tiff) for reading and writing TIFF files,
-and [napari-metadata](https://github.com/napari/napari-metadata) for displaying and editing layer metadata
+- The [napari plugin manager](https://github.com/napari/napari-plugin-manager)
+  for installing plugins within the viewer
+- The [napari packaging](https://github.com/napari/packaging) project that
+  handles our one-click bundled installer
+- The [napari hub](https://github.com/napari/hub-lite) website for browsing
+  available plugins
+- The [napari plugin
+  template](https://github.com/napari/napari-plugin-template) for quickly
+  generating a plugin from scratch
+- Plugins maintained by the napari team such as
+  [napari-tiff](https://github.com/napari/napari-tiff) for reading and writing
+  TIFF files, and [napari-metadata](https://github.com/napari/napari-metadata)
+  for displaying and editing layer metadata
 
 Any community member can become a contributor, and
 all are encouraged to do so. By contributing to the project, community members
@@ -86,11 +95,11 @@ for and against merging a pull-request, and be involved in deciding major
 changes to the API, and thereby more easily carry on with their project related
 activities.
 
-Aside from technical contributions, core team members support
-the Steering Council in carrying out the project's mission. They participate
-in discussion about the project's present and future goals and direction,
-collaborate with the SC to establish and update the project's development roadmap,
-and support the napari community at large.
+Aside from technical contributions, core team members support the Steering
+Council in carrying out the project's mission. They participate in discussion
+about the project's present and future goals and direction, collaborate with
+the SC to establish and update the project's development roadmap, and support
+the napari community at large.
 
 Core team members are expected to review code contributions while adhering to the
 [core team member guide](core-dev-guide). New core team members can be nominated
@@ -105,42 +114,48 @@ For a full list of core team members see our [About the project and team](team) 
 
 ### Steering council
 
-The purpose of the Steering Council (SC) is to ensure smooth progress from the big-picture
-perspective. The SC is ultimately responsible for all strategic and operational
-dimensions of the napari project. This includes, but is not limited to all legal, financial
-and operational decisions. The SC actively works to carry out the napari project's mission,
-in accordance with the project's values and with the support of the core team members. SC members are
+The purpose of the Steering Council (SC) is to ensure smooth progress from the
+big-picture perspective. The SC is ultimately responsible for all strategic and
+operational dimensions of the napari project. This includes, but is not limited
+to all legal, financial and operational decisions. The SC actively works to
+carry out the napari project's mission, in accordance with the project's values
+and with the support of the core team members. SC members are
 expected to participate in strategic planning, approve changes to the
 governance model, and make decisions about funding granted to the project
-itself. 
+itself.
 
 The SC has the responsibility to:
 
 - Pursue, raise, allocate and manage all project funding.
-- Coordinate, manage and select candidates for all roles and personnel employed or contracted
-to the napari project.
-- Manage all legal aspects of the napari project, such as contracts, compliance and copyright,
-with support from NumFOCUS.
+- Coordinate, manage and select candidates for all roles and personnel employed
+  or contracted to the napari project.
+- Manage all legal aspects of the napari project, such as contracts, compliance
+  and copyright, with support from NumFOCUS.
 - Manage the project's relationship with NumFOCUS as a Sponsored Project,
 - Ensure the timely delivery of all deliverables, milestones, reports and other
-commitments associated with restricted funding such as grants or contracts.
-- Coordinate and oversee the project development roadmap, and its delivery, in collaboration with
-the core team members and the broader community.
-- Hold a monthly meeting, and distribute summaries of these meetings to the core team members.
-- Ensure the publication of an annual State of Napari report that provides a summary of the
-previous year's activities across the entire napari community, and highlights the current and
-future direction of the project.
-- Members of the SC also have the "owner" role within the [napari GitHub organization](https://github.com/napari)
-and are ultimately responsible for managing the napari GitHub account, the [@napari@fosstodon.org](https://fosstodon.org/@napari)
-Mastodon account, the [napari website](https://napari.org), and other similar napari owned resources.
-- When the core team member community (including the SC members) fails to reach a consensus in
-a reasonable timeframe, the SC is the entity that resolves the issue.
+  commitments associated with restricted funding such as grants or contracts.
+- Coordinate and oversee the project development roadmap, and its delivery, in
+  collaboration with the core team members and the broader community.
+- Hold a monthly meeting, and distribute summaries of these meetings to the
+  core team members.
+- Ensure the publication of an annual State of Napari report that provides a
+  summary of the previous year's activities across the entire napari community,
+  and highlights the current and future direction of the project.
+- Members of the SC also have the "owner" role within the [napari GitHub
+  organization](https://github.com/napari)
+  and are ultimately responsible for managing the napari GitHub account, the [@napari@fosstodon.org](https://fosstodon.org/@napari)
+  Mastodon account, the [napari website](https://napari.org), and other similar napari owned resources.
+- When the core team member community (including the SC members) fails to reach
+  a consensus in a reasonable timeframe, the SC is the entity that resolves the
+  issue.
 
-SC members may be core team members but can also be nominated from the community at large. Changes 
-that impact the full project require analysis informed by long experience with both the project
-and the larger ecosystem. As such, SC members should be community members who have interacted heavily
-with the project and its ecosystem, whether they be users, plugin developers, direct napari contributors,
-or involved with the project in other ways e.g. attending community events, supporting users of napari, etc.
+SC members may be core team members but can also be nominated from the
+community at large. Changes that impact the full project require analysis
+informed by long experience with both the project and the larger ecosystem. As
+such, SC members should be community members who have interacted heavily with
+the project and its ecosystem, whether they be users, plugin developers, direct
+napari contributors, or involved with the project in other ways e.g. attending
+community events, supporting users of napari, etc.
 
 The SC will be no less than three members and no more than five members,
 with a strong preference for an odd number to ensure a simple majority vote
@@ -152,33 +167,36 @@ for a member elected by the [Institutional and Funding Partner Advisory Council]
 as detailed below.
 
 The SC membership, including the Institutional and Funding Partner (IFP) seat, is revisited every January.
-Current SC members must actively reaffirm their membership for the upcoming year, or choose to 
-resign. SC members who do not actively engage with the SC duties are expected to resign. Should
-an SC member resign, they remain eligible for rejoining the SC at a later date, via the standard process
-described below. 
+Current SC members must actively reaffirm their membership for the upcoming
+year, or choose to resign. SC members who do not actively engage with the SC
+duties are expected to resign. Should an SC member resign, they remain eligible
+for rejoining the SC at a later date, via the standard process described below.
 
-New members for vacant spots are added by nomination by a core team member or SC member, and
-subsequent vote.
-Nominees should have demonstrated long-term, continued commitment to the project and/or its community, and its
-[mission and values](mission-and-values). Before nomination, the core team should approach
-the prospective nominee to gauge their interest and availability in the role. 
-A nomination will result in discussion among current core team members and SC members,
-that cannot take more than a month and then admission to the SC by consensus, as defined [below](#decision-making-process). 
-During that time deadlocked votes of the SC will
+New members for vacant spots are added by nomination by a core team member or
+SC member, and subsequent vote. Nominees should have demonstrated long-term,
+continued commitment to the project and/or its community, and its [mission and
+values](mission-and-values). Before nomination, the core team should approach
+the prospective nominee to gauge their interest and availability in the role.
+A nomination will result in discussion among current core team members and SC
+members, that cannot take more than a month and then admission to the SC by
+consensus, as defined [below](#decision-making-process). During that time
+deadlocked votes of the SC will
 be postponed until the new member has joined and another vote can be held. The IFP seat
 is elected by the IFP Advisory Council.
 
 Any core team member or SC member can request the explusion of an SC member
-whom they believe has acted in a manner contrary to the project's mission and values,
-or who has failed to participate in Steering Council activities. This may be done by
-approaching another SC member, who is then responsible for calling a vote and managing the process,
-as detailed below.
-Written notice of the proposed expulsion must be given to the member at least 21 days
-before a vote is held, and the member must be a given reasonable opportunity of appealing.
-The member will be expelled if the vote, by secret ballot, of the core team members
-and Steering Council achieves a 75% majority. An expelled member may not be readmitted
-unless a vote for readmission, by secret ballot, of the core team members and Steering Council
-achieves a 75% majority.
+whom they believe has acted in a manner contrary to the project's mission and
+values, or who has failed to participate in Steering Council activities. This
+may be done by approaching another SC member, who is then responsible for
+calling a vote and managing the process, as detailed below.
+
+Written notice of the proposed expulsion must be given to the member at least
+21 days before a vote is held, and the member must be a given reasonable
+opportunity of appealing.  The member will be expelled if the vote, by secret
+ballot, of the core team members and Steering Council achieves a 75% majority.
+An expelled member may not be readmitted unless a vote for readmission, by
+secret ballot, of the core team members and Steering Council achieves a 75%
+majority.
 
 The SC may be contacted at `napari-steering-council@googlegroups.com`. For a list of the current
 SC see our [About the project and team](team) page.

--- a/docs/community/governance.md
+++ b/docs/community/governance.md
@@ -16,6 +16,13 @@ resolved.
 
 ## Roles and responsibilities
 
+The napari organization and software ecosystem is supported by a broad community
+of users, our contributors, and the napari team. The napari team is responsible
+for all project governance and is anchored by two bodies: the napari core
+team members, and the napari steering council. In this section, we define
+the different bodies supporting the project, and describe the roles and responsibilies
+of the napari core team members and the steering council.
+
 ### The community
 
 The napari community consists of anyone using or working with the project
@@ -31,15 +38,28 @@ project in concrete ways, such as:
 - reporting issues on our
   [GitHub issues page](https://github.com/napari/napari/issues);
 - proposing a change to the documentation, or
-  tutorials via a [GitHub pull request](https://github.com/napari/napari/pulls);
-- discussing the design of the napari or its tutorials on in existing
+  tutorials via a [GitHub pull request](https://github.com/napari/docs/pulls);
+- discussing the design of napari or its tutorials on in existing
   [issues](https://github.com/napari/napari/issues) and
   [pull requests](https://github.com/napari/napari/pulls);
 - discussing examples or use cases on the
   [image.sc forum](https://forum.image.sc/tag/napari) under the #napari tag; or
 - reviewing [open pull requests](https://github.com/napari/napari/pulls)
 
-among other possibilities. Any community member can become a contributor, and
+among other possibilities.
+
+Note that community members proposing code changes, reporting issues, discussing design,
+or reviewing pull requests for **any** project in the [napari GitHub organization](https://github.com/napari) are also deemed contributors. Some of the associated projects community members
+may be interested in are:
+
+- The [napari plugin manager]() for installing plugins within the viewer
+- The [napari packaging]() project that handles our one-click bundled installer
+- The [napari hub]() website for browsing available plugins
+- The [napari plugin template]() for quickly generating a plugin from scratch
+- Plugins maintained by the napari team such as [napari-tiff]() for reading and writing TIFF files,
+and [napari-metadata]() for displaying and editing layer metadata
+
+Any community member can become a contributor, and
 all are encouraged to do so. By contributing to the project, community members
 can directly help to shape its future.
 
@@ -79,20 +99,42 @@ For a full list of core team members see our [About the project and team](team) 
 
 ### Steering council
 
-The Steering Council (SC) members are primarily core team members who have additional
-responsibilities to ensure the smooth running of the project. SC members are
+The purpose of the Steering Council (SC) is to ensure smooth progress from the big-picture
+perspective. The SC is ultimately responsible for all strategic and operational
+dimensions of the napari project. This includes, but is not limited to all legal, financial
+and operational decisions. The SC actively works to carry out the napari project's mission,
+in accordance with its values and with the support of the core team members. SC members are
 expected to participate in strategic planning, approve changes to the
 governance model, and make decisions about funding granted to the project
-itself. (Funding to community members is theirs to pursue and manage). The
-purpose of the SC is to ensure smooth progress from the big-picture
-perspective. Changes that impact the full project require analysis informed by
-long experience with both the project and the larger ecosystem. When the core
-team member community (including the SC members) fails to reach such a consensus
-in a reasonable timeframe, the SC is the entity that resolves the issue.
+itself. 
 
-Members of the SC also have the "owner" role within the [napari GitHub organization](https://github.com/napari)
+The SC has the responsibility to:
+
+- Pursue, raise, allocate and manage all project funding.
+- Coordinate, manage and select candidates for all roles and personnel employed or contracted
+to the napari project.
+- Manage all legal aspects of the napari project, such as contracts, compliance and copyright,
+with support from NumFOCUS.
+- Manage the project's relationship with NumFOCUS as a Sponsored Project,
+- Ensure the timely delivery of all deliverables, milestones, reports and other
+commitments associated with restricted funding such as grants or contracts.
+- Coordinate and oversee the delivery of the project development roadmap, in collaboration with
+the core team members and the broader community.
+- Hold a monthly meeting, and distribute summaries of these meetings to the core team members.
+- Ensure the publication of an annual State of Napari report that provides a summary of the
+previous year's activities across the entire napari community, and highlights the current and
+future direction of the project.
+- Members of the SC also have the "owner" role within the [napari GitHub organization](https://github.com/napari)
 and are ultimately responsible for managing the napari GitHub account, the [@napari@fosstodon.org](https://fosstodon.org/@napari)
 Mastodon account, the [napari website](https://napari.org), and other similar napari owned resources.
+- When the core team member community (including the SC members) fails to reach such a consensus in
+a reasonable timeframe, the SC is the entity that resolves the issue.
+
+SC members may be core team members but can also be nominated from the community at large. Changes 
+that impact the full project require analysis informed by long experience with both the project
+and the larger ecosystem. As such, SC members should be community members who have interacted heavily
+with the project and its ecosystem, whether they be users, plugin developers, direct napari contributors,
+or involved with the project in other ways e.g. attending community events, supporting users of napari, etc.
 
 The SC will be no less than three members and no more than five members,
 with a strong preference for an odd number to ensure a simple majority vote
@@ -101,7 +143,7 @@ diversity of voices. All deadlocked votes of the SC will be postponed until
 there is an odd number of members and another vote can be held. A majority of the
 SC will not be employed by the same entity. One seat on the SC is reserved
 for a member elected by the [Institutional and Funding Partner Advisory Council](#institutional-and-funding-partners),
-as detailed below. This member need not be an existing core team member.
+as detailed below.
 
 The SC membership, including the Institutional and Funding Partner (IFP) seat, is revisited every January.
 SC members who do not actively engage with the SC duties are expected to resign. New members for

--- a/docs/community/governance.md
+++ b/docs/community/governance.md
@@ -193,8 +193,10 @@ may be done by approaching another SC member, who is then responsible for
 calling a vote and managing the process, as detailed below.
 
 Written notice of the proposed expulsion must be given to the member at least
-21 days before a vote is held, and the member must be a given reasonable
-opportunity of appealing.  The member will be expelled if the vote, by secret
+21 days before a vote is held. As soon as a removal request has been made, the
+member's permissions will be reduced to prohibit destructive actions on
+relevant platforms. Before the vote, the member must be given reasonable
+opportunity to appeal. The member will be expelled if the vote, by secret
 ballot, of the core team members and Steering Council achieves a 75% majority.
 An expelled member may not be readmitted unless a vote for readmission, by
 secret ballot, of the core team members and Steering Council achieves a 75%

--- a/docs/community/governance.md
+++ b/docs/community/governance.md
@@ -49,15 +49,15 @@ project in concrete ways, such as:
 among other possibilities.
 
 Note that community members proposing code changes, reporting issues, discussing design,
-or reviewing pull requests for **any** project in the [napari GitHub organization](https://github.com/napari) are also deemed contributors. Some of the associated projects community members
-may be interested in are:
+or reviewing pull requests for **any** project in the [napari GitHub organization](https://github.com/napari) are also deemed contributors.
+Some of the associated projects community members may be interested in are:
 
-- The [napari plugin manager]() for installing plugins within the viewer
-- The [napari packaging]() project that handles our one-click bundled installer
-- The [napari hub]() website for browsing available plugins
-- The [napari plugin template]() for quickly generating a plugin from scratch
-- Plugins maintained by the napari team such as [napari-tiff]() for reading and writing TIFF files,
-and [napari-metadata]() for displaying and editing layer metadata
+- The [napari plugin manager](https://github.com/napari/napari-plugin-manager) for installing plugins within the viewer
+- The [napari packaging](https://github.com/napari/packaging) project that handles our one-click bundled installer
+- The [napari hub](https://github.com/napari/hub-lite) website for browsing available plugins
+- The [napari plugin template](https://github.com/napari/napari-plugin-template) for quickly generating a plugin from scratch
+- Plugins maintained by the napari team such as [napari-tiff](https://github.com/napari/napari-tiff) for reading and writing TIFF files,
+and [napari-metadata](https://github.com/napari/napari-metadata) for displaying and editing layer metadata
 
 Any community member can become a contributor, and
 all are encouraged to do so. By contributing to the project, community members

--- a/docs/community/governance.md
+++ b/docs/community/governance.md
@@ -143,8 +143,10 @@ The SC has the responsibility to:
   and highlights the current and future direction of the project.
 - Members of the SC also have the "owner" role within the [napari GitHub
   organization](https://github.com/napari)
-  and are ultimately responsible for managing the napari GitHub account, the [@napari@fosstodon.org](https://fosstodon.org/@napari)
-  Mastodon account, the [napari website](https://napari.org), and other similar napari owned resources.
+  and are ultimately responsible for managing the napari GitHub account, the
+  [@napari@fosstodon.org](https://fosstodon.org/@napari) Mastodon account, the
+  [napari website](https://napari.org), and other similar napari owned
+  resources.
 - When the core team member community (including the SC members) fails to reach
   a consensus in a reasonable timeframe, the SC is the entity that resolves the
   issue.

--- a/docs/community/governance.md
+++ b/docs/community/governance.md
@@ -193,10 +193,8 @@ may be done by approaching another SC member, who is then responsible for
 calling a vote and managing the process, as detailed below.
 
 Written notice of the proposed expulsion must be given to the member at least
-21 days before a vote is held. As soon as a removal request has been made, the
-member's permissions will be reduced to prohibit destructive actions on
-relevant platforms. Before the vote, the member must be given reasonable
-opportunity to appeal. The member will be expelled if the vote, by secret
+21 days before a vote is held, and the member must be a given reasonable
+opportunity of appealing.  The member will be expelled if the vote, by secret
 ballot, of the core team members and Steering Council achieves a 75% majority.
 An expelled member may not be readmitted unless a vote for readmission, by
 secret ballot, of the core team members and Steering Council achieves a 75%

--- a/docs/community/governance.md
+++ b/docs/community/governance.md
@@ -103,7 +103,7 @@ The purpose of the Steering Council (SC) is to ensure smooth progress from the b
 perspective. The SC is ultimately responsible for all strategic and operational
 dimensions of the napari project. This includes, but is not limited to all legal, financial
 and operational decisions. The SC actively works to carry out the napari project's mission,
-in accordance with its values and with the support of the core team members. SC members are
+in accordance with the project's values and with the support of the core team members. SC members are
 expected to participate in strategic planning, approve changes to the
 governance model, and make decisions about funding granted to the project
 itself. 
@@ -127,7 +127,7 @@ future direction of the project.
 - Members of the SC also have the "owner" role within the [napari GitHub organization](https://github.com/napari)
 and are ultimately responsible for managing the napari GitHub account, the [@napari@fosstodon.org](https://fosstodon.org/@napari)
 Mastodon account, the [napari website](https://napari.org), and other similar napari owned resources.
-- When the core team member community (including the SC members) fails to reach such a consensus in
+- When the core team member community (including the SC members) fails to reach a consensus in
 a reasonable timeframe, the SC is the entity that resolves the issue.
 
 SC members may be core team members but can also be nominated from the community at large. Changes 

--- a/docs/community/governance.md
+++ b/docs/community/governance.md
@@ -86,6 +86,12 @@ for and against merging a pull-request, and be involved in deciding major
 changes to the API, and thereby more easily carry on with their project related
 activities.
 
+Aside from technical contributions, core team members support
+the Steering Council in carrying out the project's mission. They participate
+in discussion about the project's present and future goals and direction,
+collaborate with the SC to establish and update the project's development roadmap,
+and support the napari community at large.
+
 Core team members are expected to review code contributions while adhering to the
 [core team member guide](core-dev-guide). New core team members can be nominated
 by any existing core team member, and for details on that process see our core
@@ -118,7 +124,7 @@ with support from NumFOCUS.
 - Manage the project's relationship with NumFOCUS as a Sponsored Project,
 - Ensure the timely delivery of all deliverables, milestones, reports and other
 commitments associated with restricted funding such as grants or contracts.
-- Coordinate and oversee the delivery of the project development roadmap, in collaboration with
+- Coordinate and oversee the project development roadmap, and its delivery, in collaboration with
 the core team members and the broader community.
 - Hold a monthly meeting, and distribute summaries of these meetings to the core team members.
 - Ensure the publication of an annual State of Napari report that provides a summary of the
@@ -146,11 +152,19 @@ for a member elected by the [Institutional and Funding Partner Advisory Council]
 as detailed below.
 
 The SC membership, including the Institutional and Funding Partner (IFP) seat, is revisited every January.
-SC members who do not actively engage with the SC duties are expected to resign. New members for
-vacant spots are added by nomination by a core team member. Nominees should have demonstrated
-long-term, continued commitment to the project and its [mission and values](mission-and-values). A
-nomination will result in discussion that cannot take more than a month and
-then admission to the SC by consensus. During that time deadlocked votes of the SC will
+Current SC members must actively reaffirm their membership for the upcoming year, or choose to 
+resign. SC members who do not actively engage with the SC duties are expected to resign. Should
+an SC member resign, they remain eligible for rejoining the SC at a later date, via the standard process
+described below. 
+
+New members for vacant spots are added by nomination by a core team member or SC member, and
+subsequent vote.
+Nominees should have demonstrated long-term, continued commitment to the project and/or its community, and its
+[mission and values](mission-and-values). Before nomination, the core team should approach
+the prospective nominee to gauge their interest and availability in the role. 
+A nomination will result in discussion among current core team members and SC members,
+that cannot take more than a month and then admission to the SC by consensus, as defined [below](#decision-making-process). 
+During that time deadlocked votes of the SC will
 be postponed until the new member has joined and another vote can be held. The IFP seat
 is elected by the IFP Advisory Council.
 

--- a/docs/community/governance.md
+++ b/docs/community/governance.md
@@ -168,6 +168,18 @@ During that time deadlocked votes of the SC will
 be postponed until the new member has joined and another vote can be held. The IFP seat
 is elected by the IFP Advisory Council.
 
+Any core team member or SC member can request the explusion of an SC member
+whom they believe has acted in a manner contrary to the project's mission and values,
+or who has failed to participate in Steering Council activities. This may be done by
+approaching another SC member, who is then responsible for calling a vote and managing the process,
+as detailed below.
+Written notice of the proposed expulsion must be given to the member at least 21 days
+before a vote is held, and the member must be a given reasonable opportunity of appealing.
+The member will be expelled if the vote, by secret ballot, of the core team members
+and Steering Council achieves a 75% majority. An expelled member may not be readmitted
+unless a vote for readmission, by secret ballot, of the core team members and Steering Council
+achieves a 75% majority.
+
 The SC may be contacted at `napari-steering-council@googlegroups.com`. For a list of the current
 SC see our [About the project and team](team) page.
 

--- a/docs/developers/coredev/core_dev_guide.md
+++ b/docs/developers/coredev/core_dev_guide.md
@@ -17,8 +17,14 @@ foremost, you should familiarize yourself with the project's
 doubt, always refer back there.
 
 As a core team member, you gain the responsibility of shepherding
-other contributors through the review process; here are some
+other contributors through the review process; below are some
 guidelines for how to do that.
+
+You also gain the responsibility of collaborating with the Steering
+Council and the rest of the team in shaping the project's goals and future direction
+as aligned with the mission and values. Please read our [governance](../../community/governance.md)
+documentation for more information on our governance process, and the Steering
+Council's role.
 
 ## All contributors are treated the same
 
@@ -213,7 +219,8 @@ Core team members can choose to become emeritus core team members and suspend
 their approval and voting rights until they become active again. Emeritus core
 team members can request **or** be invited to become active core team members at
 a later date, and active core team members will vote on this status-change as
-above.
+above. Core team members must reaffirm their membership every January. Core team
+members who do not reaffirm their membership will automatically become emeritus.
 
 ## Contribute to this guide (!)
 

--- a/docs/developers/coredev/core_dev_guide.md
+++ b/docs/developers/coredev/core_dev_guide.md
@@ -230,10 +230,8 @@ member whom they believe has acted in a manner contrary to the project's
 mission and values. This may be done by approaching an SC member, who is then
 responsible for calling a vote and managing the process, as detailed below.
 Written notice of the proposed expulsion must be given to the member at least
-21 days before a vote is held. As soon as a removal request has been made, the
-member's permissions will be reduced to prohibit destructive actions on
-relevant platforms. Before the vote, the member must be given reasonable
-opportunity to appeal. The member will be expelled if the vote, by secret
+21 days before a vote is held, and the member must be a given reasonable
+opportunity of appealing.  The member will be expelled if the vote, by secret
 ballot, of the core team members and Steering Council achieves a 75% majority.
 An expelled member may not be readmitted unless a vote for readmission, by
 secret ballot, of the core team members and Steering Council achieves a 75%

--- a/docs/developers/coredev/core_dev_guide.md
+++ b/docs/developers/coredev/core_dev_guide.md
@@ -20,11 +20,11 @@ As a core team member, you gain the responsibility of shepherding
 other contributors through the review process; below are some
 guidelines for how to do that.
 
-You also gain the responsibility of collaborating with the Steering
-Council and the rest of the team in shaping the project's goals and future direction
-as aligned with the mission and values. Please read our [governance](../../community/governance.md)
-documentation for more information on our governance process, and the Steering
-Council's role.
+You also gain the responsibility of collaborating with the Steering Council and
+the rest of the team in shaping the project's goals and future direction as
+aligned with the mission and values. Please read our
+[governance](../../community/governance.md) documentation for more information
+on our governance process, and the Steering Council's role.
 
 ## All contributors are treated the same
 
@@ -219,21 +219,22 @@ Core team members can choose to become emeritus core team members and suspend
 their approval and voting rights until they become active again. Emeritus core
 team members can request **or** be invited to become active core team members at
 a later date, and active core team members will vote on this status-change as
-above. Core team members must reaffirm their membership every January. Core team
-members who do not reaffirm their membership will automatically become emeritus.
+above. Core team members must reaffirm their membership every January. Core
+team members who do not reaffirm their membership will automatically become
+emeritus.
 
 ## Expulsion of core team members
 
 Any core team member or SC member can request the explusion of an SC member
-whom they believe has acted in a manner contrary to the project's mission and values. This may be done by
-approaching an SC member, who is then responsible for calling a vote and managing the process,
-as detailed below.
-Written notice of the proposed expulsion must be given to the member at least 21 days
-before a vote is held, and the member must be a given reasonable opportunity of appealing.
-The member will be expelled if the vote, by secret ballot, of the core team members
-and Steering Council achieves a 75% majority. An expelled member may not be readmitted
-unless a vote for readmission, by secret ballot, of the core team members and Steering Council
-achieves a 75% majority.  
+whom they believe has acted in a manner contrary to the project's mission and
+values. This may be done by approaching an SC member, who is then responsible
+for calling a vote and managing the process, as detailed below.  Written notice
+of the proposed expulsion must be given to the member at least 21 days before a
+vote is held, and the member must be a given reasonable opportunity of
+appealing.  The member will be expelled if the vote, by secret ballot, of the
+core team members and Steering Council achieves a 75% majority. An expelled
+member may not be readmitted unless a vote for readmission, by secret ballot,
+of the core team members and Steering Council achieves a 75% majority.
 
 ## Contribute to this guide (!)
 

--- a/docs/developers/coredev/core_dev_guide.md
+++ b/docs/developers/coredev/core_dev_guide.md
@@ -222,6 +222,19 @@ a later date, and active core team members will vote on this status-change as
 above. Core team members must reaffirm their membership every January. Core team
 members who do not reaffirm their membership will automatically become emeritus.
 
+## Expulsion of core team members
+
+Any core team member or SC member can request the explusion of an SC member
+whom they believe has acted in a manner contrary to the project's mission and values. This may be done by
+approaching an SC member, who is then responsible for calling a vote and managing the process,
+as detailed below.
+Written notice of the proposed expulsion must be given to the member at least 21 days
+before a vote is held, and the member must be a given reasonable opportunity of appealing.
+The member will be expelled if the vote, by secret ballot, of the core team members
+and Steering Council achieves a 75% majority. An expelled member may not be readmitted
+unless a vote for readmission, by secret ballot, of the core team members and Steering Council
+achieves a 75% majority.  
+
 ## Contribute to this guide (!)
 
 This guide reflects the experience of the current core team members. We

--- a/docs/developers/coredev/core_dev_guide.md
+++ b/docs/developers/coredev/core_dev_guide.md
@@ -225,16 +225,17 @@ emeritus.
 
 ## Expulsion of core team members
 
-Any core team member or SC member can request the explusion of an SC member
-whom they believe has acted in a manner contrary to the project's mission and
-values. This may be done by approaching an SC member, who is then responsible
-for calling a vote and managing the process, as detailed below.  Written notice
-of the proposed expulsion must be given to the member at least 21 days before a
-vote is held, and the member must be a given reasonable opportunity of
-appealing.  The member will be expelled if the vote, by secret ballot, of the
-core team members and Steering Council achieves a 75% majority. An expelled
-member may not be readmitted unless a vote for readmission, by secret ballot,
-of the core team members and Steering Council achieves a 75% majority.
+Any core team member or SC member can request the explusion of a core team
+member whom they believe has acted in a manner contrary to the project's
+mission and values. This may be done by approaching an SC member, who is then
+responsible for calling a vote and managing the process, as detailed below.
+Written notice of the proposed expulsion must be given to the member at least
+21 days before a vote is held, and the member must be a given reasonable
+opportunity of appealing.  The member will be expelled if the vote, by secret
+ballot, of the core team members and Steering Council achieves a 75% majority.
+An expelled member may not be readmitted unless a vote for readmission, by
+secret ballot, of the core team members and Steering Council achieves a 75%
+majority.
 
 ## Contribute to this guide (!)
 

--- a/docs/developers/coredev/core_dev_guide.md
+++ b/docs/developers/coredev/core_dev_guide.md
@@ -230,8 +230,10 @@ member whom they believe has acted in a manner contrary to the project's
 mission and values. This may be done by approaching an SC member, who is then
 responsible for calling a vote and managing the process, as detailed below.
 Written notice of the proposed expulsion must be given to the member at least
-21 days before a vote is held, and the member must be a given reasonable
-opportunity of appealing.  The member will be expelled if the vote, by secret
+21 days before a vote is held. As soon as a removal request has been made, the
+member's permissions will be reduced to prohibit destructive actions on
+relevant platforms. Before the vote, the member must be given reasonable
+opportunity to appeal. The member will be expelled if the vote, by secret
 ballot, of the core team members and Steering Council achieves a 75% majority.
 An expelled member may not be readmitted unless a vote for readmission, by
 secret ballot, of the core team members and Steering Council achieves a 75%

--- a/docs/release/release_0_7_0.md
+++ b/docs/release/release_0_7_0.md
@@ -1,7 +1,7 @@
 # napari 0.7.0
 ⚠️ *Note: these release notes are still in draft while 0.7.0 is in release candidate testing.* ⚠️
 
-*Tue, Jan 27, 2026*
+*Wed, Feb 04, 2026*
 
 We're happy to announce the release of napari 0.7.0!
 napari is a fast, interactive, multi-dimensional image viewer for Python.
@@ -25,7 +25,8 @@ In all 0.6.x releases, npe1 plugins were automatically converted to npe2 by defa
 and users could turn off the `use_npe2_adaptor` setting to continue using npe1 plugins
 without auto-conversion.
 
-In 0.7.0 this setting is being removed, and plugins will *only* continue to function if
+In 0.7.0 this setting is being removed ([PR #8448](https://github.com/napari/napari/pull/8448)),
+and plugins will *only* continue to function if
 they can be auto-converted to npe2. Most plugins will be unaffected, but those that rely
 on import-time behaviour may not work as expected. If a plugin is relying on import-time
 behaviour, it may be able to replicate this using the new startup scripts functionality added
@@ -47,7 +48,106 @@ our [Plugins Zulip chat
 channel](https://napari.zulipchat.com/#narrow/channel/309872-plugins) or by
 coming to one of our [community meetings](meeting-schedule).
 
-### Grid mode - bigger, better, faster 📈
+### More pixels to play with - texture tiling
+
+Ever loaded a large 2D image in napari just to zoom in and find it's blurrier
+than a JPEG from the year 2000? That's no longer the case!
+
+Courtesy of our community contributor, Guillaume Witz (@guiwitz), and his PR for
+texture tiling ([PR #8395](https://github.com/napari/napari/pull/8395)) 2D
+images that exceed OpenGL's maximum texture size will be split into multiple
+tiles, each small enough to fit on the GPU, and rendered as separate vispy `Image` node.
+
+![Image with a screenshot of napari 0.6.6 on the left and napari 0.7.0 on the right displaying a DeCAM image of the Milky Way. The image on the left is pixelated, while the image on the right is displayed at full resolution.](https://github.com/user-attachments/assets/d0a115a8-49d5-432c-b561-f29fe9ac8116)
+
+### What's my metadata? Where's my metadata? `napari-metadata` to the rescue
+
+With a lot of work from our community contributor, Carlos Mario Rodriguez Reza (@carlosmariorr), and
+our venerable community manager Tim Monko (@TimMonko), `napari` now has a metadata viewing and editing plugin
+included in our `napari[all]` installation and our bundle ([PR #8576](https://github.com/napari/napari/pull/8576)).
+
+![Screenshot of napari displaying an image of neurons, with the napari-metadata Layer Metadata widget across the bottom of the viewer.](https://raw.githubusercontent.com/napari/napari-metadata/main/resources/horizontal-widget.png)
+
+Open the `Layer metadata` widget from the `Plugins` menu and you can view File information, and view and edit Axes metadata such as
+axis labels, translation and scale! You can also use the widget to copy specified metadata across to other layers.
+
+Check out the [README](https://github.com/napari/napari-metadata) for some usage documentation, and feel
+free to open an issue to request new features -- we're actively improving this plugin so, more to come!
+
+### (Layer) Features galore
+
+Prior to 0.7.0, our Features table widget only supported showing individual selected layer features.
+
+With [#8189](https://github.com/napari/napari/pull/8189), courtesy of our community 
+contributor Marcelo Zoccoler (@zoccoler), the widget will display
+features of all selected layers! The layer's name is displayed in an additional column, so you 
+always know what you're looking at, and you can choose to display only the shared feature columns
+across all layers. Pretty slick!
+
+![GIF displaying the usage of the features table with multiple selected layers.](https://github.com/user-attachments/assets/e06fd403-ed03-4edd-9192-a4e287d25ff7)
+
+### Imitation is the highest form of flattery - smarter new layer buttons
+
+Prior to 0.7.0, creating a new layer Points, Shapes or Labels layer would give you a layer
+with extent and dimensionality equal to the union of all currently open layers, and with
+none of the other spatial information (scale, units, etc.) inherited.
+
+Now, with [#8357](https://github.com/napari/napari/pull/8357) you can create a new Shapes
+or Points layer (Labels coming soon!) that inherits from a selected layer
+(or a combination of selected layers)! Your new layer will copy all spatial information
+from its ancestor, ready for annotating!
+
+TODO: add image of the different button visual, once merged, and note
+
+If you wish to recover the original behavior, deselect all existing layers before creating your new layer.
+
+PS -- You can now also create these new layers from the `File -> New Layer` menu!
+
+### Negative axis labels? A real positive
+
+If you've ever loaded data of mixed dimensionality in napari, like a TYX volume
+alongside a YX segmentation, you may have noticed the default axis labels didn't
+quite line up:
+
+```
+axes  | 0 | 1 | 2
+volume| 0 | 1 | 2
+segmt |   | 0 | 1
+```
+
+That's because napari used 0-based indexing for its viewer axis labels, which breaks
+down when layers have different numbers of dimensions. With
+[#8565](https://github.com/napari/napari/pull/8565),
+viewer axis labels now use negative indexing by default, just like Python's own indexing
+semantics. The last axis is always `-1`, the second-to-last is always `-2`, and so on:
+
+```
+axes  | 0  | 1  | 2
+volume| -3 | -2 | -1
+segmt |    | -2 | -1
+```
+
+This means axis labels stay consistent as you add or remove layers of different
+dimensionality -- axis `-1` is always your last axis. This also fixes
+a long-standing bug where axis labels could end up duplicated when mixing layers of
+different dimensionality ([#6569](https://github.com/napari/napari/issues/6569)).
+
+You'll notice this change in the dims slider labels, the axis overlay, and the dims
+popup widget. If you already label your axes with your own names (e.g. `z`, `y`, `x`),
+nothing's changed. For everyone else, we have consistency at last!
+
+### Lightning labels
+
+Labels painting on large images used to be sluggish. Polygon fills on a 10000x10000
+label array took over 22 seconds, and large brush sizes would lock up the viewer entirely.
+
+With [#8592](https://github.com/napari/napari/pull/8592), polygon rasterization now uses
+PIL instead of scikit-image's `polygon2mask`, giving us an up to 6x speedup,
+and `data_setitem` now uses numpy's `min`/`max`, giving us an up to 4x speedup!
+
+Small changes, big wins!
+
+### Grid mode -- bigger, better, faster 📈
 
 If you've been playing with our new grid mode since 0.6.5, you 
 may have stumbled into performance issues when progressively adding
@@ -109,18 +209,30 @@ If you had scripts or notebooks setting up angles for screenshots, or if you've 
 materials or tutorials with preset angles, they'll need to be updated. Any existing code
 using `viewer.camera.angles = (z, y, x)` will now produce a different view than before.
 
-...
+### Delete layers without delay
 
-- Multilayer features table ([#8189](https://github.com/napari/napari/pull/8189))
-- Remove `numpydoc` as a base and testing dependency ([#8338](https://github.com/napari/napari/pull/8338))
-- Texture tiling ([#8395](https://github.com/napari/napari/pull/8395))
+[#8479](https://github.com/napari/napari/pull/8479) made a number of improvements to
+our layer and overlay clean-up, addressing a number of issues large numbers of layers
+in the viewer - adding them, deleting them, and even closing the viewer is now snappy
+and smooth!
+
+### Infrastucture & dependencies
+
+A couple of notes on big changes in our dependencies:
+
+- TODO on merge: Python 3.14 and Pydantic v2 support #8509
+- In [#8450](https://github.com/napari/napari/pull/8450) we dropped support for PySide2. If you
+were using napari with PySide for your Qt bindings, you'll need to upgrade to PySide6. Good news
+is that PySide6 is looking pretty stable, while PySide2 had some compatibility issues with numpy2,
+and had to be built from source for Python 3.11+.
+- In [#8338](https://github.com/napari/napari/pull/8338) we replaced `numpydoc` with `docstring_parser`
+for parsing our docstrings. This will be a pretty invisible change from a user's perspective, but
+it saves more than 50MB of disk space for a napari install!
+
+- Better text overlay (and subclasses) ([#8236](https://github.com/napari/napari/pull/8236))
 - Fix overlay initialization and layer addition slowdown ([#8443](https://github.com/napari/napari/pull/8443))
-- Remove shim setting and warning dialog ([#8448](https://github.com/napari/napari/pull/8448))
-- Remove PySide2 support ([#8450](https://github.com/napari/napari/pull/8450))
-- Speed up the deletion of layers by deduplicating the function calls  ([#8479](https://github.com/napari/napari/pull/8479))
-- Remove `npe1` settings and theme loading ([#8540](https://github.com/napari/napari/pull/8540))
-- Use negative indexing for viewer dims axis labels ([#8565](https://github.com/napari/napari/pull/8565))
-- Add napari-metadata to napari dependencies ([#8576](https://github.com/napari/napari/pull/8576))
+- Enable instanced markers if available. ([#8552](https://github.com/napari/napari/pull/8552))
+- Add visual for new points/shapes button on selected layers ([#8649](https://github.com/napari/napari/pull/8649))
 
 ## New Features
 
@@ -136,6 +248,7 @@ using `viewer.camera.angles = (z, y, x)` will now produce a different view than 
 ## Improvements
 
 - perf: reallocate instead of clearing and repopulating set of selected points ([#6895](https://github.com/napari/napari/pull/6895))
+- Add cell tracking example ([#8051](https://github.com/napari/napari/pull/8051))
 - Add a seed argument to built-in samples with random seeds ([#8317](https://github.com/napari/napari/pull/8317))
 - Enh: clarify Points selection keybinding behavior: select_in_slice not append by default, add new select_append_in_slice ([#8339](https://github.com/napari/napari/pull/8339))
 - Enh: Improve zarr reading by builtins ([#8355](https://github.com/napari/napari/pull/8355))
@@ -156,6 +269,8 @@ using `viewer.camera.angles = (z, y, x)` will now produce a different view than 
 - Add caching of outlines to reduce delay on Shapes zoom ([#8536](https://github.com/napari/napari/pull/8536))
 - Don't warn user when a Zarr array with channel axis is passed ([#8559](https://github.com/napari/napari/pull/8559))
 - Use negative indexing for viewer dims axis labels ([#8565](https://github.com/napari/napari/pull/8565))
+- Add colorbar & bounding box overlays to Layers menu ([#8611](https://github.com/napari/napari/pull/8611))
+- Add visual for new points/shapes button on selected layers ([#8649](https://github.com/napari/napari/pull/8649))
 
 ## Performance
 
@@ -194,16 +309,28 @@ using `viewer.camera.angles = (z, y, x)` will now produce a different view than 
 - Fix dim order of rendering of 2D rgb data in 3D mode ([#8522](https://github.com/napari/napari/pull/8522))
 - Fix numpy warning for pure python edge triangulation ([#8523](https://github.com/napari/napari/pull/8523))
 - Do not use keyword argument when creating tooltip ([#8528](https://github.com/napari/napari/pull/8528))
-- Fix angle label values in ndim popup widget ([#8535](https://github.com/napari/napari/pull/8535))
 - Fix update of shape that lead to wrong rendering ([#8543](https://github.com/napari/napari/pull/8543))
 - Close proper window on Ctrl+W ([#8548](https://github.com/napari/napari/pull/8548))
 - Fix the Shapes mode setter to use _is_creating for _finish_drawing and clear selection when going to ADD_* ([#8551](https://github.com/napari/napari/pull/8551))
+- Enable instanced markers if available. ([#8552](https://github.com/napari/napari/pull/8552))
 - Do not expose legacy angle ([#8557](https://github.com/napari/napari/pull/8557))
 - Fix test on PySide6 by change mocking of qt methods ([#8560](https://github.com/napari/napari/pull/8560))
 - Account for tile2data in the Labels polygon overlay ([#8563](https://github.com/napari/napari/pull/8563))
 - ensure overlays are reused properly when gridded mode is enabled ([#8569](https://github.com/napari/napari/pull/8569))
 - Stop welcome screen time on hiding of QtWiewer ([#8585](https://github.com/napari/napari/pull/8585))
 - Fix Labels layer controls contiguous checkbox to initialize to the layer state ([#8594](https://github.com/napari/napari/pull/8594))
+- Proper cleanup and reuse of existing overlays ([#8610](https://github.com/napari/napari/pull/8610))
+- [UI] Update the viewer button tooltips to use the new axis labels (-3, -2, -1) ([#8614](https://github.com/napari/napari/pull/8614))
+- Fix scale bar padding ([#8616](https://github.com/napari/napari/pull/8616))
+- Fix empty thumbnail ([#8620](https://github.com/napari/napari/pull/8620))
+- Reverse overlay tiling order ([#8623](https://github.com/napari/napari/pull/8623))
+- Fix welcome screen timer ([#8627](https://github.com/napari/napari/pull/8627))
+- Reinitialize welcome screen shortcuts in a less ugly way ([#8634](https://github.com/napari/napari/pull/8634))
+- Fix empty points tiny point ([#8639](https://github.com/napari/napari/pull/8639))
+- Fix labels of angle order of camera widget ([#8644](https://github.com/napari/napari/pull/8644))
+- Add a opaque background Rectangle to Welcome overlay ([#8645](https://github.com/napari/napari/pull/8645))
+- Do not start welcome widget timer until QtViewer is visible ([#8652](https://github.com/napari/napari/pull/8652))
+- Allow selection in feature table widget with empty features ([#8653](https://github.com/napari/napari/pull/8653))
 
 ## Build Tools
 
@@ -215,6 +342,7 @@ using `viewer.camera.angles = (z, y, x)` will now produce a different view than 
 
 ## Documentation
 
+- Add colorbar and overlay tiling example ([#8433](https://github.com/napari/napari/pull/8433))
 - Create 3D_vectors_through_time.py ([#8461](https://github.com/napari/napari/pull/8461))
 - Fix and improve `dock_widgets` docstrings ([#8494](https://github.com/napari/napari/pull/8494))
 - Plugin dependencies for docs generation ([#8581](https://github.com/napari/napari/pull/8581))
@@ -235,14 +363,18 @@ using `viewer.camera.angles = (z, y, x)` will now produce a different view than 
 - Migrate and update hub customization from wiki to docs ([docs#906](https://github.com/napari/docs/pull/906))
 - Improve open image section ([docs#907](https://github.com/napari/docs/pull/907))
 - Remove mention of outdated plugin from quick start ([docs#908](https://github.com/napari/docs/pull/908))
+- Update governance documentation ([docs#911](https://github.com/napari/docs/pull/911))
 - increase stack size to solve import recursion problem ([docs#912](https://github.com/napari/docs/pull/912))
 - Update display text copy in shapes.md ([docs#914](https://github.com/napari/docs/pull/914))
 - Update release notes for 0.7.0a1 ([docs#915](https://github.com/napari/docs/pull/915))
 - Simplify titles in App installation instructions ([docs#918](https://github.com/napari/docs/pull/918))
+- Update release notes for 0.7.0a2 ([docs#922](https://github.com/napari/docs/pull/922))
+- Move code for setting recursion limit ([docs#927](https://github.com/napari/docs/pull/927))
+- Add intersphinx mapping for pydantic ([docs#930](https://github.com/napari/docs/pull/930))
+- Add policy on LLM contributions based on Zulip's ([docs#932](https://github.com/napari/docs/pull/932))
 
 ## Other Pull Requests
 
-- Add cell tracking example ([#8051](https://github.com/napari/napari/pull/8051))
 - TYP: overload for `labeled_particles` incorrectly notes `Literal[True]=...` as default for `return_density` ([#8114](https://github.com/napari/napari/pull/8114))
 - Decompose Layer code by move slicing to specialized class ([#8254](https://github.com/napari/napari/pull/8254))
 - Update `hypothesis`, `psygnal` ([#8310](https://github.com/napari/napari/pull/8310))
@@ -263,7 +395,6 @@ using `viewer.camera.angles = (z, y, x)` will now produce a different view than 
 - ci(dependabot): bump the actions group with 3 updates ([#8400](https://github.com/napari/napari/pull/8400))
 - Exclude dependabot from PR author check ([#8409](https://github.com/napari/napari/pull/8409))
 - Fix cff check for bots ([#8420](https://github.com/napari/napari/pull/8420))
-- Add colorbar and overlay tiling example ([#8433](https://github.com/napari/napari/pull/8433))
 - Update `certifi`, `coverage`, `dask`, `fsspec`, `hypothesis`, `imageio`, `ipython`, `matplotlib`, `numpy`, `pandas`, `pillow`, `pint`, `psutil`, `psygnal`, `pydantic`, `pyqt6`, `pyside6`, `pytest`, `pytest-rerunfailures`, `pyyaml`, `rich`, `scipy`, `tensorstore`, `tifffile`, `toolz`, `virtualenv`, `wrapt`, `xarray` ([#8441](https://github.com/napari/napari/pull/8441))
 - [pre-commit.ci] pre-commit autoupdate ([#8442](https://github.com/napari/napari/pull/8442))
 - Stop updating python 3.10 docs constraints ([#8444](https://github.com/napari/napari/pull/8444))
@@ -289,24 +420,43 @@ using `viewer.camera.angles = (z, y, x)` will now produce a different view than 
 - Test on macos-15-intel without numba ([#8503](https://github.com/napari/napari/pull/8503))
 - Move constraints calculation to script, allow upgrade subset of packages ([#8505](https://github.com/napari/napari/pull/8505))
 - Workaround for Zenodo outage by downloading data from google drive.  ([#8508](https://github.com/napari/napari/pull/8508))
+- Migrate EventedModel to pydantic v2 and overlays to psygnal to support python 3.14  ([#8509](https://github.com/napari/napari/pull/8509))
 - Fix overlay tests ([#8513](https://github.com/napari/napari/pull/8513))
 - Update `certifi`, `coverage`, `dask`, `fsspec`, `hypothesis`, `ipython`, `jsonschema`, `pandas`, `pillow`, `psutil`, `psygnal`, `pyqt6`, `scikit-image`, `scipy`, `superqt`, `tifffile`, `virtualenv` ([#8518](https://github.com/napari/napari/pull/8518))
 - [pre-commit.ci] pre-commit autoupdate ([#8519](https://github.com/napari/napari/pull/8519))
 - Reduce noise in benchmark logs ([#8525](https://github.com/napari/napari/pull/8525))
 - Improve language in Citation PR Author check ([#8526](https://github.com/napari/napari/pull/8526))
 - ci(dependabot): bump the actions group with 4 updates ([#8533](https://github.com/napari/napari/pull/8533))
+- Remove `npe1` settings and theme loading ([#8540](https://github.com/napari/napari/pull/8540))
 - Enforce unix line endings ([#8541](https://github.com/napari/napari/pull/8541))
 - Add temporary tox plugin for fix installation of dependency groups ([#8545](https://github.com/napari/napari/pull/8545))
 - Revert: Add temporary tox plugin for fix installation of dependency groups (#8545) ([#8546](https://github.com/napari/napari/pull/8546))
+- Fix typing in layers.points and layers.labels utilities ([#8549](https://github.com/napari/napari/pull/8549))
 - Fix path to constraints update script  ([#8553](https://github.com/napari/napari/pull/8553))
 - [pre-commit.ci] pre-commit autoupdate ([#8554](https://github.com/napari/napari/pull/8554))
 - Stop using `get_settings` during import time ([#8556](https://github.com/napari/napari/pull/8556))
 - Remove 'axis' prefix from layer axis labels ([#8566](https://github.com/napari/napari/pull/8566))
 - [pre-commit.ci] pre-commit autoupdate ([#8571](https://github.com/napari/napari/pull/8571))
 - Remove npe1 code for reading and writing ([#8579](https://github.com/napari/napari/pull/8579))
+- Pin Python < 3.14 ([#8580](https://github.com/napari/napari/pull/8580))
 - Fix build constraints with circular napari dependency ([#8588](https://github.com/napari/napari/pull/8588))
 - Modify sphinx-external-toc version constraint to eliminate warnings ([#8591](https://github.com/napari/napari/pull/8591))
 - Switch logo URL used for reader test ([#8596](https://github.com/napari/napari/pull/8596))
+- Update `coverage`, `hypothesis`, `rich` ([#8597](https://github.com/napari/napari/pull/8597))
+- Move comment trigger of constraints update to a separate workflow ([#8600](https://github.com/napari/napari/pull/8600))
+- Fix running benchmarks by label by fix condition ([#8601](https://github.com/napari/napari/pull/8601))
+- [pre-commit.ci] pre-commit autoupdate ([#8602](https://github.com/napari/napari/pull/8602))
+- Add new logo png and icons for windows/mac ([#8603](https://github.com/napari/napari/pull/8603))
+- ci(dependabot): bump the actions group with 5 updates ([#8613](https://github.com/napari/napari/pull/8613))
+- Update `babel`, `dask`, `hypothesis`, `pooch`, `psutil`, `rich`, `tifffile`, `tqdm`, `wrapt`, `xarray` ([#8615](https://github.com/napari/napari/pull/8615))
+- Postpone QtViewer deprecation to 0.8.0 ([#8617](https://github.com/napari/napari/pull/8617))
+- Remove settings call on import in qt_event_loop ([#8619](https://github.com/napari/napari/pull/8619))
+- Remove remaining `npe1` usage ([#8622](https://github.com/napari/napari/pull/8622))
+- Add `uv.lock` and leak graphs to gitignore ([#8637](https://github.com/napari/napari/pull/8637))
+- Fix pint warning about deprecation of getitem ([#8638](https://github.com/napari/napari/pull/8638))
+- Bump superqt to 0.7.8 ([#8646](https://github.com/napari/napari/pull/8646))
+- Bump napari plugin manager ([#8647](https://github.com/napari/napari/pull/8647))
+- [pre-commit.ci] pre-commit autoupdate ([#8655](https://github.com/napari/napari/pull/8655))
 - ci(dependabot): bump the github-actions group with 4 updates ([docs#856](https://github.com/napari/docs/pull/856))
 - Allow to redeploy docs after merge new commits to main branch ([docs#874](https://github.com/napari/docs/pull/874))
 - Add mdformat to pre-commit config ([docs#878](https://github.com/napari/docs/pull/878))
@@ -320,21 +470,25 @@ using `viewer.camera.angles = (z, y, x)` will now produce a different view than 
 - Stop tracking `docs/release/index.md` so that it is ignored ([docs#905](https://github.com/napari/docs/pull/905))
 - Maint Update PIP_CONSTRAINT to UV_CONSTRAINT in config ([docs#909](https://github.com/napari/docs/pull/909))
 - Remove pixi configuration for macos intel ([docs#913](https://github.com/napari/docs/pull/913))
+- Prepare on migration to `sphinxcontrib-mermaid` ([docs#923](https://github.com/napari/docs/pull/923))
+- ci(dependabot): bump the github-actions group with 2 updates ([docs#925](https://github.com/napari/docs/pull/925))
 
 
-## 17 authors added to this release (alphabetical)
+## 19 authors added to this release (alphabetical)
 
 (+) denotes first-time contributors 🥳
 
 - [Ashley Anderson](https://github.com/napari/napari/commits?author=aganders3) - @aganders3
+- [Constantin Aronssohn](https://github.com/napari/napari/commits?author=cnstt) - @cnstt
 - [Daniel Zhang](https://github.com/napari/napari/commits?author=DanGonite57) - @DanGonite57
 - [David Stansby](https://github.com/napari/napari/commits?author=dstansby) ([docs](https://github.com/napari/docs/commits?author=dstansby))  - @dstansby
 - [Draga Doncila Pop](https://github.com/napari/napari/commits?author=DragaDoncila) ([docs](https://github.com/napari/docs/commits?author=DragaDoncila))  - @DragaDoncila
 - [Edward Andò](https://github.com/napari/napari/commits?author=edwardando) - @edwardando +
 - [Grzegorz Bokota](https://github.com/napari/napari/commits?author=Czaki) ([docs](https://github.com/napari/docs/commits?author=Czaki))  - @Czaki
 - [Guillaume Witz](https://github.com/napari/napari/commits?author=guiwitz) ([docs](https://github.com/napari/docs/commits?author=guiwitz))  - @guiwitz
-- [Juan Nunez-Iglesias](https://github.com/napari/napari/commits?author=jni) - @jni
+- [Juan Nunez-Iglesias](https://github.com/napari/napari/commits?author=jni) ([docs](https://github.com/napari/docs/commits?author=jni))  - @jni
 - [Lorenzo Gaifas](https://github.com/napari/napari/commits?author=brisvag) ([docs](https://github.com/napari/docs/commits?author=brisvag))  - @brisvag
+- [Marcelo Zoccoler](https://github.com/napari/napari/commits?author=zoccoler) - @zoccoler
 - [Marco Edward Gorelli](https://github.com/napari/napari/commits?author=MarcoGorelli) - @MarcoGorelli +
 - [Melissa Weber Mendonça](https://github.com/napari/napari/commits?author=melissawm) ([docs](https://github.com/napari/docs/commits?author=melissawm))  - @melissawm
 - [Peter Sobolewski](https://github.com/napari/napari/commits?author=psobolewskiPhD) ([docs](https://github.com/napari/docs/commits?author=psobolewskiPhD))  - @psobolewskiPhD
@@ -359,9 +513,9 @@ using `viewer.camera.angles = (z, y, x)` will now produce a different view than 
 - [Guillaume Witz](https://github.com/napari/napari/commits?author=guiwitz) ([docs](https://github.com/napari/docs/commits?author=guiwitz))  - @guiwitz
 - [Jacopo Abramo](https://github.com/napari/docs/commits?author=jacopoabramo) - @jacopoabramo
 - [Johannes Soltwedel](https://github.com/napari/docs/commits?author=jo-mueller) - @jo-mueller
-- [Juan Nunez-Iglesias](https://github.com/napari/napari/commits?author=jni) - @jni
+- [Juan Nunez-Iglesias](https://github.com/napari/napari/commits?author=jni) ([docs](https://github.com/napari/docs/commits?author=jni))  - @jni
 - [Lorenzo Gaifas](https://github.com/napari/napari/commits?author=brisvag) ([docs](https://github.com/napari/docs/commits?author=brisvag))  - @brisvag
-- [Marcelo Zoccoler](https://github.com/napari/docs/commits?author=zoccoler) - @zoccoler
+- [Marcelo Zoccoler](https://github.com/napari/napari/commits?author=zoccoler) - @zoccoler
 - [Marco Edward Gorelli](https://github.com/napari/napari/commits?author=MarcoGorelli) - @MarcoGorelli +
 - [Melissa Weber Mendonça](https://github.com/napari/napari/commits?author=melissawm) ([docs](https://github.com/napari/docs/commits?author=melissawm))  - @melissawm
 - [Peter Sobolewski](https://github.com/napari/napari/commits?author=psobolewskiPhD) ([docs](https://github.com/napari/docs/commits?author=psobolewskiPhD))  - @psobolewskiPhD

--- a/docs/release/release_0_7_0.md
+++ b/docs/release/release_0_7_0.md
@@ -1,7 +1,7 @@
 # napari 0.7.0
 ⚠️ *Note: these release notes are still in draft while 0.7.0 is in release candidate testing.* ⚠️
 
-*Wed, Feb 04, 2026*
+*Tue, Jan 27, 2026*
 
 We're happy to announce the release of napari 0.7.0!
 napari is a fast, interactive, multi-dimensional image viewer for Python.
@@ -25,8 +25,7 @@ In all 0.6.x releases, npe1 plugins were automatically converted to npe2 by defa
 and users could turn off the `use_npe2_adaptor` setting to continue using npe1 plugins
 without auto-conversion.
 
-In 0.7.0 this setting is being removed ([PR #8448](https://github.com/napari/napari/pull/8448)),
-and plugins will *only* continue to function if
+In 0.7.0 this setting is being removed, and plugins will *only* continue to function if
 they can be auto-converted to npe2. Most plugins will be unaffected, but those that rely
 on import-time behaviour may not work as expected. If a plugin is relying on import-time
 behaviour, it may be able to replicate this using the new startup scripts functionality added
@@ -48,106 +47,7 @@ our [Plugins Zulip chat
 channel](https://napari.zulipchat.com/#narrow/channel/309872-plugins) or by
 coming to one of our [community meetings](meeting-schedule).
 
-### More pixels to play with - texture tiling
-
-Ever loaded a large 2D image in napari just to zoom in and find it's blurrier
-than a JPEG from the year 2000? That's no longer the case!
-
-Courtesy of our community contributor, Guillaume Witz (@guiwitz), and his PR for
-texture tiling ([PR #8395](https://github.com/napari/napari/pull/8395)) 2D
-images that exceed OpenGL's maximum texture size will be split into multiple
-tiles, each small enough to fit on the GPU, and rendered as separate vispy `Image` node.
-
-![Image with a screenshot of napari 0.6.6 on the left and napari 0.7.0 on the right displaying a DeCAM image of the Milky Way. The image on the left is pixelated, while the image on the right is displayed at full resolution.](https://github.com/user-attachments/assets/d0a115a8-49d5-432c-b561-f29fe9ac8116)
-
-### What's my metadata? Where's my metadata? `napari-metadata` to the rescue
-
-With a lot of work from our community contributor, Carlos Mario Rodriguez Reza (@carlosmariorr), and
-our venerable community manager Tim Monko (@TimMonko), `napari` now has a metadata viewing and editing plugin
-included in our `napari[all]` installation and our bundle ([PR #8576](https://github.com/napari/napari/pull/8576)).
-
-![Screenshot of napari displaying an image of neurons, with the napari-metadata Layer Metadata widget across the bottom of the viewer.](https://raw.githubusercontent.com/napari/napari-metadata/main/resources/horizontal-widget.png)
-
-Open the `Layer metadata` widget from the `Plugins` menu and you can view File information, and view and edit Axes metadata such as
-axis labels, translation and scale! You can also use the widget to copy specified metadata across to other layers.
-
-Check out the [README](https://github.com/napari/napari-metadata) for some usage documentation, and feel
-free to open an issue to request new features -- we're actively improving this plugin so, more to come!
-
-### (Layer) Features galore
-
-Prior to 0.7.0, our Features table widget only supported showing individual selected layer features.
-
-With [#8189](https://github.com/napari/napari/pull/8189), courtesy of our community 
-contributor Marcelo Zoccoler (@zoccoler), the widget will display
-features of all selected layers! The layer's name is displayed in an additional column, so you 
-always know what you're looking at, and you can choose to display only the shared feature columns
-across all layers. Pretty slick!
-
-![GIF displaying the usage of the features table with multiple selected layers.](https://github.com/user-attachments/assets/e06fd403-ed03-4edd-9192-a4e287d25ff7)
-
-### Imitation is the highest form of flattery - smarter new layer buttons
-
-Prior to 0.7.0, creating a new layer Points, Shapes or Labels layer would give you a layer
-with extent and dimensionality equal to the union of all currently open layers, and with
-none of the other spatial information (scale, units, etc.) inherited.
-
-Now, with [#8357](https://github.com/napari/napari/pull/8357) you can create a new Shapes
-or Points layer (Labels coming soon!) that inherits from a selected layer
-(or a combination of selected layers)! Your new layer will copy all spatial information
-from its ancestor, ready for annotating!
-
-TODO: add image of the different button visual, once merged, and note
-
-If you wish to recover the original behavior, deselect all existing layers before creating your new layer.
-
-PS -- You can now also create these new layers from the `File -> New Layer` menu!
-
-### Negative axis labels? A real positive
-
-If you've ever loaded data of mixed dimensionality in napari, like a TYX volume
-alongside a YX segmentation, you may have noticed the default axis labels didn't
-quite line up:
-
-```
-axes  | 0 | 1 | 2
-volume| 0 | 1 | 2
-segmt |   | 0 | 1
-```
-
-That's because napari used 0-based indexing for its viewer axis labels, which breaks
-down when layers have different numbers of dimensions. With
-[#8565](https://github.com/napari/napari/pull/8565),
-viewer axis labels now use negative indexing by default, just like Python's own indexing
-semantics. The last axis is always `-1`, the second-to-last is always `-2`, and so on:
-
-```
-axes  | 0  | 1  | 2
-volume| -3 | -2 | -1
-segmt |    | -2 | -1
-```
-
-This means axis labels stay consistent as you add or remove layers of different
-dimensionality -- axis `-1` is always your last axis. This also fixes
-a long-standing bug where axis labels could end up duplicated when mixing layers of
-different dimensionality ([#6569](https://github.com/napari/napari/issues/6569)).
-
-You'll notice this change in the dims slider labels, the axis overlay, and the dims
-popup widget. If you already label your axes with your own names (e.g. `z`, `y`, `x`),
-nothing's changed. For everyone else, we have consistency at last!
-
-### Lightning labels
-
-Labels painting on large images used to be sluggish. Polygon fills on a 10000x10000
-label array took over 22 seconds, and large brush sizes would lock up the viewer entirely.
-
-With [#8592](https://github.com/napari/napari/pull/8592), polygon rasterization now uses
-PIL instead of scikit-image's `polygon2mask`, giving us an up to 6x speedup,
-and `data_setitem` now uses numpy's `min`/`max`, giving us an up to 4x speedup!
-
-Small changes, big wins!
-
-### Grid mode -- bigger, better, faster 📈
+### Grid mode - bigger, better, faster 📈
 
 If you've been playing with our new grid mode since 0.6.5, you 
 may have stumbled into performance issues when progressively adding
@@ -209,30 +109,18 @@ If you had scripts or notebooks setting up angles for screenshots, or if you've 
 materials or tutorials with preset angles, they'll need to be updated. Any existing code
 using `viewer.camera.angles = (z, y, x)` will now produce a different view than before.
 
-### Delete layers without delay
+...
 
-[#8479](https://github.com/napari/napari/pull/8479) made a number of improvements to
-our layer and overlay clean-up, addressing a number of issues large numbers of layers
-in the viewer - adding them, deleting them, and even closing the viewer is now snappy
-and smooth!
-
-### Infrastucture & dependencies
-
-A couple of notes on big changes in our dependencies:
-
-- TODO on merge: Python 3.14 and Pydantic v2 support #8509
-- In [#8450](https://github.com/napari/napari/pull/8450) we dropped support for PySide2. If you
-were using napari with PySide for your Qt bindings, you'll need to upgrade to PySide6. Good news
-is that PySide6 is looking pretty stable, while PySide2 had some compatibility issues with numpy2,
-and had to be built from source for Python 3.11+.
-- In [#8338](https://github.com/napari/napari/pull/8338) we replaced `numpydoc` with `docstring_parser`
-for parsing our docstrings. This will be a pretty invisible change from a user's perspective, but
-it saves more than 50MB of disk space for a napari install!
-
-- Better text overlay (and subclasses) ([#8236](https://github.com/napari/napari/pull/8236))
+- Multilayer features table ([#8189](https://github.com/napari/napari/pull/8189))
+- Remove `numpydoc` as a base and testing dependency ([#8338](https://github.com/napari/napari/pull/8338))
+- Texture tiling ([#8395](https://github.com/napari/napari/pull/8395))
 - Fix overlay initialization and layer addition slowdown ([#8443](https://github.com/napari/napari/pull/8443))
-- Enable instanced markers if available. ([#8552](https://github.com/napari/napari/pull/8552))
-- Add visual for new points/shapes button on selected layers ([#8649](https://github.com/napari/napari/pull/8649))
+- Remove shim setting and warning dialog ([#8448](https://github.com/napari/napari/pull/8448))
+- Remove PySide2 support ([#8450](https://github.com/napari/napari/pull/8450))
+- Speed up the deletion of layers by deduplicating the function calls  ([#8479](https://github.com/napari/napari/pull/8479))
+- Remove `npe1` settings and theme loading ([#8540](https://github.com/napari/napari/pull/8540))
+- Use negative indexing for viewer dims axis labels ([#8565](https://github.com/napari/napari/pull/8565))
+- Add napari-metadata to napari dependencies ([#8576](https://github.com/napari/napari/pull/8576))
 
 ## New Features
 
@@ -248,7 +136,6 @@ it saves more than 50MB of disk space for a napari install!
 ## Improvements
 
 - perf: reallocate instead of clearing and repopulating set of selected points ([#6895](https://github.com/napari/napari/pull/6895))
-- Add cell tracking example ([#8051](https://github.com/napari/napari/pull/8051))
 - Add a seed argument to built-in samples with random seeds ([#8317](https://github.com/napari/napari/pull/8317))
 - Enh: clarify Points selection keybinding behavior: select_in_slice not append by default, add new select_append_in_slice ([#8339](https://github.com/napari/napari/pull/8339))
 - Enh: Improve zarr reading by builtins ([#8355](https://github.com/napari/napari/pull/8355))
@@ -269,8 +156,6 @@ it saves more than 50MB of disk space for a napari install!
 - Add caching of outlines to reduce delay on Shapes zoom ([#8536](https://github.com/napari/napari/pull/8536))
 - Don't warn user when a Zarr array with channel axis is passed ([#8559](https://github.com/napari/napari/pull/8559))
 - Use negative indexing for viewer dims axis labels ([#8565](https://github.com/napari/napari/pull/8565))
-- Add colorbar & bounding box overlays to Layers menu ([#8611](https://github.com/napari/napari/pull/8611))
-- Add visual for new points/shapes button on selected layers ([#8649](https://github.com/napari/napari/pull/8649))
 
 ## Performance
 
@@ -309,28 +194,16 @@ it saves more than 50MB of disk space for a napari install!
 - Fix dim order of rendering of 2D rgb data in 3D mode ([#8522](https://github.com/napari/napari/pull/8522))
 - Fix numpy warning for pure python edge triangulation ([#8523](https://github.com/napari/napari/pull/8523))
 - Do not use keyword argument when creating tooltip ([#8528](https://github.com/napari/napari/pull/8528))
+- Fix angle label values in ndim popup widget ([#8535](https://github.com/napari/napari/pull/8535))
 - Fix update of shape that lead to wrong rendering ([#8543](https://github.com/napari/napari/pull/8543))
 - Close proper window on Ctrl+W ([#8548](https://github.com/napari/napari/pull/8548))
 - Fix the Shapes mode setter to use _is_creating for _finish_drawing and clear selection when going to ADD_* ([#8551](https://github.com/napari/napari/pull/8551))
-- Enable instanced markers if available. ([#8552](https://github.com/napari/napari/pull/8552))
 - Do not expose legacy angle ([#8557](https://github.com/napari/napari/pull/8557))
 - Fix test on PySide6 by change mocking of qt methods ([#8560](https://github.com/napari/napari/pull/8560))
 - Account for tile2data in the Labels polygon overlay ([#8563](https://github.com/napari/napari/pull/8563))
 - ensure overlays are reused properly when gridded mode is enabled ([#8569](https://github.com/napari/napari/pull/8569))
 - Stop welcome screen time on hiding of QtWiewer ([#8585](https://github.com/napari/napari/pull/8585))
 - Fix Labels layer controls contiguous checkbox to initialize to the layer state ([#8594](https://github.com/napari/napari/pull/8594))
-- Proper cleanup and reuse of existing overlays ([#8610](https://github.com/napari/napari/pull/8610))
-- [UI] Update the viewer button tooltips to use the new axis labels (-3, -2, -1) ([#8614](https://github.com/napari/napari/pull/8614))
-- Fix scale bar padding ([#8616](https://github.com/napari/napari/pull/8616))
-- Fix empty thumbnail ([#8620](https://github.com/napari/napari/pull/8620))
-- Reverse overlay tiling order ([#8623](https://github.com/napari/napari/pull/8623))
-- Fix welcome screen timer ([#8627](https://github.com/napari/napari/pull/8627))
-- Reinitialize welcome screen shortcuts in a less ugly way ([#8634](https://github.com/napari/napari/pull/8634))
-- Fix empty points tiny point ([#8639](https://github.com/napari/napari/pull/8639))
-- Fix labels of angle order of camera widget ([#8644](https://github.com/napari/napari/pull/8644))
-- Add a opaque background Rectangle to Welcome overlay ([#8645](https://github.com/napari/napari/pull/8645))
-- Do not start welcome widget timer until QtViewer is visible ([#8652](https://github.com/napari/napari/pull/8652))
-- Allow selection in feature table widget with empty features ([#8653](https://github.com/napari/napari/pull/8653))
 
 ## Build Tools
 
@@ -342,7 +215,6 @@ it saves more than 50MB of disk space for a napari install!
 
 ## Documentation
 
-- Add colorbar and overlay tiling example ([#8433](https://github.com/napari/napari/pull/8433))
 - Create 3D_vectors_through_time.py ([#8461](https://github.com/napari/napari/pull/8461))
 - Fix and improve `dock_widgets` docstrings ([#8494](https://github.com/napari/napari/pull/8494))
 - Plugin dependencies for docs generation ([#8581](https://github.com/napari/napari/pull/8581))
@@ -363,18 +235,14 @@ it saves more than 50MB of disk space for a napari install!
 - Migrate and update hub customization from wiki to docs ([docs#906](https://github.com/napari/docs/pull/906))
 - Improve open image section ([docs#907](https://github.com/napari/docs/pull/907))
 - Remove mention of outdated plugin from quick start ([docs#908](https://github.com/napari/docs/pull/908))
-- Update governance documentation ([docs#911](https://github.com/napari/docs/pull/911))
 - increase stack size to solve import recursion problem ([docs#912](https://github.com/napari/docs/pull/912))
 - Update display text copy in shapes.md ([docs#914](https://github.com/napari/docs/pull/914))
 - Update release notes for 0.7.0a1 ([docs#915](https://github.com/napari/docs/pull/915))
 - Simplify titles in App installation instructions ([docs#918](https://github.com/napari/docs/pull/918))
-- Update release notes for 0.7.0a2 ([docs#922](https://github.com/napari/docs/pull/922))
-- Move code for setting recursion limit ([docs#927](https://github.com/napari/docs/pull/927))
-- Add intersphinx mapping for pydantic ([docs#930](https://github.com/napari/docs/pull/930))
-- Add policy on LLM contributions based on Zulip's ([docs#932](https://github.com/napari/docs/pull/932))
 
 ## Other Pull Requests
 
+- Add cell tracking example ([#8051](https://github.com/napari/napari/pull/8051))
 - TYP: overload for `labeled_particles` incorrectly notes `Literal[True]=...` as default for `return_density` ([#8114](https://github.com/napari/napari/pull/8114))
 - Decompose Layer code by move slicing to specialized class ([#8254](https://github.com/napari/napari/pull/8254))
 - Update `hypothesis`, `psygnal` ([#8310](https://github.com/napari/napari/pull/8310))
@@ -395,6 +263,7 @@ it saves more than 50MB of disk space for a napari install!
 - ci(dependabot): bump the actions group with 3 updates ([#8400](https://github.com/napari/napari/pull/8400))
 - Exclude dependabot from PR author check ([#8409](https://github.com/napari/napari/pull/8409))
 - Fix cff check for bots ([#8420](https://github.com/napari/napari/pull/8420))
+- Add colorbar and overlay tiling example ([#8433](https://github.com/napari/napari/pull/8433))
 - Update `certifi`, `coverage`, `dask`, `fsspec`, `hypothesis`, `imageio`, `ipython`, `matplotlib`, `numpy`, `pandas`, `pillow`, `pint`, `psutil`, `psygnal`, `pydantic`, `pyqt6`, `pyside6`, `pytest`, `pytest-rerunfailures`, `pyyaml`, `rich`, `scipy`, `tensorstore`, `tifffile`, `toolz`, `virtualenv`, `wrapt`, `xarray` ([#8441](https://github.com/napari/napari/pull/8441))
 - [pre-commit.ci] pre-commit autoupdate ([#8442](https://github.com/napari/napari/pull/8442))
 - Stop updating python 3.10 docs constraints ([#8444](https://github.com/napari/napari/pull/8444))
@@ -420,43 +289,24 @@ it saves more than 50MB of disk space for a napari install!
 - Test on macos-15-intel without numba ([#8503](https://github.com/napari/napari/pull/8503))
 - Move constraints calculation to script, allow upgrade subset of packages ([#8505](https://github.com/napari/napari/pull/8505))
 - Workaround for Zenodo outage by downloading data from google drive.  ([#8508](https://github.com/napari/napari/pull/8508))
-- Migrate EventedModel to pydantic v2 and overlays to psygnal to support python 3.14  ([#8509](https://github.com/napari/napari/pull/8509))
 - Fix overlay tests ([#8513](https://github.com/napari/napari/pull/8513))
 - Update `certifi`, `coverage`, `dask`, `fsspec`, `hypothesis`, `ipython`, `jsonschema`, `pandas`, `pillow`, `psutil`, `psygnal`, `pyqt6`, `scikit-image`, `scipy`, `superqt`, `tifffile`, `virtualenv` ([#8518](https://github.com/napari/napari/pull/8518))
 - [pre-commit.ci] pre-commit autoupdate ([#8519](https://github.com/napari/napari/pull/8519))
 - Reduce noise in benchmark logs ([#8525](https://github.com/napari/napari/pull/8525))
 - Improve language in Citation PR Author check ([#8526](https://github.com/napari/napari/pull/8526))
 - ci(dependabot): bump the actions group with 4 updates ([#8533](https://github.com/napari/napari/pull/8533))
-- Remove `npe1` settings and theme loading ([#8540](https://github.com/napari/napari/pull/8540))
 - Enforce unix line endings ([#8541](https://github.com/napari/napari/pull/8541))
 - Add temporary tox plugin for fix installation of dependency groups ([#8545](https://github.com/napari/napari/pull/8545))
 - Revert: Add temporary tox plugin for fix installation of dependency groups (#8545) ([#8546](https://github.com/napari/napari/pull/8546))
-- Fix typing in layers.points and layers.labels utilities ([#8549](https://github.com/napari/napari/pull/8549))
 - Fix path to constraints update script  ([#8553](https://github.com/napari/napari/pull/8553))
 - [pre-commit.ci] pre-commit autoupdate ([#8554](https://github.com/napari/napari/pull/8554))
 - Stop using `get_settings` during import time ([#8556](https://github.com/napari/napari/pull/8556))
 - Remove 'axis' prefix from layer axis labels ([#8566](https://github.com/napari/napari/pull/8566))
 - [pre-commit.ci] pre-commit autoupdate ([#8571](https://github.com/napari/napari/pull/8571))
 - Remove npe1 code for reading and writing ([#8579](https://github.com/napari/napari/pull/8579))
-- Pin Python < 3.14 ([#8580](https://github.com/napari/napari/pull/8580))
 - Fix build constraints with circular napari dependency ([#8588](https://github.com/napari/napari/pull/8588))
 - Modify sphinx-external-toc version constraint to eliminate warnings ([#8591](https://github.com/napari/napari/pull/8591))
 - Switch logo URL used for reader test ([#8596](https://github.com/napari/napari/pull/8596))
-- Update `coverage`, `hypothesis`, `rich` ([#8597](https://github.com/napari/napari/pull/8597))
-- Move comment trigger of constraints update to a separate workflow ([#8600](https://github.com/napari/napari/pull/8600))
-- Fix running benchmarks by label by fix condition ([#8601](https://github.com/napari/napari/pull/8601))
-- [pre-commit.ci] pre-commit autoupdate ([#8602](https://github.com/napari/napari/pull/8602))
-- Add new logo png and icons for windows/mac ([#8603](https://github.com/napari/napari/pull/8603))
-- ci(dependabot): bump the actions group with 5 updates ([#8613](https://github.com/napari/napari/pull/8613))
-- Update `babel`, `dask`, `hypothesis`, `pooch`, `psutil`, `rich`, `tifffile`, `tqdm`, `wrapt`, `xarray` ([#8615](https://github.com/napari/napari/pull/8615))
-- Postpone QtViewer deprecation to 0.8.0 ([#8617](https://github.com/napari/napari/pull/8617))
-- Remove settings call on import in qt_event_loop ([#8619](https://github.com/napari/napari/pull/8619))
-- Remove remaining `npe1` usage ([#8622](https://github.com/napari/napari/pull/8622))
-- Add `uv.lock` and leak graphs to gitignore ([#8637](https://github.com/napari/napari/pull/8637))
-- Fix pint warning about deprecation of getitem ([#8638](https://github.com/napari/napari/pull/8638))
-- Bump superqt to 0.7.8 ([#8646](https://github.com/napari/napari/pull/8646))
-- Bump napari plugin manager ([#8647](https://github.com/napari/napari/pull/8647))
-- [pre-commit.ci] pre-commit autoupdate ([#8655](https://github.com/napari/napari/pull/8655))
 - ci(dependabot): bump the github-actions group with 4 updates ([docs#856](https://github.com/napari/docs/pull/856))
 - Allow to redeploy docs after merge new commits to main branch ([docs#874](https://github.com/napari/docs/pull/874))
 - Add mdformat to pre-commit config ([docs#878](https://github.com/napari/docs/pull/878))
@@ -470,25 +320,21 @@ it saves more than 50MB of disk space for a napari install!
 - Stop tracking `docs/release/index.md` so that it is ignored ([docs#905](https://github.com/napari/docs/pull/905))
 - Maint Update PIP_CONSTRAINT to UV_CONSTRAINT in config ([docs#909](https://github.com/napari/docs/pull/909))
 - Remove pixi configuration for macos intel ([docs#913](https://github.com/napari/docs/pull/913))
-- Prepare on migration to `sphinxcontrib-mermaid` ([docs#923](https://github.com/napari/docs/pull/923))
-- ci(dependabot): bump the github-actions group with 2 updates ([docs#925](https://github.com/napari/docs/pull/925))
 
 
-## 19 authors added to this release (alphabetical)
+## 17 authors added to this release (alphabetical)
 
 (+) denotes first-time contributors 🥳
 
 - [Ashley Anderson](https://github.com/napari/napari/commits?author=aganders3) - @aganders3
-- [Constantin Aronssohn](https://github.com/napari/napari/commits?author=cnstt) - @cnstt
 - [Daniel Zhang](https://github.com/napari/napari/commits?author=DanGonite57) - @DanGonite57
 - [David Stansby](https://github.com/napari/napari/commits?author=dstansby) ([docs](https://github.com/napari/docs/commits?author=dstansby))  - @dstansby
 - [Draga Doncila Pop](https://github.com/napari/napari/commits?author=DragaDoncila) ([docs](https://github.com/napari/docs/commits?author=DragaDoncila))  - @DragaDoncila
 - [Edward Andò](https://github.com/napari/napari/commits?author=edwardando) - @edwardando +
 - [Grzegorz Bokota](https://github.com/napari/napari/commits?author=Czaki) ([docs](https://github.com/napari/docs/commits?author=Czaki))  - @Czaki
 - [Guillaume Witz](https://github.com/napari/napari/commits?author=guiwitz) ([docs](https://github.com/napari/docs/commits?author=guiwitz))  - @guiwitz
-- [Juan Nunez-Iglesias](https://github.com/napari/napari/commits?author=jni) ([docs](https://github.com/napari/docs/commits?author=jni))  - @jni
+- [Juan Nunez-Iglesias](https://github.com/napari/napari/commits?author=jni) - @jni
 - [Lorenzo Gaifas](https://github.com/napari/napari/commits?author=brisvag) ([docs](https://github.com/napari/docs/commits?author=brisvag))  - @brisvag
-- [Marcelo Zoccoler](https://github.com/napari/napari/commits?author=zoccoler) - @zoccoler
 - [Marco Edward Gorelli](https://github.com/napari/napari/commits?author=MarcoGorelli) - @MarcoGorelli +
 - [Melissa Weber Mendonça](https://github.com/napari/napari/commits?author=melissawm) ([docs](https://github.com/napari/docs/commits?author=melissawm))  - @melissawm
 - [Peter Sobolewski](https://github.com/napari/napari/commits?author=psobolewskiPhD) ([docs](https://github.com/napari/docs/commits?author=psobolewskiPhD))  - @psobolewskiPhD
@@ -513,9 +359,9 @@ it saves more than 50MB of disk space for a napari install!
 - [Guillaume Witz](https://github.com/napari/napari/commits?author=guiwitz) ([docs](https://github.com/napari/docs/commits?author=guiwitz))  - @guiwitz
 - [Jacopo Abramo](https://github.com/napari/docs/commits?author=jacopoabramo) - @jacopoabramo
 - [Johannes Soltwedel](https://github.com/napari/docs/commits?author=jo-mueller) - @jo-mueller
-- [Juan Nunez-Iglesias](https://github.com/napari/napari/commits?author=jni) ([docs](https://github.com/napari/docs/commits?author=jni))  - @jni
+- [Juan Nunez-Iglesias](https://github.com/napari/napari/commits?author=jni) - @jni
 - [Lorenzo Gaifas](https://github.com/napari/napari/commits?author=brisvag) ([docs](https://github.com/napari/docs/commits?author=brisvag))  - @brisvag
-- [Marcelo Zoccoler](https://github.com/napari/napari/commits?author=zoccoler) - @zoccoler
+- [Marcelo Zoccoler](https://github.com/napari/docs/commits?author=zoccoler) - @zoccoler
 - [Marco Edward Gorelli](https://github.com/napari/napari/commits?author=MarcoGorelli) - @MarcoGorelli +
 - [Melissa Weber Mendonça](https://github.com/napari/napari/commits?author=melissawm) ([docs](https://github.com/napari/docs/commits?author=melissawm))  - @melissawm
 - [Peter Sobolewski](https://github.com/napari/napari/commits?author=psobolewskiPhD) ([docs](https://github.com/napari/docs/commits?author=psobolewskiPhD))  - @psobolewskiPhD


### PR DESCRIPTION
# Description
As discussed on zulip and in core team meetings, this PR updates our governance documentation to clarify the roles and responsibilities of the core team and steering council, and expand on the process for nominating and onboarding new members.

**Edit 2026-01-29:**
One addition which we did not discuss is the process for expelling core team members and SC members (although we did discuss the need for such a process). @jni and I spoke about it today and based the addition in this PR on the cooperative rules, which we thought were reasonable. Of course, like all changes in this PR, this is fully open for discussion and feedback! 