### PR TITLE
Remove pixi configuration for macos intel

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -4,7 +4,7 @@ authors = ["napari developers"]
 channels = ["conda-forge"]
 name = "napari-docs"
 
-platforms = ["win-64", "linux-64", "osx-arm64"]  # All platforms
+platforms = ["win-64", "linux-64", "osx-arm64"]  # Mac Intel support is not available
 version = "0.1.0"
 
 [feature.base.dependencies]

--- a/pixi.toml
+++ b/pixi.toml
@@ -4,7 +4,7 @@ authors = ["napari developers"]
 channels = ["conda-forge"]
 name = "napari-docs"
 
-platforms = ["win-64", "linux-64", "osx-64", "osx-arm64"]  # All platforms
+platforms = ["win-64", "linux-64", "osx-arm64"]  # All platforms
 version = "0.1.0"
 
 [feature.base.dependencies]


### PR DESCRIPTION
# References and relevant issues


# Description

Many packages are dropping support for macOS with Intel processors in the Pixi configuration. This allows not to resolve to old packages and be closer to the CI environment. 
