### PR TITLE
Expand on 0.7.0 highlights

### DIFF
--- a/docs/release/release_0_7_0.md
+++ b/docs/release/release_0_7_0.md
@@ -56,7 +56,7 @@ than a JPEG from the year 2000? That's no longer the case!
 Courtesy of our community contributor, Guillaume Witz (@guiwitz), and his PR for
 texture tiling ([PR #8395](https://github.com/napari/napari/pull/8395)) 2D
 images that exceed OpenGL's maximum texture size will be split into multiple
-tiles, each small enough to fit on the GPU, and rendered as separate vispy `Image` node.
+tiles, each small enough to fit on the GPU.
 
 ![Image with a screenshot of napari 0.6.6 on the left and napari 0.7.0 on the right displaying a DeCAM image of the Milky Way. The image on the left is pixelated, while the image on the right is displayed at full resolution.](https://github.com/user-attachments/assets/d0a115a8-49d5-432c-b561-f29fe9ac8116)
 

--- a/docs/release/release_0_7_0.md
+++ b/docs/release/release_0_7_0.md
@@ -1,7 +1,7 @@
 # napari 0.7.0
 ⚠️ *Note: these release notes are still in draft while 0.7.0 is in release candidate testing.* ⚠️
 
-*Tue, Jan 27, 2026*
+*Wed, Feb 04, 2026*
 
 We're happy to announce the release of napari 0.7.0!
 napari is a fast, interactive, multi-dimensional image viewer for Python.
@@ -25,7 +25,8 @@ In all 0.6.x releases, npe1 plugins were automatically converted to npe2 by defa
 and users could turn off the `use_npe2_adaptor` setting to continue using npe1 plugins
 without auto-conversion.
 
-In 0.7.0 this setting is being removed, and plugins will *only* continue to function if
+In 0.7.0 this setting is being removed ([PR #8448](https://github.com/napari/napari/pull/8448)),
+and plugins will *only* continue to function if
 they can be auto-converted to npe2. Most plugins will be unaffected, but those that rely
 on import-time behaviour may not work as expected. If a plugin is relying on import-time
 behaviour, it may be able to replicate this using the new startup scripts functionality added
@@ -47,7 +48,106 @@ our [Plugins Zulip chat
 channel](https://napari.zulipchat.com/#narrow/channel/309872-plugins) or by
 coming to one of our [community meetings](meeting-schedule).
 
-### Grid mode - bigger, better, faster 📈
+### More pixels to play with - texture tiling
+
+Ever loaded a large 2D image in napari just to zoom in and find it's blurrier
+than a JPEG from the year 2000? That's no longer the case!
+
+Courtesy of our community contributor, Guillaume Witz (@guiwitz), and his PR for
+texture tiling ([PR #8395](https://github.com/napari/napari/pull/8395)) 2D
+images that exceed OpenGL's maximum texture size will be split into multiple
+tiles, each small enough to fit on the GPU, and rendered as separate vispy `Image` node.
+
+![Image with a screenshot of napari 0.6.6 on the left and napari 0.7.0 on the right displaying a DeCAM image of the Milky Way. The image on the left is pixelated, while the image on the right is displayed at full resolution.](https://github.com/user-attachments/assets/d0a115a8-49d5-432c-b561-f29fe9ac8116)
+
+### What's my metadata? Where's my metadata? `napari-metadata` to the rescue
+
+With a lot of work from our community contributor, Carlos Mario Rodriguez Reza (@carlosmariorr), and
+our venerable community manager Tim Monko (@TimMonko), `napari` now has a metadata viewing and editing plugin
+included in our `napari[all]` installation and our bundle ([PR #8576](https://github.com/napari/napari/pull/8576)).
+
+![Screenshot of napari displaying an image of neurons, with the napari-metadata Layer Metadata widget across the bottom of the viewer.](https://raw.githubusercontent.com/napari/napari-metadata/main/resources/horizontal-widget.png)
+
+Open the `Layer metadata` widget from the `Plugins` menu and you can view File information, and view and edit Axes metadata such as
+axis labels, translation and scale! You can also use the widget to copy specified metadata across to other layers.
+
+Check out the [README](https://github.com/napari/napari-metadata) for some usage documentation, and feel
+free to open an issue to request new features -- we're actively improving this plugin so, more to come!
+
+### (Layer) Features galore
+
+Prior to 0.7.0, our Features table widget only supported showing individual selected layer features.
+
+With [#8189](https://github.com/napari/napari/pull/8189), courtesy of our community 
+contributor Marcelo Zoccoler (@zoccoler), the widget will display
+features of all selected layers! The layer's name is displayed in an additional column, so you 
+always know what you're looking at, and you can choose to display only the shared feature columns
+across all layers. Pretty slick!
+
+![GIF displaying the usage of the features table with multiple selected layers.](https://github.com/user-attachments/assets/e06fd403-ed03-4edd-9192-a4e287d25ff7)
+
+### Imitation is the highest form of flattery - smarter new layer buttons
+
+Prior to 0.7.0, creating a new layer Points, Shapes or Labels layer would give you a layer
+with extent and dimensionality equal to the union of all currently open layers, and with
+none of the other spatial information (scale, units, etc.) inherited.
+
+Now, with [#8357](https://github.com/napari/napari/pull/8357) you can create a new Shapes
+or Points layer (Labels coming soon!) that inherits from a selected layer
+(or a combination of selected layers)! Your new layer will copy all spatial information
+from its ancestor, ready for annotating!
+
+TODO: add image of the different button visual, once merged, and note
+
+If you wish to recover the original behavior, deselect all existing layers before creating your new layer.
+
+PS -- You can now also create these new layers from the `File -> New Layer` menu!
+
+### Negative axis labels? A real positive
+
+If you've ever loaded data of mixed dimensionality in napari, like a TYX volume
+alongside a YX segmentation, you may have noticed the default axis labels didn't
+quite line up:
+
+```
+axes  | 0 | 1 | 2
+volume| 0 | 1 | 2
+segmt |   | 0 | 1
+```
+
+That's because napari used 0-based indexing for its viewer axis labels, which breaks
+down when layers have different numbers of dimensions. With
+[#8565](https://github.com/napari/napari/pull/8565),
+viewer axis labels now use negative indexing by default, just like Python's own indexing
+semantics. The last axis is always `-1`, the second-to-last is always `-2`, and so on:
+
+```
+axes  | 0  | 1  | 2
+volume| -3 | -2 | -1
+segmt |    | -2 | -1
+```
+
+This means axis labels stay consistent as you add or remove layers of different
+dimensionality -- axis `-1` is always your last axis. This also fixes
+a long-standing bug where axis labels could end up duplicated when mixing layers of
+different dimensionality ([#6569](https://github.com/napari/napari/issues/6569)).
+
+You'll notice this change in the dims slider labels, the axis overlay, and the dims
+popup widget. If you already label your axes with your own names (e.g. `z`, `y`, `x`),
+nothing's changed. For everyone else, we have consistency at last!
+
+### Lightning labels
+
+Labels painting on large images used to be sluggish. Polygon fills on a 10000x10000
+label array took over 22 seconds, and large brush sizes would lock up the viewer entirely.
+
+With [#8592](https://github.com/napari/napari/pull/8592), polygon rasterization now uses
+PIL instead of scikit-image's `polygon2mask`, giving us an up to 6x speedup,
+and `data_setitem` now uses numpy's `min`/`max`, giving us an up to 4x speedup!
+
+Small changes, big wins!
+
+### Grid mode -- bigger, better, faster 📈
 
 If you've been playing with our new grid mode since 0.6.5, you 
 may have stumbled into performance issues when progressively adding
@@ -109,18 +209,30 @@ If you had scripts or notebooks setting up angles for screenshots, or if you've 
 materials or tutorials with preset angles, they'll need to be updated. Any existing code
 using `viewer.camera.angles = (z, y, x)` will now produce a different view than before.
 
-...
+### Delete layers without delay
 
-- Multilayer features table ([#8189](https://github.com/napari/napari/pull/8189))
-- Remove `numpydoc` as a base and testing dependency ([#8338](https://github.com/napari/napari/pull/8338))
-- Texture tiling ([#8395](https://github.com/napari/napari/pull/8395))
+[#8479](https://github.com/napari/napari/pull/8479) made a number of improvements to
+our layer and overlay clean-up, addressing a number of issues large numbers of layers
+in the viewer - adding them, deleting them, and even closing the viewer is now snappy
+and smooth!
+
+### Infrastructure & dependencies
+
+A couple of notes on big changes in our dependencies:
+
+- TODO on merge: Python 3.14 and Pydantic v2 support #8509
+- In [#8450](https://github.com/napari/napari/pull/8450) we dropped support for PySide2. If you
+were using napari with PySide for your Qt bindings, you'll need to upgrade to PySide6. Good news
+is that PySide6 is looking pretty stable, while PySide2 had some compatibility issues with numpy2,
+and had to be built from source for Python 3.11+.
+- In [#8338](https://github.com/napari/napari/pull/8338) we replaced `numpydoc` with `docstring_parser`
+for parsing our docstrings. This will be a pretty invisible change from a user's perspective, but
+it saves more than 50MB of disk space for a napari install!
+
+- Better text overlay (and subclasses) ([#8236](https://github.com/napari/napari/pull/8236))
 - Fix overlay initialization and layer addition slowdown ([#8443](https://github.com/napari/napari/pull/8443))
-- Remove shim setting and warning dialog ([#8448](https://github.com/napari/napari/pull/8448))
-- Remove PySide2 support ([#8450](https://github.com/napari/napari/pull/8450))
-- Speed up the deletion of layers by deduplicating the function calls  ([#8479](https://github.com/napari/napari/pull/8479))
-- Remove `npe1` settings and theme loading ([#8540](https://github.com/napari/napari/pull/8540))
-- Use negative indexing for viewer dims axis labels ([#8565](https://github.com/napari/napari/pull/8565))
-- Add napari-metadata to napari dependencies ([#8576](https://github.com/napari/napari/pull/8576))
+- Enable instanced markers if available. ([#8552](https://github.com/napari/napari/pull/8552))
+- Add visual for new points/shapes button on selected layers ([#8649](https://github.com/napari/napari/pull/8649))
 
 ## New Features
 
@@ -136,6 +248,7 @@ using `viewer.camera.angles = (z, y, x)` will now produce a different view than 
 ## Improvements
 
 - perf: reallocate instead of clearing and repopulating set of selected points ([#6895](https://github.com/napari/napari/pull/6895))
+- Add cell tracking example ([#8051](https://github.com/napari/napari/pull/8051))
 - Add a seed argument to built-in samples with random seeds ([#8317](https://github.com/napari/napari/pull/8317))
 - Enh: clarify Points selection keybinding behavior: select_in_slice not append by default, add new select_append_in_slice ([#8339](https://github.com/napari/napari/pull/8339))
 - Enh: Improve zarr reading by builtins ([#8355](https://github.com/napari/napari/pull/8355))
@@ -156,6 +269,8 @@ using `viewer.camera.angles = (z, y, x)` will now produce a different view than 
 - Add caching of outlines to reduce delay on Shapes zoom ([#8536](https://github.com/napari/napari/pull/8536))
 - Don't warn user when a Zarr array with channel axis is passed ([#8559](https://github.com/napari/napari/pull/8559))
 - Use negative indexing for viewer dims axis labels ([#8565](https://github.com/napari/napari/pull/8565))
+- Add colorbar & bounding box overlays to Layers menu ([#8611](https://github.com/napari/napari/pull/8611))
+- Add visual for new points/shapes button on selected layers ([#8649](https://github.com/napari/napari/pull/8649))
 
 ## Performance
 
@@ -194,16 +309,28 @@ using `viewer.camera.angles = (z, y, x)` will now produce a different view than 
 - Fix dim order of rendering of 2D rgb data in 3D mode ([#8522](https://github.com/napari/napari/pull/8522))
 - Fix numpy warning for pure python edge triangulation ([#8523](https://github.com/napari/napari/pull/8523))
 - Do not use keyword argument when creating tooltip ([#8528](https://github.com/napari/napari/pull/8528))
-- Fix angle label values in ndim popup widget ([#8535](https://github.com/napari/napari/pull/8535))
 - Fix update of shape that lead to wrong rendering ([#8543](https://github.com/napari/napari/pull/8543))
 - Close proper window on Ctrl+W ([#8548](https://github.com/napari/napari/pull/8548))
 - Fix the Shapes mode setter to use _is_creating for _finish_drawing and clear selection when going to ADD_* ([#8551](https://github.com/napari/napari/pull/8551))
+- Enable instanced markers if available. ([#8552](https://github.com/napari/napari/pull/8552))
 - Do not expose legacy angle ([#8557](https://github.com/napari/napari/pull/8557))
 - Fix test on PySide6 by change mocking of qt methods ([#8560](https://github.com/napari/napari/pull/8560))
 - Account for tile2data in the Labels polygon overlay ([#8563](https://github.com/napari/napari/pull/8563))
 - ensure overlays are reused properly when gridded mode is enabled ([#8569](https://github.com/napari/napari/pull/8569))
 - Stop welcome screen time on hiding of QtWiewer ([#8585](https://github.com/napari/napari/pull/8585))
 - Fix Labels layer controls contiguous checkbox to initialize to the layer state ([#8594](https://github.com/napari/napari/pull/8594))
+- Proper cleanup and reuse of existing overlays ([#8610](https://github.com/napari/napari/pull/8610))
+- [UI] Update the viewer button tooltips to use the new axis labels (-3, -2, -1) ([#8614](https://github.com/napari/napari/pull/8614))
+- Fix scale bar padding ([#8616](https://github.com/napari/napari/pull/8616))
+- Fix empty thumbnail ([#8620](https://github.com/napari/napari/pull/8620))
+- Reverse overlay tiling order ([#8623](https://github.com/napari/napari/pull/8623))
+- Fix welcome screen timer ([#8627](https://github.com/napari/napari/pull/8627))
+- Reinitialize welcome screen shortcuts in a less ugly way ([#8634](https://github.com/napari/napari/pull/8634))
+- Fix empty points tiny point ([#8639](https://github.com/napari/napari/pull/8639))
+- Fix labels of angle order of camera widget ([#8644](https://github.com/napari/napari/pull/8644))
+- Add a opaque background Rectangle to Welcome overlay ([#8645](https://github.com/napari/napari/pull/8645))
+- Do not start welcome widget timer until QtViewer is visible ([#8652](https://github.com/napari/napari/pull/8652))
+- Allow selection in feature table widget with empty features ([#8653](https://github.com/napari/napari/pull/8653))
 
 ## Build Tools
 
@@ -215,6 +342,7 @@ using `viewer.camera.angles = (z, y, x)` will now produce a different view than 
 
 ## Documentation
 
+- Add colorbar and overlay tiling example ([#8433](https://github.com/napari/napari/pull/8433))
 - Create 3D_vectors_through_time.py ([#8461](https://github.com/napari/napari/pull/8461))
 - Fix and improve `dock_widgets` docstrings ([#8494](https://github.com/napari/napari/pull/8494))
 - Plugin dependencies for docs generation ([#8581](https://github.com/napari/napari/pull/8581))
@@ -235,14 +363,19 @@ using `viewer.camera.angles = (z, y, x)` will now produce a different view than 
 - Migrate and update hub customization from wiki to docs ([docs#906](https://github.com/napari/docs/pull/906))
 - Improve open image section ([docs#907](https://github.com/napari/docs/pull/907))
 - Remove mention of outdated plugin from quick start ([docs#908](https://github.com/napari/docs/pull/908))
+- Update governance documentation ([docs#911](https://github.com/napari/docs/pull/911))
 - increase stack size to solve import recursion problem ([docs#912](https://github.com/napari/docs/pull/912))
 - Update display text copy in shapes.md ([docs#914](https://github.com/napari/docs/pull/914))
 - Update release notes for 0.7.0a1 ([docs#915](https://github.com/napari/docs/pull/915))
 - Simplify titles in App installation instructions ([docs#918](https://github.com/napari/docs/pull/918))
+- Update release notes for 0.7.0a2 ([docs#922](https://github.com/napari/docs/pull/922))
+- Move code for setting recursion limit ([docs#927](https://github.com/napari/docs/pull/927))
+- Remove npe1-related docs ([docs#929](https://github.com/napari/docs/pull/929))
+- Add intersphinx mapping for pydantic ([docs#930](https://github.com/napari/docs/pull/930))
+- Add policy on LLM contributions based on Zulip's ([docs#932](https://github.com/napari/docs/pull/932))
 
 ## Other Pull Requests
 
-- Add cell tracking example ([#8051](https://github.com/napari/napari/pull/8051))
 - TYP: overload for `labeled_particles` incorrectly notes `Literal[True]=...` as default for `return_density` ([#8114](https://github.com/napari/napari/pull/8114))
 - Decompose Layer code by move slicing to specialized class ([#8254](https://github.com/napari/napari/pull/8254))
 - Update `hypothesis`, `psygnal` ([#8310](https://github.com/napari/napari/pull/8310))
@@ -263,7 +396,6 @@ using `viewer.camera.angles = (z, y, x)` will now produce a different view than 
 - ci(dependabot): bump the actions group with 3 updates ([#8400](https://github.com/napari/napari/pull/8400))
 - Exclude dependabot from PR author check ([#8409](https://github.com/napari/napari/pull/8409))
 - Fix cff check for bots ([#8420](https://github.com/napari/napari/pull/8420))
-- Add colorbar and overlay tiling example ([#8433](https://github.com/napari/napari/pull/8433))
 - Update `certifi`, `coverage`, `dask`, `fsspec`, `hypothesis`, `imageio`, `ipython`, `matplotlib`, `numpy`, `pandas`, `pillow`, `pint`, `psutil`, `psygnal`, `pydantic`, `pyqt6`, `pyside6`, `pytest`, `pytest-rerunfailures`, `pyyaml`, `rich`, `scipy`, `tensorstore`, `tifffile`, `toolz`, `virtualenv`, `wrapt`, `xarray` ([#8441](https://github.com/napari/napari/pull/8441))
 - [pre-commit.ci] pre-commit autoupdate ([#8442](https://github.com/napari/napari/pull/8442))
 - Stop updating python 3.10 docs constraints ([#8444](https://github.com/napari/napari/pull/8444))
@@ -289,24 +421,43 @@ using `viewer.camera.angles = (z, y, x)` will now produce a different view than 
 - Test on macos-15-intel without numba ([#8503](https://github.com/napari/napari/pull/8503))
 - Move constraints calculation to script, allow upgrade subset of packages ([#8505](https://github.com/napari/napari/pull/8505))
 - Workaround for Zenodo outage by downloading data from google drive.  ([#8508](https://github.com/napari/napari/pull/8508))
+- Migrate EventedModel to pydantic v2 and overlays to psygnal to support python 3.14  ([#8509](https://github.com/napari/napari/pull/8509))
 - Fix overlay tests ([#8513](https://github.com/napari/napari/pull/8513))
 - Update `certifi`, `coverage`, `dask`, `fsspec`, `hypothesis`, `ipython`, `jsonschema`, `pandas`, `pillow`, `psutil`, `psygnal`, `pyqt6`, `scikit-image`, `scipy`, `superqt`, `tifffile`, `virtualenv` ([#8518](https://github.com/napari/napari/pull/8518))
 - [pre-commit.ci] pre-commit autoupdate ([#8519](https://github.com/napari/napari/pull/8519))
 - Reduce noise in benchmark logs ([#8525](https://github.com/napari/napari/pull/8525))
 - Improve language in Citation PR Author check ([#8526](https://github.com/napari/napari/pull/8526))
 - ci(dependabot): bump the actions group with 4 updates ([#8533](https://github.com/napari/napari/pull/8533))
+- Remove `npe1` settings and theme loading ([#8540](https://github.com/napari/napari/pull/8540))
 - Enforce unix line endings ([#8541](https://github.com/napari/napari/pull/8541))
 - Add temporary tox plugin for fix installation of dependency groups ([#8545](https://github.com/napari/napari/pull/8545))
 - Revert: Add temporary tox plugin for fix installation of dependency groups (#8545) ([#8546](https://github.com/napari/napari/pull/8546))
+- Fix typing in layers.points and layers.labels utilities ([#8549](https://github.com/napari/napari/pull/8549))
 - Fix path to constraints update script  ([#8553](https://github.com/napari/napari/pull/8553))
 - [pre-commit.ci] pre-commit autoupdate ([#8554](https://github.com/napari/napari/pull/8554))
 - Stop using `get_settings` during import time ([#8556](https://github.com/napari/napari/pull/8556))
 - Remove 'axis' prefix from layer axis labels ([#8566](https://github.com/napari/napari/pull/8566))
 - [pre-commit.ci] pre-commit autoupdate ([#8571](https://github.com/napari/napari/pull/8571))
 - Remove npe1 code for reading and writing ([#8579](https://github.com/napari/napari/pull/8579))
+- Pin Python < 3.14 ([#8580](https://github.com/napari/napari/pull/8580))
 - Fix build constraints with circular napari dependency ([#8588](https://github.com/napari/napari/pull/8588))
 - Modify sphinx-external-toc version constraint to eliminate warnings ([#8591](https://github.com/napari/napari/pull/8591))
 - Switch logo URL used for reader test ([#8596](https://github.com/napari/napari/pull/8596))
+- Update `coverage`, `hypothesis`, `rich` ([#8597](https://github.com/napari/napari/pull/8597))
+- Move comment trigger of constraints update to a separate workflow ([#8600](https://github.com/napari/napari/pull/8600))
+- Fix running benchmarks by label by fix condition ([#8601](https://github.com/napari/napari/pull/8601))
+- [pre-commit.ci] pre-commit autoupdate ([#8602](https://github.com/napari/napari/pull/8602))
+- Add new logo png and icons for windows/mac ([#8603](https://github.com/napari/napari/pull/8603))
+- ci(dependabot): bump the actions group with 5 updates ([#8613](https://github.com/napari/napari/pull/8613))
+- Update `babel`, `dask`, `hypothesis`, `pooch`, `psutil`, `rich`, `tifffile`, `tqdm`, `wrapt`, `xarray` ([#8615](https://github.com/napari/napari/pull/8615))
+- Postpone QtViewer deprecation to 0.8.0 ([#8617](https://github.com/napari/napari/pull/8617))
+- Remove settings call on import in qt_event_loop ([#8619](https://github.com/napari/napari/pull/8619))
+- Remove remaining `npe1` usage ([#8622](https://github.com/napari/napari/pull/8622))
+- Add `uv.lock` and leak graphs to gitignore ([#8637](https://github.com/napari/napari/pull/8637))
+- Fix pint warning about deprecation of getitem ([#8638](https://github.com/napari/napari/pull/8638))
+- Bump superqt to 0.7.8 ([#8646](https://github.com/napari/napari/pull/8646))
+- Bump napari plugin manager ([#8647](https://github.com/napari/napari/pull/8647))
+- [pre-commit.ci] pre-commit autoupdate ([#8655](https://github.com/napari/napari/pull/8655))
 - ci(dependabot): bump the github-actions group with 4 updates ([docs#856](https://github.com/napari/docs/pull/856))
 - Allow to redeploy docs after merge new commits to main branch ([docs#874](https://github.com/napari/docs/pull/874))
 - Add mdformat to pre-commit config ([docs#878](https://github.com/napari/docs/pull/878))
@@ -320,21 +471,25 @@ using `viewer.camera.angles = (z, y, x)` will now produce a different view than 
 - Stop tracking `docs/release/index.md` so that it is ignored ([docs#905](https://github.com/napari/docs/pull/905))
 - Maint Update PIP_CONSTRAINT to UV_CONSTRAINT in config ([docs#909](https://github.com/napari/docs/pull/909))
 - Remove pixi configuration for macos intel ([docs#913](https://github.com/napari/docs/pull/913))
+- Prepare on migration to `sphinxcontrib-mermaid` ([docs#923](https://github.com/napari/docs/pull/923))
+- ci(dependabot): bump the github-actions group with 2 updates ([docs#925](https://github.com/napari/docs/pull/925))
 
 
-## 17 authors added to this release (alphabetical)
+## 19 authors added to this release (alphabetical)
 
 (+) denotes first-time contributors 🥳
 
 - [Ashley Anderson](https://github.com/napari/napari/commits?author=aganders3) - @aganders3
+- [Constantin Aronssohn](https://github.com/napari/napari/commits?author=cnstt) - @cnstt
 - [Daniel Zhang](https://github.com/napari/napari/commits?author=DanGonite57) - @DanGonite57
 - [David Stansby](https://github.com/napari/napari/commits?author=dstansby) ([docs](https://github.com/napari/docs/commits?author=dstansby))  - @dstansby
 - [Draga Doncila Pop](https://github.com/napari/napari/commits?author=DragaDoncila) ([docs](https://github.com/napari/docs/commits?author=DragaDoncila))  - @DragaDoncila
 - [Edward Andò](https://github.com/napari/napari/commits?author=edwardando) - @edwardando +
 - [Grzegorz Bokota](https://github.com/napari/napari/commits?author=Czaki) ([docs](https://github.com/napari/docs/commits?author=Czaki))  - @Czaki
 - [Guillaume Witz](https://github.com/napari/napari/commits?author=guiwitz) ([docs](https://github.com/napari/docs/commits?author=guiwitz))  - @guiwitz
-- [Juan Nunez-Iglesias](https://github.com/napari/napari/commits?author=jni) - @jni
+- [Juan Nunez-Iglesias](https://github.com/napari/napari/commits?author=jni) ([docs](https://github.com/napari/docs/commits?author=jni))  - @jni
 - [Lorenzo Gaifas](https://github.com/napari/napari/commits?author=brisvag) ([docs](https://github.com/napari/docs/commits?author=brisvag))  - @brisvag
+- [Marcelo Zoccoler](https://github.com/napari/napari/commits?author=zoccoler) - @zoccoler
 - [Marco Edward Gorelli](https://github.com/napari/napari/commits?author=MarcoGorelli) - @MarcoGorelli +
 - [Melissa Weber Mendonça](https://github.com/napari/napari/commits?author=melissawm) ([docs](https://github.com/napari/docs/commits?author=melissawm))  - @melissawm
 - [Peter Sobolewski](https://github.com/napari/napari/commits?author=psobolewskiPhD) ([docs](https://github.com/napari/docs/commits?author=psobolewskiPhD))  - @psobolewskiPhD
@@ -359,9 +514,9 @@ using `viewer.camera.angles = (z, y, x)` will now produce a different view than 
 - [Guillaume Witz](https://github.com/napari/napari/commits?author=guiwitz) ([docs](https://github.com/napari/docs/commits?author=guiwitz))  - @guiwitz
 - [Jacopo Abramo](https://github.com/napari/docs/commits?author=jacopoabramo) - @jacopoabramo
 - [Johannes Soltwedel](https://github.com/napari/docs/commits?author=jo-mueller) - @jo-mueller
-- [Juan Nunez-Iglesias](https://github.com/napari/napari/commits?author=jni) - @jni
+- [Juan Nunez-Iglesias](https://github.com/napari/napari/commits?author=jni) ([docs](https://github.com/napari/docs/commits?author=jni))  - @jni
 - [Lorenzo Gaifas](https://github.com/napari/napari/commits?author=brisvag) ([docs](https://github.com/napari/docs/commits?author=brisvag))  - @brisvag
-- [Marcelo Zoccoler](https://github.com/napari/docs/commits?author=zoccoler) - @zoccoler
+- [Marcelo Zoccoler](https://github.com/napari/napari/commits?author=zoccoler) - @zoccoler
 - [Marco Edward Gorelli](https://github.com/napari/napari/commits?author=MarcoGorelli) - @MarcoGorelli +
 - [Melissa Weber Mendonça](https://github.com/napari/napari/commits?author=melissawm) ([docs](https://github.com/napari/docs/commits?author=melissawm))  - @melissawm
 - [Peter Sobolewski](https://github.com/napari/napari/commits?author=psobolewskiPhD) ([docs](https://github.com/napari/docs/commits?author=psobolewskiPhD))  - @psobolewskiPhD

--- a/docs/release/release_0_7_0.md
+++ b/docs/release/release_0_7_0.md
@@ -86,7 +86,7 @@ across all layers. Pretty slick!
 
 ![GIF displaying the usage of the features table with multiple selected layers.](https://github.com/user-attachments/assets/e06fd403-ed03-4edd-9192-a4e287d25ff7)
 
-### Imitation is the highest form of flattery - smarter new layer buttons
+### Smarter new layer buttons - inheriting from selected layers
 
 Prior to 0.7.0, creating a new layer Points, Shapes or Labels layer would give you a layer
 with extent and dimensionality equal to the union of all currently open layers, and with
@@ -94,8 +94,9 @@ none of the other spatial information (scale, units, etc.) inherited.
 
 Now, with [#8357](https://github.com/napari/napari/pull/8357) you can create a new Shapes
 or Points layer (Labels coming soon!) that inherits from a selected layer
-(or a combination of selected layers)! Your new layer will copy all spatial information
-from its ancestor, ready for annotating!
+(or a combination of selected layers). If you have one layer selected, 
+your new layer will copy all spatial information from its ancestor, ready for annotating!
+If you have multiple layers selected, only scale is copied.
 
 TODO: add image of the different button visual, once merged, and note
 
@@ -109,11 +110,10 @@ If you've ever loaded data of mixed dimensionality in napari, like a TYX volume
 alongside a YX segmentation, you may have noticed the default axis labels didn't
 quite line up:
 
-```
-axes  | 0 | 1 | 2
-volume| 0 | 1 | 2
-segmt |   | 0 | 1
-```
+| axes   | 0 | 1 | 2 |
+|--------|---|---|---|
+| volume | 0 | 1 | 2 |
+| segmt  |   | 0 | 1 |
 
 That's because napari used 0-based indexing for its viewer axis labels, which breaks
 down when layers have different numbers of dimensions. With
@@ -121,11 +121,10 @@ down when layers have different numbers of dimensions. With
 viewer axis labels now use negative indexing by default, just like Python's own indexing
 semantics. The last axis is always `-1`, the second-to-last is always `-2`, and so on:
 
-```
-axes  | 0  | 1  | 2
-volume| -3 | -2 | -1
-segmt |    | -2 | -1
-```
+| axes   | 0  | 1  | 2  |
+|--------|----|----|----|
+| volume | -3 | -2 | -1 |
+| segmt  |    | -2 | -1 |
 
 This means axis labels stay consistent as you add or remove layers of different
 dimensionality -- axis `-1` is always your last axis. This also fixes


### PR DESCRIPTION
# References and relevant issues
<!-- What relevant resources were used in the creation of this PR?
If this PR addresses an existing issue on the repo,
please link to that issue here as "Closes #(issue-number)".
If this PR adds docs for a napari PR please add a "Depends on <napari PR link>" -->

# Description
There are still a couple of PRs in-flight, and a couple I didn't get a chance to update today, but I wanted to get this PR in so we can at least get closer to full release notes for 0.7.0, and make review somewhat easier!

<!-- Previewing the Documentation Build
When you submit this PR, jobs that preview the documentation will be kicked off.
By default, they will use the `slimfast` build (`make` target), which is fast, because
it doesn't build any content from outside the `docs` repository and doesn't run notebook cells.
You can trigger other builds by commenting on the PR with:

@napari-bot make <target>

where <target> can be:
html : a full build, just like the deployment to napari.org
html-noplot : a full build, but without the gallery examples from `napari/napari`
docs : only the content from `napari/docs`, with notebook code cells executed
slimfast : the default, only the content from `napari/docs`, without code cell execution
slimgallery : `slimfast`, but with the gallery examples from `napari/napari` built
-->

<!-- Final Checklist
- If images included: I have added [alt text](https://webaim.org/techniques/alttext/)
If workflow, documentation build or deployment change:
- My PR is the minimum possible work for the desired functionality
- I have commented my code, to let others know what it does
-->
