### PR TITLE
Fix camera angles in handedness guide

### DIFF
--- a/docs/guides/handedness.md
+++ b/docs/guides/handedness.md
@@ -142,7 +142,7 @@ layer = viewer.add_surface((vertices, faces), name='1BNA', shading='smooth')
 ---
 tags: [remove-input]
 ---
-viewer.camera.angles = (90, 0, 90)
+viewer.camera.angles = (90, 0, 0)
 viewer.camera.zoom = 16
 viewer.axes.visible = True
 


### PR DESCRIPTION
The camera angle in the handedness guide was set incorrectly set after
napari/napari#8281. This sets it to the equivalent angle.
