### PR TITLE
Add intersphinx mapping for pydantic

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -172,6 +172,10 @@ intersphinx_mapping = {
         'https://vispy.org/',
         'https://vispy.org/objects.inv',
     ],
+    'pydantic': [
+        'https://docs.pydantic.dev/latest/',
+        'https://docs.pydantic.dev/latest/objects.inv',
+    ]
 }
 
 # myst markdown extensions for additional markdown features


### PR DESCRIPTION
# References and relevant issues


# Description

I think that we use Pydantic enough heavy to add intersphinx mapping. 