### PR TITLE
Restructure homepage and add rotating featured examples

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -69,7 +69,7 @@ html[data-theme="dark"] div.sphx-glr-download a:hover {
   display: grid;
   align-items: center;
   gap: 1.5rem;
-  grid-template-columns: 3fr 2fr;
+  grid-template-columns: 1fr 1fr;
   margin: 1.5rem 0 2rem;
 }
 

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -119,23 +119,26 @@ html[data-theme="dark"] div.sphx-glr-download a:hover {
   }
 }
 
-/* ── Homepage quicklinks (icon row) ─────────────────────────────────── */
+/* ── Homepage quicklinks (icon columns) ──────────────────────────────── */
 
 .homepage-quicklinks {
   border-bottom: 1px solid var(--pst-color-border);
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem 2rem;
+  justify-content: center;
+  gap: 0.75rem 4rem;
   margin: 1rem 0 1.5rem;
   padding-bottom: 1rem;
 }
 
 .homepage-quicklinks a {
   align-items: center;
-  display: inline-flex;
-  font-size: 1rem;
+  display: flex;
+  flex-direction: column;
+  font-size: 0.9rem;
   font-weight: 500;
-  gap: 0.4rem;
+  gap: 0.5rem;
+  text-align: center;
   text-decoration: none;
 }
 
@@ -143,24 +146,50 @@ html[data-theme="dark"] div.sphx-glr-download a:hover {
   text-decoration: underline;
 }
 
+/* Quicklinks icons */
 .homepage-quicklinks i {
   color: var(--pst-color-primary);
-  width: 1em;
+  font-size: 3.5rem;
+  line-height: 1;
+  width: auto;
 }
 
-/* ── Homepage example buttons: soften the bold black sd-btn defaults ────
-   sphinx-design marks every button property !important, so we must too.  */
+/* ── Homepage accent cards & buttons ──────────────────────────────────
+   Install, Download, Examples Gallery with theme-aware napari blue.
+   sphinx-design marks every property !important, so we must too.        */
 
