### PR TITLE
increase stack size to solve import recursion problem

### DIFF
--- a/docs/_scripts/update_ui_sections_docs.py
+++ b/docs/_scripts/update_ui_sections_docs.py
@@ -780,6 +780,9 @@ def main(stubs=False):
 
 if __name__ == '__main__':
     import argparse
+    import sys
+
+    sys.setrecursionlimit(5000)
 
     parser = argparse.ArgumentParser(description='Update UI sections docs.')
     parser.add_argument(


### PR DESCRIPTION
# References and relevant issues

unlock napari/napari#8051

# Description

Currently napari/napari#8051 is failing the docs build because the `pydeps` graph being built during the "generating docs for UI section: Application status bar" step hits a recursion error. Although that PR doesn't really touch our code that much (and certainly doesn't touch the Application status bar), it **does** introduce a couple of new gallery dependencies, and their presence in the docs environment may be causing this error.

As I have problems with finding the best way to improve pydeps, this PR is just increasing the stack limit to merge the example in 0.7.0 release. 
