### PR TITLE
Fix typo in optional-dependencies

### DIFF
--- a/docs/plugins/building_a_plugin/best_practices.md
+++ b/docs/plugins/building_a_plugin/best_practices.md
@@ -46,7 +46,7 @@ command line installation in a fresh environment. In `pyproject.toml` this would
 
     ```
     [project.optional-dependencies]
-    all = [napari["all]"]
+    all = ["napari[all]"]
     ```
 
     And then your plugin could be installed with napari and the default Qt backend using:


### PR DESCRIPTION
Spotted this small tpyo of a misplaced `"`.

In a newly setup project using the template the opening double-quote comes before `napari`

# References and relevant issues
<!-- What relevant resources were used in the creation of this PR?
If this PR addresses an existing issue on the repo,
please link to that issue here as "Closes #(issue-number)".
If this PR adds docs for a napari PR please add a "Depends on <napari PR link>" -->

I created a new napari project using the [napari-plugin-template](https://github.com/napari/napari-plugin-template) and looked at the `pyproject.toml` it has the field...

```toml
[project.optional-dependencies]
# Allow easily installation with the full, default napari installation
# (including Qt backend) using napari-afmslicer[all].
all = ["napari[all]"]
```

...which differs from the documentation hence the correction.

# Description

Corrects the tpyo in the documentation.

<!-- What does this pull request (PR) do? Does it add new content, improve/fix existing
context, improve/fix workflow/documentation build/deployment or something else?
<!-- If relevant, please include a screenshot or a screen capture in your content
change: "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations. -->
<!-- You can also see a preview of the documentation changes you are submitting by
clicking on "Details" to the right of the "Check the rendered docs here!" check on your PR.-->

<!-- Previewing the Documentation Build
When you submit this PR, jobs that preview the documentation will be kicked off.
By default, they will use the `slimfast` build (`make` target), which is fast, because
it doesn't build any content from outside the `docs` repository and doesn't run notebook cells.
You can trigger other builds by commenting on the PR with:

@napari-bot make <target>

where <target> can be:
html : a full build, just like the deployment to napari.org
html-noplot : a full build, but without the gallery examples from `napari/napari`
docs : only the content from `napari/docs`, with notebook code cells executed
slimfast : the default, only the content from `napari/docs`, without code cell execution
slimgallery : `slimfast`, but with the gallery examples from `napari/napari` built
-->

<!-- Final Checklist
- If images included: I have added [alt text](https://webaim.org/techniques/alttext/)
If workflow, documentation build or deployment change:
- My PR is the minimum possible work for the desired functionality
- I have commented my code, to let others know what it does
-->
