### PR TITLE
Update references to PyQt5 as default backend to PyQt6

### DIFF
--- a/docs/developers/architecture/dir_organization.md
+++ b/docs/developers/architecture/dir_organization.md
@@ -45,7 +45,7 @@ Notable folders in the root directory:
 
 [Qt](https://doc.qt.io/) is a C++ framework to build graphical user interfaces (GUIs)
 that is available in Python from a number of libraries, such as
-[PyQt5](https://www.riverbankcomputing.com/static/Docs/PyQt5/).
+[PyQt6](https://www.riverbankcomputing.com/static/Docs/PyQt6/).
 Napari uses Qt to build its GUI, but we want to remain flexible to offer other GUI
 frameworks (such as a web-based GUI) in the future. Therefore,
 we try to confine code that directly imports Qt (currently the only supported GUI

--- a/docs/developers/contributing/dev_install.md
+++ b/docs/developers/contributing/dev_install.md
@@ -60,22 +60,16 @@ In order to make changes to `napari`, you will need to [fork](https://docs.githu
    napari supports different Qt backends and Qt versions. In this step, choose one of the following
    commands to install the developer tools and your preferred Qt backend.
 
-   For PyQt5, the default Qt backend, use:
+   For PyQt6, the default Qt backend, use:
 
    ```sh
    pip install -e ".[pyqt]" --group dev  # (quotes only needed for zsh shell)
    ```
 
-   To use PySide6 instead of the PyQt5, use:
+   To use PySide6 instead of the PyQt6, use:
 
    ```sh
    pip install -e ".[pyside]" --group dev  # (quotes only needed for zsh shell)
-   ```
-
-   For PyQt6, use:
-
-   ```sh
-   pip install -e ".[pyqt6]" --group dev  # (quotes only needed for zsh shell)
    ```
 
    If you wish to install the developer tools only, use the following. Choose

--- a/docs/developers/contributing/testing.md
+++ b/docs/developers/contributing/testing.md
@@ -143,10 +143,10 @@ in `System Settings > Privacy & Security > Accessibility` so `pyautogui` can con
 It is also possible to run tests locally using `tox`. We use `tox` to run test in CI.
 The main difference between running `pytest` locally or `tox` locally is that `tox` will create a virtual environment
 for each test environment, so it will take a bit more time. Though, `tox` will be more similar to the CI environment.
-To run test using `tox` using Python 3.10 and pyqt5 on Linux, enter:
+To run test using `tox` using Python 3.13 and pyqt6 on Linux, enter:
 
 ```sh
-tox -e py310-linux-pyqt5
+tox -e py313-linux-pyqt6
 ```
 
 To get list of all available environments that may be run:
@@ -171,7 +171,7 @@ You can avoid pop-up windows opening two different ways:
    or
 
    ```shell
-   QT_QPA_PLATFORM=offscreen tox -e py310-linux-pyqt5
+   QT_QPA_PLATFORM=offscreen tox -e py313-linux-pyqt6
    ```
 
 1. If you are using Linux or WSL (Windows Subsystem for Linux), you can use the `xvfb-run` command.
@@ -184,10 +184,10 @@ You can avoid pop-up windows opening two different ways:
    or
 
    ```sh
-   xvfb-run tox -e py310-linux-pyqt5
+   xvfb-run tox -e py313-linux-pyqt6
    ```
 
-where the tox environment selector `py310-linux-pyqt5` must match your OS and Python version.
+where the tox environment selector `py313-linux-pyqt6` must match your OS and Python version.
 
 ### Tips for speeding up local testing
 

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -190,8 +190,10 @@ the current release {{ napari_version }}, using the command: `napari --version` 
 
 napari needs a library called [Qt](https://www.qt.io/) to run its user interface
 (UI). In Python, there are three alternative libraries to run this, called
-[PyQt5](https://www.riverbankcomputing.com/software/pyqt/download) for Qt5, [PyQt6](https://www.riverbankcomputing.com/software/pyqt/download) and
-[PySide6](https://doc.qt.io/qtforpython-6/) for Qt6. By default, we don't choose for you,
+[PyQt6](https://www.riverbankcomputing.com/software/pyqt/download) and
+[PySide6](https://doc.qt.io/qtforpython-6/) for Qt6. There is also an older version,
+[PyQt5](https://www.riverbankcomputing.com/software/pyqt/download) for Qt5.
+By default, we don't choose for you,
 and simply running `python -m pip install napari` will not install either. You *might*
 already have one of them installed in your environment, thanks to other
 scientific packages such as Spyder or matplotlib. If neither is available,
@@ -199,7 +201,7 @@ running napari will result in an error message asking you to install one of
 them.
 
 Running `python -m pip install "napari[all]"` will install the default framework, which is currently
-PyQt5--but this could change in the future.
+PyQt6--but this could change in the future.
 
 To install napari with a specific framework, you can use:
 
@@ -218,7 +220,7 @@ you're not using.
 ```
 
 ```{note}
-As PySide2 is not maintained, and we dropped support for it in napari 0.7.0. PyQt5 is still supported, as there is no PyQt6 on conda-forge yet.
+As PySide2 is not maintained, and we dropped support for it in napari 0.7.0. PyQt5 is still supported, but PyQt6 is the default installation.
 ```
 
 #### Using constraints files

--- a/docs/howtos/napari_imageJ.md
+++ b/docs/howtos/napari_imageJ.md
@@ -118,7 +118,7 @@ To fix this we can use either of these 3 following methods :
 Here is a plain Python script that starts up Qt and spins up ImageJ without use of napari's Qt Console.
 
 ```python
-from PyQt5 import QtCore, QtWidgets
+from PyQt6 import QtCore, QtWidgets
 
 
 def main():
@@ -159,7 +159,7 @@ def start_imagej():
     print(ij.getVersion())
 
 
-from PyQt5 import QtCore
+from PyQt6 import QtCore
 
 QtCore.QTimer.singleShot(0, start_imagej)
 ```

--- a/docs/plugins/building_a_plugin/best_practices.md
+++ b/docs/plugins/building_a_plugin/best_practices.md
@@ -13,24 +13,24 @@ affect the ability to install or use your plugin effectively.
 *This is important! Avoid including any form of Qt in your plugin's dependencies!*
 
 Napari supports *both* PyQt and PySide backends for Qt. It is up to the
-end-user to choose which one they want. If they installed napari with `pip install napari[all]`, then this includes `PyQt5` from PyPI as the default backend.
-If they installed via `conda install napari pyqt`, then they'll have `PyQt5`,
+end-user to choose which one they want. If they installed napari with `pip install napari[all]`, then this includes `PyQt6` from PyPI as the default backend.
+If they installed via `conda install napari pyqt`, then they'll have `PyQt6`,
 but from conda-forge instead of PyPI. Meanwhile, the napari bundle installs with PySide6.
-Users are also free to install PyQt6, or PySide6 backend.
+Users are also free to install PyQt5, or PySide6 backend.
 
 Here's what can go wrong if you *also* declare one of these backends **or napari[all]**
 in the `dependencies`/`install_requires` section of your plugin metadata:
 
 - If they installed via `conda install napari pyqt` and then they install your plugin
   via `pip` (or vice versa) then there *will* be a binary incompatibility between the
-  conda `pyqt` installation, and the `PyQt5` installation from PyPI. *This will very likely
+  conda `pyqt` installation, and the `PyQt6` installation from PyPI. *This will very likely
   lead to a broken environment, forcing the user to re-create their entire
   environment and re-install napari*. This is an unfortunate consequence of
   [package naming decisions](https://github.com/ContinuumIO/anaconda-issues/issues/1554),
   and it's not something napari can fix.
 - Alternatively, they may end up with some combination of *both* PyQt5, PyQt6,
   and PySide6 in their environment: the Qt backend they had installed and the one your
-  plugin installed as a dependency. This is will not *always* to break things, but
+  plugin installed as a dependency. This will not *always* break things, but
   it will lead to unexpected and difficult to debug problems.
 - Both of the above cases are most likely to happen with the built-in GUI napari plugin manager,
   which will install your plugin plus the base dependencies. As a result, this frequently
@@ -39,7 +39,7 @@ in the `dependencies`/`install_requires` section of your plugin metadata:
 
 ````{tip}
 1. You can still include a specific Qt backend in optional `dev` or `testing` dependencies!
-Just *don't* include a specific Qt backend (or `napari[all]`, which currently includes PyQt5)
+Just *don't* include a specific Qt backend (or `napari[all]`, which currently includes PyQt6)
 in your base dependencies.
 2. You can include an optional `all` dependency on `napari[all]` to mimic the simple,
 command line installation in a fresh environment. In `pyproject.toml` this would be:
@@ -60,8 +60,8 @@ command line installation in a fresh environment. In `pyproject.toml` this would
 
 ## Don't import from any specific Qt backend (e.g. `PyQt5`, `PyQt6`, `PySide6`, etc.) in your plugin: use `qtpy`
 
-If you use `from PyQt5 import QtCore` (or similar) in your plugin, but the
-end-user has chosen to use `PySide6` or `PyQt6` for their Qt backend — or vice versa —
+If you use `from PyQt6 import QtCore` (or similar) in your plugin, but the
+end-user has chosen to use `PySide6` or `PyQt5` for their Qt backend — or vice versa —
 then your plugin will fail to import. Instead use `from qtpy import QtCore`.
 `qtpy` is a [Qt compatibility layer](https://github.com/spyder-ide/qtpy)
 that will import from whatever backend is installed in the environment.

--- a/docs/release/release_0_5_0.md
+++ b/docs/release/release_0_5_0.md
@@ -569,7 +569,7 @@ improvements. Please see below for the full list of changes since 0.4.19.
 - Type `_WeakCounter` ([#6246](https://github.com/napari/napari/pull/6246))
 - Fix typing in napari.utils.theme ([#6247](https://github.com/napari/napari/pull/6247))
 - remove: napari.qt.progress (deprecated in 0.4.11) ([#6252](https://github.com/napari/napari/pull/6252))
-- Restore 'V' keybinding for layer visibiltiy toggle ([#6261](https://github.com/napari/napari/pull/6261))
+- Restore 'V' keybinding for layer visibility toggle ([#6261](https://github.com/napari/napari/pull/6261))
 - Update `app-model`, `dask`, `fsspec`, `hypothesis`, `imageio`, `ipython`, `jsonschema`, `matplotlib`, `numpy`, `pandas`, `pillow`, `psygnal`, `pytest`, `qtconsole`, `qtpy`, `rich`, `scipy`, `superqt`, `tensorstore`, `tifffile`, `virtualenv`, `xarray`, `zarr` ([#6265](https://github.com/napari/napari/pull/6265))
 - [pre-commit.ci] pre-commit autoupdate ([#6266](https://github.com/napari/napari/pull/6266))
 - Fix nitpicks in `id` and `title` `Action` fields in samples menu ([#6267](https://github.com/napari/napari/pull/6267))


### PR DESCRIPTION
# References and relevant issues
Closes #949 

# Description
This PR updates references to PyQt5 as a default backend (or where it seems like it's implicitly being used as the default) to instead use PyQt6. It does not remove all references to PyQt5, since we still support it as a backend. 