-.homepage-featured-example__actions .sd-btn {
-  background-color: var(--pst-color-on-background) !important;
-  border-color: var(--pst-color-border) !important;
-  color: var(--pst-color-text-base) !important;
-  font-weight: 700 !important;
+html[data-theme="light"] .homepage-card-accent,
+html[data-theme="light"] .homepage-card-accent .sd-card-body,
+html[data-theme="light"] .homepage-featured-example__actions .sd-btn-primary {
+  background-color: var(--napari-light-blue) !important;
+  border-color: var(--napari-primary-blue) !important;
 }
 
-.homepage-featured-example__actions .sd-btn:hover,
-.homepage-featured-example__actions .sd-btn:focus {
-  background-color: var(--pst-color-border) !important;
-  border-color: var(--pst-color-border) !important;
-  color: var(--pst-color-text-base) !important;
+html[data-theme="light"] .homepage-featured-example__actions .sd-btn-primary {
+  color: var(--napari-color-text-base) !important;
+}
+
+html[data-theme="light"] .homepage-featured-example__actions .sd-btn-primary:hover,
+html[data-theme="light"] .homepage-featured-example__actions .sd-btn-primary:focus {
+  background-color: var(--napari-primary-blue) !important;
+  border-color: var(--napari-primary-blue) !important;
+  color: var(--napari-color-text-base) !important;
+}
+
+html[data-theme="dark"] .homepage-card-accent,
+html[data-theme="dark"] .homepage-card-accent .sd-card-body,
+html[data-theme="dark"] .homepage-featured-example__actions .sd-btn-primary {
+  background-color: color-mix(in srgb, var(--napari-deep-blue), transparent 75%) !important;
+  border-color: var(--napari-deep-blue) !important;
+}
+
+html[data-theme="dark"] .homepage-featured-example__actions .sd-btn-primary {
+  color: var(--napari-color-text-base) !important;
+}
+
+html[data-theme="dark"] .homepage-featured-example__actions .sd-btn-primary:hover,
+html[data-theme="dark"] .homepage-featured-example__actions .sd-btn-primary:focus {
+  background-color: var(--napari-deep-blue) !important;
+  border-color: var(--napari-deep-blue) !important;
+  color: var(--napari-color-text-base) !important;
 }

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -62,3 +62,90 @@ html[data-theme="dark"] div.sphx-glr-download a:hover {
   color: var(--napari-color-text-base);
   font-weight: 700;
 }
+
+/* ── Homepage featured example ─────────────────────────────────────── */
+
+.homepage-featured-example {
+  align-items: center;
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: 3fr 2fr;
+  margin: 0.5rem 0 2rem;
+}
+
+.homepage-featured-example__media {
+  display: block;
+}
+
+.homepage-featured-example__media img {
+  border-radius: 6px;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.15);
+  display: block;
+  width: 100%;
+}
+
+.homepage-featured-example__eyebrow {
+  color: var(--pst-color-secondary);
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  margin-bottom: 0.4rem;
+  text-transform: uppercase;
+}
+
+.homepage-featured-example__title {
+  font-size: 1.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.homepage-featured-example__title a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.homepage-featured-example__title a:hover {
+  text-decoration: underline;
+}
+
+.homepage-featured-example__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
+@media (max-width: 768px) {
+  .homepage-featured-example {
+    grid-template-columns: 1fr;
+  }
+
+  .homepage-featured-example__media {
+    order: -1;
+  }
+}
+
+/* ── Homepage quicklinks (icon row) ─────────────────────────────────── */
+
+.homepage-quicklinks {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 1.5rem;
+  margin: 0.5rem 0 1.5rem;
+}
+
+.homepage-quicklinks a {
+  align-items: center;
+  display: inline-flex;
+  font-size: 0.9rem;
+  gap: 0.35rem;
+  text-decoration: none;
+}
+
+.homepage-quicklinks a:hover {
+  text-decoration: underline;
+}
+
+.homepage-quicklinks i {
+  color: var(--pst-color-primary);
+  width: 1em;
+}

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -149,47 +149,73 @@ html[data-theme="dark"] div.sphx-glr-download a:hover {
 /* Quicklinks icons */
 .homepage-quicklinks i {
   color: var(--pst-color-primary);
-  font-size: 3.5rem;
+  font-size: 5rem;
   line-height: 1;
   width: auto;
 }
 
-/* ── Homepage accent cards & buttons ──────────────────────────────────
-   Install, Download, Examples Gallery with theme-aware napari blue.
-   sphinx-design marks every property !important, so we must too.        */
+/* ── Homepage accent cards ───────────────────────────────────────────
+   Install, Download cards with theme-aware napari blue.
+   sphinx-design marks every property !important, so we must too.     */
 
 html[data-theme="light"] .homepage-card-accent,
-html[data-theme="light"] .homepage-card-accent .sd-card-body,
-html[data-theme="light"] .homepage-featured-example__actions .sd-btn-primary {
+html[data-theme="light"] .homepage-card-accent .sd-card-body {
   background-color: var(--napari-light-blue) !important;
   border-color: var(--napari-primary-blue) !important;
 }
 
+html[data-theme="dark"] .homepage-card-accent,
+html[data-theme="dark"] .homepage-card-accent .sd-card-body {
+  background-color: color-mix(in srgb, var(--napari-deep-blue), transparent 75%) !important;
+  border-color: var(--napari-deep-blue) !important;
+}
+
+/* ── Homepage featured example buttons ───────────────────────────────
+   "Examples gallery" (sd-btn-primary) matches the accent card napari blue.
+   "Show another example" (sd-btn-outline-primary) is a neutral card-style button.
+   background-image reset prevents any sphinx-design gradient from bleeding through. */
+
 html[data-theme="light"] .homepage-featured-example__actions .sd-btn-primary {
+  background-color: var(--napari-light-blue) !important;
+  background-image: none !important;
+  border-color: var(--napari-primary-blue) !important;
   color: var(--napari-color-text-base) !important;
 }
 
 html[data-theme="light"] .homepage-featured-example__actions .sd-btn-primary:hover,
 html[data-theme="light"] .homepage-featured-example__actions .sd-btn-primary:focus {
   background-color: var(--napari-primary-blue) !important;
+  background-image: none !important;
   border-color: var(--napari-primary-blue) !important;
   color: var(--napari-color-text-base) !important;
 }
 
-html[data-theme="dark"] .homepage-card-accent,
-html[data-theme="dark"] .homepage-card-accent .sd-card-body,
 html[data-theme="dark"] .homepage-featured-example__actions .sd-btn-primary {
   background-color: color-mix(in srgb, var(--napari-deep-blue), transparent 75%) !important;
+  background-image: none !important;
   border-color: var(--napari-deep-blue) !important;
-}
-
-html[data-theme="dark"] .homepage-featured-example__actions .sd-btn-primary {
   color: var(--napari-color-text-base) !important;
 }
 
 html[data-theme="dark"] .homepage-featured-example__actions .sd-btn-primary:hover,
 html[data-theme="dark"] .homepage-featured-example__actions .sd-btn-primary:focus {
   background-color: var(--napari-deep-blue) !important;
+  background-image: none !important;
   border-color: var(--napari-deep-blue) !important;
+  color: var(--napari-color-text-base) !important;
+}
+
+.homepage-featured-example__actions .sd-btn-outline-primary {
+  background-color: var(--pst-color-on-background) !important;
+  background-image: none !important;
+  border-color: var(--pst-color-border) !important;
+  color: var(--napari-color-text-base) !important;
+}
+
+.homepage-featured-example__actions .sd-btn-outline-primary:hover,
+.homepage-featured-example__actions .sd-btn-outline-primary:focus {
+  background-color: var(--pst-color-border) !important;
+  background-image: none !important;
+  border-color: var(--pst-color-border) !important;
   color: var(--napari-color-text-base) !important;
 }

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -66,11 +66,29 @@ html[data-theme="dark"] div.sphx-glr-download a:hover {
 /* ── Homepage featured example ─────────────────────────────────────── */
 
 .homepage-featured-example {
-  align-items: center;
   display: grid;
+  align-items: center;
   gap: 1.5rem;
   grid-template-columns: 3fr 2fr;
-  margin: 0.5rem 0 2rem;
+  margin: 1.5rem 0 2rem;
+}
+
+.homepage-featured-example__copy {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.homepage-featured-example__title {
+  margin-top: 0;
+}
+
+.homepage-featured-example__title a {
+  text-decoration: none;
+}
+
+.homepage-featured-example__title a:hover {
+  text-decoration: underline;
 }
 
 .homepage-featured-example__media {
@@ -78,33 +96,10 @@ html[data-theme="dark"] div.sphx-glr-download a:hover {
 }
 
 .homepage-featured-example__media img {
-  border-radius: 6px;
-  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.15);
+  border-radius: 5px;
+  box-shadow: 2px 2px 15px rgba(0, 0, 0, 0.3);
   display: block;
   width: 100%;
-}
-
-.homepage-featured-example__eyebrow {
-  color: var(--pst-color-secondary);
-  font-size: 0.8rem;
-  font-weight: 700;
-  letter-spacing: 0.07em;
-  margin-bottom: 0.4rem;
-  text-transform: uppercase;
-}
-
-.homepage-featured-example__title {
-  font-size: 1.5rem;
-  margin-bottom: 0.5rem;
-}
-
-.homepage-featured-example__title a {
-  color: inherit;
-  text-decoration: none;
-}
-
-.homepage-featured-example__title a:hover {
-  text-decoration: underline;
 }
 
 .homepage-featured-example__actions {

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -125,7 +125,7 @@ html[data-theme="dark"] div.sphx-glr-download a:hover {
   border-top: 1px solid var(--napari-dark-gray);
   border-bottom: 1px solid var(--napari-dark-gray);
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   gap: 0.75rem 0;
   justify-content: center;
   margin: 1rem 0 1.5rem;
@@ -155,8 +155,24 @@ html[data-theme="dark"] div.sphx-glr-download a:hover {
 
 .homepage-quicklinks i {
   color: var(--pst-color-primary);
-  font-size: 6rem;
+  font-size: 4rem;
   line-height: 1;
+}
+
+@media (max-width: 640px) {
+  .homepage-quicklinks {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 0.75rem 0;
+  }
+
+  .homepage-quicklinks a {
+    padding: 0.5rem 1.5rem;
+  }
+
+  .homepage-quicklinks a:nth-child(2n) {
+    border-right: none;
+  }
 }
 
 /* ── Homepage accent cards ───────────────────────────────────────────

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -122,36 +122,41 @@ html[data-theme="dark"] div.sphx-glr-download a:hover {
 /* ── Homepage quicklinks (icon columns) ──────────────────────────────── */
 
 .homepage-quicklinks {
-  border-bottom: 1px solid var(--pst-color-border);
+  border-top: 1px solid var(--napari-dark-gray);
+  border-bottom: 1px solid var(--napari-dark-gray);
   display: flex;
   flex-wrap: wrap;
+  gap: 0.75rem 0;
   justify-content: center;
-  gap: 0.75rem 4rem;
   margin: 1rem 0 1.5rem;
-  padding-bottom: 1rem;
+  padding: 1rem 0;
 }
 
 .homepage-quicklinks a {
   align-items: center;
+  border-right: 1px solid var(--napari-dark-gray);
   display: flex;
   flex-direction: column;
   font-size: 0.9rem;
   font-weight: 500;
   gap: 0.5rem;
+  padding: 0.25rem 2rem;
   text-align: center;
   text-decoration: none;
+}
+
+.homepage-quicklinks a:last-child {
+  border-right: none;
 }
 
 .homepage-quicklinks a:hover {
   text-decoration: underline;
 }
 
-/* Quicklinks icons */
 .homepage-quicklinks i {
   color: var(--pst-color-primary);
-  font-size: 5rem;
+  font-size: 6rem;
   line-height: 1;
-  width: auto;
 }
 
 /* ── Homepage accent cards ───────────────────────────────────────────

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -155,6 +155,7 @@ html[data-theme="dark"] div.sphx-glr-download a:hover {
   background-color: var(--pst-color-on-background) !important;
   border-color: var(--pst-color-border) !important;
   color: var(--pst-color-text-base) !important;
+  font-weight: 700 !important;
 }
 
 .homepage-featured-example__actions .sd-btn:hover,

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -147,3 +147,19 @@ html[data-theme="dark"] div.sphx-glr-download a:hover {
   color: var(--pst-color-primary);
   width: 1em;
 }
+
+/* ── Homepage example buttons: soften the bold black sd-btn defaults ────
+   sphinx-design marks every button property !important, so we must too.  */
+
+.homepage-featured-example__actions .sd-btn {
+  background-color: var(--pst-color-on-background) !important;
+  border-color: var(--pst-color-border) !important;
+  color: var(--pst-color-text-base) !important;
+}
+
+.homepage-featured-example__actions .sd-btn:hover,
+.homepage-featured-example__actions .sd-btn:focus {
+  background-color: var(--pst-color-border) !important;
+  border-color: var(--pst-color-border) !important;
+  color: var(--pst-color-text-base) !important;
+}

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -127,17 +127,20 @@ html[data-theme="dark"] div.sphx-glr-download a:hover {
 /* ── Homepage quicklinks (icon row) ─────────────────────────────────── */
 
 .homepage-quicklinks {
+  border-bottom: 1px solid var(--pst-color-border);
   display: flex;
   flex-wrap: wrap;
-  gap: 0.4rem 1.5rem;
-  margin: 0.5rem 0 1.5rem;
+  gap: 0.5rem 2rem;
+  margin: 1rem 0 1.5rem;
+  padding-bottom: 1rem;
 }
 
 .homepage-quicklinks a {
   align-items: center;
   display: inline-flex;
-  font-size: 0.9rem;
-  gap: 0.35rem;
+  font-size: 1rem;
+  font-weight: 500;
+  gap: 0.4rem;
   text-decoration: none;
 }
 

--- a/docs/_static/featured_examples.json
+++ b/docs/_static/featured_examples.json
@@ -32,7 +32,7 @@
     "description": "Multiplexed heart murine sample with annotated features to show cell type",
     "image": "_images/shpx_glr_heart_masks_points_001.png",
     "href": "gallery/3D_vectors_through_time.html",
-    "alt": "napari viewer showing annotations with labels and points with features",
+    "alt": "napari viewer showing annotations with labels and points with features"
   },
   {
     "title": "Overlays and grid mode",

--- a/docs/_static/featured_examples.json
+++ b/docs/_static/featured_examples.json
@@ -1,7 +1,7 @@
 ﻿[
   {
     "title": "3D vector field and image across time",
-    "description": "Visualize the compression vectors of x-ray tomography mechanical compression of a granular material",
+    "description": "Visualize the compression vectors of x-ray tomography mechanical compression of a granular material.",
     "image": "_images/sphx_glr_3D_vectors_through_time_001.png",
     "href": "gallery/3D_vectors_through_time.html",
     "alt": "napari viewer showing a 3D vector field across time"
@@ -22,21 +22,21 @@
   },
   {
     "title": "Xarray weather data across time",
-    "description": "Visualize weather data across time with metadata from an Xarray object",
+    "description": "Visualize weather data across time with metadata from an Xarray object.",
     "image": "_images/sphx_glr_xarray-latlon-timeseries_001.png",
     "href": "gallery/xarray-latlon-timeseries.html",
     "alt": "napari viewer showing Xarray weather data across time"
   },
   {
     "title": "Annotations with labels and points with features",
-    "description": "Multiplexed heart murine sample with annotated features to show cell type",
+    "description": "Multiplexed heart murine sample with annotated features to show cell type.",
     "image": "_images/shpx_glr_heart_masks_points_001.png",
     "href": "gallery/3D_vectors_through_time.html",
     "alt": "napari viewer showing annotations with labels and points with features"
   },
   {
     "title": "Overlays and grid mode",
-    "description": "Overlay information like colorbars and scale on an image seperated in grid mode",
+    "description": "Overlay information like colorbars and scale on an image separated in grid mode.",
     "image": "_images/sphx_glr_colorbar_tiling_001.png",
     "href": "gallery/colorbar_tiling.html",
     "alt": "napari viewer showing grid mode and overlays"

--- a/docs/_static/featured_examples.json
+++ b/docs/_static/featured_examples.json
@@ -1,72 +1,37 @@
-[
+﻿[
   {
-    "title": "Add image",
-    "description": "Display an image in napari and explore the viewer with a minimal example.",
-    "image": "_images/sphx_glr_add_image_001.png",
-    "href": "gallery/add_image.html",
-    "alt": "Screenshot preview of the add image example"
+    "title": "3D vector field and image across time",
+    "description": "Visualize the compression vectors of x-ray tomography mechanical compression of a granular material",
+    "image": "_images/sphx_glr_3D_vectors_through_time_001.png",
+    "href": "gallery/3D_vectors_through_time.html",
+    "alt": "napari viewer showing a 3D vector field across time"
   },
   {
-    "title": "Add labels",
-    "description": "Work with segmentation masks and label data in a dedicated labels layer.",
-    "image": "_images/sphx_glr_add_labels_001.png",
-    "href": "gallery/add_labels.html",
-    "alt": "Screenshot preview of the add labels example"
-  },
-  {
-    "title": "Add points",
-    "description": "Plot and inspect point annotations directly on top of image data.",
-    "image": "_images/sphx_glr_add_points_001.png",
-    "href": "gallery/add_points.html",
-    "alt": "Screenshot preview of the add points example"
-  },
-  {
-    "title": "Add shapes",
-    "description": "Overlay polygons, paths, rectangles, and other editable shapes.",
-    "image": "_images/sphx_glr_add_shapes_001.png",
-    "href": "gallery/add_shapes.html",
-    "alt": "Screenshot preview of the add shapes example"
-  },
-  {
-    "title": "3D paths",
-    "description": "Visualize paths in 3D and explore volumetric data from multiple angles.",
-    "image": "_images/sphx_glr_3D_paths_001.png",
-    "href": "gallery/3D_paths.html",
-    "alt": "Screenshot preview of the 3D paths example"
-  },
-  {
-    "title": "Affine coffee cup",
-    "description": "See how affine transforms change the display of layered data.",
+    "title": "Affine transforms in 3D",
+    "description": "Translation and rotation of a 3D object scanned by a phone.",
     "image": "_images/sphx_glr_affine_coffee_cup_001.png",
     "href": "gallery/affine_coffee_cup.html",
-    "alt": "Screenshot preview of the affine coffee cup example"
+    "alt": "napari viewer showing 3D affine transforms"
   },
   {
-    "title": "Dask nD image",
-    "description": "Open and explore larger-than-memory arrays backed by Dask.",
-    "image": "_images/sphx_glr_dask_nD_image_001.png",
-    "href": "gallery/dask_nD_image.html",
-    "alt": "Screenshot preview of the Dask nD image example"
+    "title": "Tracking labeled cells",
+    "description": "Visualize cell tracking data with labels and tracks layers.",
+    "image": "_images/sphx_glr_cell_tracking_001.png",
+    "href": "gallery/cell_tracking.html",
+    "alt": "napari viewer showing cell tracking with labels and tracks"
   },
   {
-    "title": "Layer bounding box",
-    "description": "Inspect layer extents and geometry while working interactively.",
-    "image": "_images/sphx_glr_layer_bounding_box_001.png",
-    "href": "gallery/layer_bounding_box.html",
-    "alt": "Screenshot preview of the layer bounding box example"
-  },
-  {
-    "title": "Point cloud",
-    "description": "Render dense point clouds and navigate them in three dimensions.",
-    "image": "_images/sphx_glr_point_cloud_001.png",
-    "href": "gallery/point_cloud.html",
-    "alt": "Screenshot preview of the point cloud example"
-  },
-  {
-    "title": "Xarray time series",
-    "description": "Explore labeled xarray data with geographic and temporal dimensions.",
+    "title": "Xarray weather data across time",
+    "description": "Visualize weather data across time with metadata from an Xarray object",
     "image": "_images/sphx_glr_xarray-latlon-timeseries_001.png",
     "href": "gallery/xarray-latlon-timeseries.html",
-    "alt": "Screenshot preview of the xarray latlon timeseries example"
+    "alt": "napari viewer showing Xarray weather data across time"
+  },
+  {
+    "title": "Annotations with labels and points with features",
+    "description": "Multiplexed heart murine sample with annotated features to show cell type",
+    "image": "_images/shpx_glr_heart_masks_points_001.png",
+    "href": "gallery/3D_vectors_through_time.html",
+    "alt": "napari viewer showing annotations with labels and points with features",
   }
 ]

--- a/docs/_static/featured_examples.json
+++ b/docs/_static/featured_examples.json
@@ -33,5 +33,12 @@
     "image": "_images/shpx_glr_heart_masks_points_001.png",
     "href": "gallery/3D_vectors_through_time.html",
     "alt": "napari viewer showing annotations with labels and points with features",
+  },
+  {
+    "title": "Overlays and grid mode",
+    "description": "Overlay information like colorbars and scale on an image seperated in grid mode",
+    "image": "_images/sphx_glr_colorbar_tiling_001.png",
+    "href": "gallery/colorbar_tiling.html",
+    "alt": "napari viewer showing grid mode and overlays"
   }
 ]

--- a/docs/_static/featured_examples.json
+++ b/docs/_static/featured_examples.json
@@ -1,0 +1,72 @@
+[
+  {
+    "title": "Add image",
+    "description": "Display an image in napari and explore the viewer with a minimal example.",
+    "image": "_images/sphx_glr_add_image_001.png",
+    "href": "gallery/add_image.html",
+    "alt": "Screenshot preview of the add image example"
+  },
+  {
+    "title": "Add labels",
+    "description": "Work with segmentation masks and label data in a dedicated labels layer.",
+    "image": "_images/sphx_glr_add_labels_001.png",
+    "href": "gallery/add_labels.html",
+    "alt": "Screenshot preview of the add labels example"
+  },
+  {
+    "title": "Add points",
+    "description": "Plot and inspect point annotations directly on top of image data.",
+    "image": "_images/sphx_glr_add_points_001.png",
+    "href": "gallery/add_points.html",
+    "alt": "Screenshot preview of the add points example"
+  },
+  {
+    "title": "Add shapes",
+    "description": "Overlay polygons, paths, rectangles, and other editable shapes.",
+    "image": "_images/sphx_glr_add_shapes_001.png",
+    "href": "gallery/add_shapes.html",
+    "alt": "Screenshot preview of the add shapes example"
+  },
+  {
+    "title": "3D paths",
+    "description": "Visualize paths in 3D and explore volumetric data from multiple angles.",
+    "image": "_images/sphx_glr_3D_paths_001.png",
+    "href": "gallery/3D_paths.html",
+    "alt": "Screenshot preview of the 3D paths example"
+  },
+  {
+    "title": "Affine coffee cup",
+    "description": "See how affine transforms change the display of layered data.",
+    "image": "_images/sphx_glr_affine_coffee_cup_001.png",
+    "href": "gallery/affine_coffee_cup.html",
+    "alt": "Screenshot preview of the affine coffee cup example"
+  },
+  {
+    "title": "Dask nD image",
+    "description": "Open and explore larger-than-memory arrays backed by Dask.",
+    "image": "_images/sphx_glr_dask_nD_image_001.png",
+    "href": "gallery/dask_nD_image.html",
+    "alt": "Screenshot preview of the Dask nD image example"
+  },
+  {
+    "title": "Layer bounding box",
+    "description": "Inspect layer extents and geometry while working interactively.",
+    "image": "_images/sphx_glr_layer_bounding_box_001.png",
+    "href": "gallery/layer_bounding_box.html",
+    "alt": "Screenshot preview of the layer bounding box example"
+  },
+  {
+    "title": "Point cloud",
+    "description": "Render dense point clouds and navigate them in three dimensions.",
+    "image": "_images/sphx_glr_point_cloud_001.png",
+    "href": "gallery/point_cloud.html",
+    "alt": "Screenshot preview of the point cloud example"
+  },
+  {
+    "title": "Xarray time series",
+    "description": "Explore labeled xarray data with geographic and temporal dimensions.",
+    "image": "_images/sphx_glr_xarray-latlon-timeseries_001.png",
+    "href": "gallery/xarray-latlon-timeseries.html",
+    "alt": "Screenshot preview of the xarray latlon timeseries example"
+  }
+]

--- a/docs/_static/featured_examples.json
+++ b/docs/_static/featured_examples.json
@@ -30,8 +30,8 @@
   {
     "title": "Annotations with labels and points with features",
     "description": "Multiplexed heart murine sample with annotated features to show cell type.",
-    "image": "_images/shpx_glr_heart_masks_points_001.png",
-    "href": "gallery/3D_vectors_through_time.html",
+    "image": "_images/sphx_glr_heart_masks_points_001.png",
+    "href": "gallery/heart_masks_points.html",
     "alt": "napari viewer showing annotations with labels and points with features"
   },
   {

--- a/docs/_static/random_example.js
+++ b/docs/_static/random_example.js
@@ -11,10 +11,9 @@
     const description  = document.getElementById('homepage-featured-example-description');
     const image        = document.getElementById('homepage-featured-example-image');
     const mediaLink    = document.querySelector('.homepage-featured-example__media');
-    const cta          = document.getElementById('homepage-featured-example-cta');
     const reroll       = document.getElementById('homepage-featured-example-reroll');
 
-    if (!titleLink || !description || !image || !mediaLink || !cta || !reroll) return;
+    if (!titleLink || !description || !image || !mediaLink || !reroll) return;
 
     // Resolve the JSON file relative to this script's own URL so it works at
     // any deploy sub-path.  Fall back to a predictable root-relative path.
@@ -32,7 +31,6 @@
       image.src             = example.image;
       image.alt             = example.alt;
       mediaLink.href        = example.href;
-      cta.href              = example.href;
       currentHref           = example.href;
     };
 

--- a/docs/_static/random_example.js
+++ b/docs/_static/random_example.js
@@ -1,0 +1,57 @@
+(() => {
+  // Must capture currentScript here at IIFE scope — it is null inside any
+  // deferred callback (DOMContentLoaded, setTimeout, etc.).
+  const scriptSrc = document.currentScript ? document.currentScript.src : null;
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const section = document.querySelector('.homepage-featured-example');
+    if (!section) return;
+
+    const titleLink    = document.getElementById('homepage-featured-example-link');
+    const description  = document.getElementById('homepage-featured-example-description');
+    const image        = document.getElementById('homepage-featured-example-image');
+    const mediaLink    = document.querySelector('.homepage-featured-example__media');
+    const cta          = document.getElementById('homepage-featured-example-cta');
+    const reroll       = document.getElementById('homepage-featured-example-reroll');
+
+    if (!titleLink || !description || !image || !mediaLink || !cta || !reroll) return;
+
+    // Resolve the JSON file relative to this script's own URL so it works at
+    // any deploy sub-path.  Fall back to a predictable root-relative path.
+    const dataUrl = scriptSrc
+      ? new URL('featured_examples.json', scriptSrc).toString()
+      : '_static/featured_examples.json';
+
+    let examples = [];
+    let currentHref = titleLink.getAttribute('href');
+
+    const applyExample = (example) => {
+      titleLink.textContent = example.title;
+      titleLink.href        = example.href;
+      description.textContent = example.description;
+      image.src             = example.image;
+      image.alt             = example.alt;
+      mediaLink.href        = example.href;
+      cta.href              = example.href;
+      currentHref           = example.href;
+    };
+
+    const chooseExample = () => {
+      if (!examples.length) return;
+      const candidates = examples.filter((ex) => ex.href !== currentHref);
+      const pool = candidates.length ? candidates : examples;
+      applyExample(pool[Math.floor(Math.random() * pool.length)]);
+    };
+
+    reroll.addEventListener('click', chooseExample);
+
+    fetch(dataUrl)
+      .then((r) => (r.ok ? r.json() : Promise.reject(r.status)))
+      .then((data) => {
+        if (!Array.isArray(data) || !data.length) { reroll.hidden = true; return; }
+        examples = data;
+        chooseExample();
+      })
+      .catch(() => { reroll.hidden = true; });
+  });
+})();

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -85,6 +85,9 @@ html_logo = '_static/images/logo.svg'
 html_css_files = [
     'custom.css',
 ]
+html_js_files = [
+    'random_example.js',
+]
 templates_path = ['_templates']
 favicons = [
     {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -121,7 +121,7 @@ html_theme_options = {
         'version_match': version_match,
     },
     'show_version_warning_banner': True,
-    'navbar_persistent': [],
+    'navbar_persistent': ['search-button'],
     'header_links_before_dropdown': 6,
     'secondary_sidebar_items': ['page-toc'],
     'pygments_light_style': 'napari',
@@ -141,7 +141,7 @@ html_theme_options = {
 # sidebar content
 html_sidebars = {
     '**': ['search-field.html', 'sidebar-nav-bs'],
-    'index': ['search-field.html', 'sidebar-link-items.html'],
+    'index': [],
 }
 
 # html context is passed into the template engine's context for all pages.

--- a/docs/index.md
+++ b/docs/index.md
@@ -82,7 +82,8 @@ theme:
 
 `````
 
-`````{grid} 1 1 2 2
+`````{grid} 1 2 2 4
+:gutter: 3
 
 ````{grid-item-card} Install with Python
 :link: install-python-package
@@ -137,8 +138,8 @@ Discover how plugins extend napari and learn to build your own.
       Display an image in napari and explore the viewer with a minimal example.
     </p>
     <div class="homepage-featured-example__actions">
-      <button class="sd-btn sd-btn-outline-primary sd-shadow-sm" id="homepage-featured-example-reroll" type="button">Show another example</button>
       <a class="sd-btn sd-btn-primary sd-shadow-sm" href="gallery.html">Examples gallery</a>
+      <button class="sd-btn sd-btn-outline-primary sd-shadow-sm" id="homepage-featured-example-reroll" type="button">Show another example</button>
     </div>
   </div>
   <a class="homepage-featured-example__media" href="gallery/add_image.html" aria-label="View the featured napari example">

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,7 +49,7 @@ theme:
 `````{grid} 1 1 3 3
 
 ````{grid-item}
-:columns: 12 12 4 4
+:columns: 12 12 5 5
 
 - **view and explore** 2D, 3D, and higher-dimensional arrays on a canvas;
 - **overlay** derived data such as *points*, *polygons*, *segmentations*, and
@@ -61,7 +61,7 @@ theme:
 ````
 
 ````{grid-item}
-:columns: 12 12 8 8
+:columns: 12 12 7 7
 
 ```{raw} html
 <figure>
@@ -82,55 +82,129 @@ theme:
 
 `````
 
-`````{grid}
+`````{grid} 1 1 3 3
 
-````{grid-item-card} Examples
-:link: gallery
+````{grid-item-card} Install with Python
+:link: install-python-package
 :link-type: ref
 
-See some of the things napari can do.
+Install napari from PyPI or conda-forge in a Python environment for
+the full viewer and Python API experience.
 ````
 
-````{grid-item-card} Installation
-:link: napari-installation
+````{grid-item-card} Download bundled app
+:link: installation_bundle_conda
 :link-type: ref
 
-How to install napari.
+Download a standalone installer when you want napari as an app without setting
+up Python first.
 ````
 
 ````{grid-item-card} Getting started
 :link: launch
 :link-type: ref
 
-Get started with napari.
+Launch napari, open images, and learn the core interactions of the viewer.
 ````
 
 `````
 
-`````{grid}
+## Featured example
 
-````{grid-item-card} Community
-:link: community
+```{raw} html
+<section class="homepage-featured-example" aria-labelledby="homepage-featured-example-title">
+  <div class="homepage-featured-example__copy">
+    <h3 id="homepage-featured-example-title" class="homepage-featured-example__title">
+      <a id="homepage-featured-example-link" href="gallery/add_image.html">Add image</a>
+    </h3>
+    <p id="homepage-featured-example-description" class="homepage-featured-example__description">
+      Display an image in napari and explore the viewer with a minimal example.
+    </p>
+    <div class="homepage-featured-example__actions">
+      <a class="sd-btn sd-btn-primary sd-shadow-sm" id="homepage-featured-example-cta" href="gallery/add_image.html">View example</a>
+      <button class="sd-btn sd-btn-outline-primary sd-shadow-sm" id="homepage-featured-example-reroll" type="button">Show another example</button>
+    </div>
+  </div>
+  <a class="homepage-featured-example__media" href="gallery/add_image.html" aria-label="View the featured napari example">
+    <img
+      id="homepage-featured-example-image"
+      src="_images/sphx_glr_add_image_001.png"
+      alt="Screenshot preview of the add image example"
+      loading="lazy"
+    >
+  </a>
+</section>
+```
+
+## Explore napari
+
+`````{grid} 1 1 3 3
+
+````{grid-item-card} Examples gallery
+:link: gallery
 :link-type: ref
 
-Forums, web chat, video chat, where to ask questions and more! Join us!
+Browse examples that show how to work with images, labels, shapes, points,
+vectors, and more.
 ````
 
-````{grid-item-card} Governance
-:link: napari-governance
-:link-type: ref
+````{grid-item-card} Tutorials
+:link: tutorials/index
+:link-type: doc
 
-napari is developed by a global community. See how.
+Follow step-by-step walkthroughs for common workflows and data-analysis tasks.
 ````
 
 ````{grid-item-card} Plugins
 :link: plugins-index
 :link-type: ref
 
-napari is extensible! Find plugins, or develop your own!
+Discover how plugins extend napari and learn where to find tools for your own
+workflow.
 ````
 
 `````
+
+## Community and resources
+
+`````{grid} 1 1 3 3
+:gutter: 2
+
+````{grid-item-card} Community
+:link: community
+:link-type: ref
+
+Meet the team, find support, join community calls, and learn where to ask
+questions.
+````
+
+````{grid-item-card} Developer resources
+:link: developers/index
+:link-type: doc
+
+Contribute to napari, understand how the project is organized, and find guides
+for working on the codebase and docs.
+````
+
+````{grid-item-card} Release notes and roadmap
+:link: release/index
+:link-type: doc
+
+See what changed in recent releases and where the project is heading next.
+````
+
+`````
+
+```{raw} html
+<div class="homepage-quicklinks">
+  <a href="community/meeting_schedule.html"><i class="fa-solid fa-calendar-days"></i> Community calendar</a>
+  <a href="https://napari.zulipchat.com/"><i class="fa-solid fa-comments"></i> Community chat</a>
+  <a href="troubleshooting.html"><i class="fa-solid fa-circle-question"></i> Troubleshooting</a>
+  <a href="release/index.html"><i class="fa-solid fa-newspaper"></i> Release notes</a>
+  <a href="roadmaps/index.html"><i class="fa-solid fa-map"></i> Roadmaps</a>
+  <a href="https://napari.org/island-dispatch"><i class="fa-solid fa-rss"></i> Blog</a>
+</div>
+```
 
 ## funding
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -88,16 +88,14 @@ theme:
 :link: install-python-package
 :link-type: ref
 
-Install napari from PyPI or conda-forge in a Python environment for
-the full viewer and Python API experience.
+Install napari in a Python environment for the most customizable experience.
 ````
 
-````{grid-item-card} Download bundled app
+````{grid-item-card} Download napari app
 :link: installation_bundle_conda
 :link-type: ref
 
-Download a standalone installer when you want napari as an app without setting
-up Python first.
+A standalone installer for when you want napari without setting up Python first.
 ````
 
 ````{grid-item-card} Getting started
@@ -111,8 +109,7 @@ Launch napari, open images, and learn the core interactions of the viewer.
 :link: plugins-index
 :link-type: ref
 
-Discover how plugins extend napari and learn where to find tools for your
-workflow.
+Discover how plugins extend napari and learn to build your own.
 ````
 
 `````

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,7 +46,7 @@ theme:
 
 # napari: a fast, interactive viewer for multi-dimensional images in Python
 
-`````{grid} 1 1 3 3
+`````{grid} 1 1 2 2
 
 ````{grid-item}
 :columns: 12 12 5 5
@@ -124,7 +124,6 @@ Discover how plugins extend napari and learn to build your own.
   <a href="https://napari.org/island-dispatch"><i class="fa-solid fa-rss"></i> Blog</a>
 </div>
 ```
-## featured example
 
 ```{raw} html
 <section class="homepage-featured-example" aria-labelledby="homepage-featured-example-title">

--- a/docs/index.md
+++ b/docs/index.md
@@ -82,7 +82,7 @@ theme:
 
 `````
 
-`````{grid} 1 1 3 3
+`````{grid} 1 2 2 4
 
 ````{grid-item-card} Install with Python
 :link: install-python-package
@@ -107,9 +107,27 @@ up Python first.
 Launch napari, open images, and learn the core interactions of the viewer.
 ````
 
+````{grid-item-card} Plugins
+:link: plugins-index
+:link-type: ref
+
+Discover how plugins extend napari and learn where to find tools for your
+workflow.
+````
+
 `````
 
-## Featured example
+```{raw} html
+<div class="homepage-quicklinks">
+  <a href="community/meeting_schedule.html"><i class="fa-solid fa-calendar-days"></i> Community calendar</a>
+  <a href="https://napari.zulipchat.com/"><i class="fa-solid fa-comments"></i> Community chat</a>
+  <a href="release/index.html"><i class="fa-solid fa-newspaper"></i> Release notes</a>
+  <a href="troubleshooting.html"><i class="fa-solid fa-circle-question"></i> Troubleshooting</a>
+  <a href="roadmaps/index.html"><i class="fa-solid fa-map"></i> Roadmap</a>
+  <a href="https://napari.org/island-dispatch"><i class="fa-solid fa-rss"></i> Blog</a>
+</div>
+```
+## featured example
 
 ```{raw} html
 <section class="homepage-featured-example" aria-labelledby="homepage-featured-example-title">
@@ -121,8 +139,8 @@ Launch napari, open images, and learn the core interactions of the viewer.
       Display an image in napari and explore the viewer with a minimal example.
     </p>
     <div class="homepage-featured-example__actions">
-      <a class="sd-btn sd-btn-primary sd-shadow-sm" id="homepage-featured-example-cta" href="gallery/add_image.html">View example</a>
       <button class="sd-btn sd-btn-outline-primary sd-shadow-sm" id="homepage-featured-example-reroll" type="button">Show another example</button>
+      <a class="sd-btn sd-btn-primary sd-shadow-sm" href="gallery.html">Examples gallery</a>
     </div>
   </div>
   <a class="homepage-featured-example__media" href="gallery/add_image.html" aria-label="View the featured napari example">
@@ -134,76 +152,6 @@ Launch napari, open images, and learn the core interactions of the viewer.
     >
   </a>
 </section>
-```
-
-## Explore napari
-
-`````{grid} 1 1 3 3
-
-````{grid-item-card} Examples gallery
-:link: gallery
-:link-type: ref
-
-Browse examples that show how to work with images, labels, shapes, points,
-vectors, and more.
-````
-
-````{grid-item-card} Tutorials
-:link: tutorials/index
-:link-type: doc
-
-Follow step-by-step walkthroughs for common workflows and data-analysis tasks.
-````
-
-````{grid-item-card} Plugins
-:link: plugins-index
-:link-type: ref
-
-Discover how plugins extend napari and learn where to find tools for your own
-workflow.
-````
-
-`````
-
-## Community and resources
-
-`````{grid} 1 1 3 3
-:gutter: 2
-
-````{grid-item-card} Community
-:link: community
-:link-type: ref
-
-Meet the team, find support, join community calls, and learn where to ask
-questions.
-````
-
-````{grid-item-card} Developer resources
-:link: developers/index
-:link-type: doc
-
-Contribute to napari, understand how the project is organized, and find guides
-for working on the codebase and docs.
-````
-
-````{grid-item-card} Release notes and roadmap
-:link: release/index
-:link-type: doc
-
-See what changed in recent releases and where the project is heading next.
-````
-
-`````
-
-```{raw} html
-<div class="homepage-quicklinks">
-  <a href="community/meeting_schedule.html"><i class="fa-solid fa-calendar-days"></i> Community calendar</a>
-  <a href="https://napari.zulipchat.com/"><i class="fa-solid fa-comments"></i> Community chat</a>
-  <a href="troubleshooting.html"><i class="fa-solid fa-circle-question"></i> Troubleshooting</a>
-  <a href="release/index.html"><i class="fa-solid fa-newspaper"></i> Release notes</a>
-  <a href="roadmaps/index.html"><i class="fa-solid fa-map"></i> Roadmaps</a>
-  <a href="https://napari.org/island-dispatch"><i class="fa-solid fa-rss"></i> Blog</a>
-</div>
 ```
 
 ## funding

--- a/docs/index.md
+++ b/docs/index.md
@@ -82,11 +82,12 @@ theme:
 
 `````
 
-`````{grid} 1 2 2 4
+`````{grid} 1 1 2 2
 
 ````{grid-item-card} Install with Python
 :link: install-python-package
 :link-type: ref
+:class-card: homepage-card-accent
 
 Install napari in a Python environment for the most customizable experience.
 ````
@@ -94,12 +95,13 @@ Install napari in a Python environment for the most customizable experience.
 ````{grid-item-card} Download napari app
 :link: installation_bundle_conda
 :link-type: ref
+:class-card: homepage-card-accent
 
 A standalone installer for when you want napari without setting up Python first.
 ````
 
-````{grid-item-card} Getting started
-:link: launch
+````{grid-item-card} Quick start
+:link: napari-quick-start
 :link-type: ref
 
 Launch napari, open images, and learn the core interactions of the viewer.
@@ -116,12 +118,12 @@ Discover how plugins extend napari and learn to build your own.
 
 ```{raw} html
 <div class="homepage-quicklinks">
-  <a href="community/meeting_schedule.html"><i class="fa-solid fa-calendar-days"></i> Community calendar</a>
-  <a href="https://napari.zulipchat.com/"><i class="fa-solid fa-comments"></i> Community chat</a>
-  <a href="release/index.html"><i class="fa-solid fa-newspaper"></i> Release notes</a>
-  <a href="troubleshooting.html"><i class="fa-solid fa-circle-question"></i> Troubleshooting</a>
-  <a href="roadmaps/index.html"><i class="fa-solid fa-map"></i> Roadmap</a>
-  <a href="https://napari.org/island-dispatch"><i class="fa-solid fa-rss"></i> Blog</a>
+  <a href="https://napari.zulipchat.com/"><i class="fa-solid fa-comments"></i><span>Community chat</span></a>
+  <a href="community/meeting_schedule.html"><i class="fa-solid fa-calendar-days"></i><span>Calendar</span></a>
+  <a href="release/index.html"><i class="fa-solid fa-newspaper"></i><span>Release notes</span></a>
+  <a href="troubleshooting.html"><i class="fa-solid fa-circle-question"></i><span>Troubleshooting</span></a>
+  <a href="roadmaps/index.html"><i class="fa-solid fa-map"></i><span>Roadmap</span></a>
+  <a href="https://napari.org/island-dispatch"><i class="fa-solid fa-rss"></i><span>Blog</span></a>
 </div>
 ```
 


### PR DESCRIPTION
# References and relevant issues

Address #793, I think?
~~Also, I think it will need to wait until 0.7.0 releases because it will look for the example images in stable static ... right? They won't be there until after 0.7.0 releases.~~ This is no longer true since we use versioned homepage now

# Description

Revamp of homepage, will detail out later. Having a bit of trouble full building locally so I'm pushing to make the bot build for me lol. This makes the homepage MUCH easier and quicker to parse _and_ I think actually provides more information. I prompted copilot with Claude Opus to set this up and it did a REALLY bad job aesthetically (I still have css cleanup to do), BUT it use this whole .js stuff that I'm clueless about and that actual works (and is what matplotlib uses). So it was sort of a win and sort of a fighting a toddler moment. In the end, I combed over most of the code myself lol.

1. Gets ride of sidebar on homepage only
2. Adds a search button in the navbar persistent on all pages, to continue to allow searching from home page
3. Gets rid of many cards, especially those that are redundant with navbar links (like community and contributing)... **TODO: realizing I should probably drop the plugins card too...? But this one is more of a "heres how napari works" compared to community and contributing**
4. Takes the quicklinks from the sidebar and makes them prevalant, but still less downplayed parts of the homepage
5. Adds a rotating example from the gallery -- `featured_examples.json` allows us to control which examples. We could probably do this as a gallery tag, but I thought it was nice to control here (rather than in napari/napari) how examples are rendered and we can be more precise about home page wording for the individual example . Also notice the dropshadow around the media, so we won't have the really sad white border around it like with the above viewer example.

<img width="2119" height="1979" alt="image" src="https://github.com/user-attachments/assets/92f1612b-5ca5-4317-b157-9b00b7d61f23" />


## Some more ideas

1. have a copy-pastable `uvx "napari[all]" remote_path_to_example.py` to show it running python files?
7. Instead of the "really nice" examples, we could do more basic ones to demonstrate API like `viewer.add_image()` leading to the add image example? I don't really like this though
8. We could also just ref any page we want and any image, the `featured_examples.json` just takes keys that are title, description, doc path, and image path. So if we have in dpeth tutorials or other things to highlight (or we can make another dynamic section with the same model that highlights other parts of the docs)
9. Ignore the example part, but do keep the sidebar removal + moving those key links over + the install + download cards.

<!-- Previewing the Documentation Build
When you submit this PR, jobs that preview the documentation will be kicked off.
By default, they will use the `slimfast` build (`make` target), which is fast, because
it doesn't build any content from outside the `docs` repository and doesn't run notebook cells.
You can trigger other builds by commenting on the PR with:

@napari-bot make <target>

where <target> can be:
html : a full build, just like the deployment to napari.org
html-noplot : a full build, but without the gallery examples from `napari/napari`
docs : only the content from `napari/docs`, with notebook code cells executed
slimfast : the default, only the content from `napari/docs`, without code cell execution
slimgallery : `slimfast`, but with the gallery examples from `napari/napari` built
-->

