### PR TITLE
Simplify titles in App installation instructions

### DIFF
--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -242,7 +242,7 @@ pip install napari[pyqt6, optional] -c constraints_py3.10.txt
 
 (installation_bundle_conda)=
 
-## How to install the napari app
+## Install as an application
 
 napari can be installed as a bundled app on [MacOS](#macos-bundle), [Windows](#windows-bundle), and [Linux](#linux-bundle) with a simple one click download and guided installation process. This installation method is best if you mainly want to use napari as a standalone GUI app. However, certain plugins may not be supported.
 
@@ -250,8 +250,6 @@ napari can be installed as a bundled app on [MacOS](#macos-bundle), [Windows](#w
 * If you want to use napari within a Python project, please follow the [Python package installation guide](installation.md#install-as-python-package-recommended).
 * If you want to contribute code back into napari, please follow the [development installation instructions in the contributing guide](napari-contributing).
 ```
-
-### Download and install the napari app ({{ napari_version }}) for your operating system
 
 Click the tile below to jump to the installation instructions for your operating system.
 
@@ -280,7 +278,7 @@ If you are interested in an earlier version of the napari app, you may access th
 
 (macos-bundle)=
 
-### How to install the macOS app
+### macOS
 
 Download the napari app ({{ napari_version }}) for your platform:
 
@@ -341,7 +339,7 @@ Next check out our [tutorial on the viewer](viewer-tutorial) or explore any of t
 
 (windows-bundle)=
 
-### How to install the Windows app
+### Windows
 
 Download the napari app ({{ napari_version }}) for your platform:
 
@@ -385,7 +383,7 @@ Next check out our [tutorial on the viewer](viewer-tutorial) or explore any of t
 
 (linux-bundle)=
 
-### How to install the Linux app
+### Linux
 
 Download the napari app ({{ napari_version }}) for your platform:
 


### PR DESCRIPTION
# References and relevant issues
<!-- What relevant resources were used in the creation of this PR?
If this PR addresses an existing issue on the repo,
please link to that issue here as "Closes #(issue-number)".
If this PR adds docs for a napari PR please add a "Depends on <napari PR link>" -->

# Description
The table of contents in the [installation guide](https://napari.org/dev/getting_started/installation.html#how-to-install-the-napari-app) is currently quite congested with text:

<img width="252" height="475" alt="Screenshot 2026-01-23 at 20 29 30" src="https://github.com/user-attachments/assets/5607730e-c724-43a4-966b-c69a6b543b67" />

This PR simiplifies the title text to simplify the table of contents and make it more readable.

<!-- Previewing the Documentation Build
When you submit this PR, jobs that preview the documentation will be kicked off.
By default, they will use the `slimfast` build (`make` target), which is fast, because
it doesn't build any content from outside the `docs` repository and doesn't run notebook cells.
You can trigger other builds by commenting on the PR with:

@napari-bot make <target>

where <target> can be:
html : a full build, just like the deployment to napari.org
html-noplot : a full build, but without the gallery examples from `napari/napari`
docs : only the content from `napari/docs`, with notebook code cells executed
slimfast : the default, only the content from `napari/docs`, without code cell execution
slimgallery : `slimfast`, but with the gallery examples from `napari/napari` built
-->

<!-- Final Checklist
- If images included: I have added [alt text](https://webaim.org/techniques/alttext/)
If workflow, documentation build or deployment change:
- My PR is the minimum possible work for the desired functionality
- I have commented my code, to let others know what it does
-->
