### PR TITLE
Fix typo in 0.7.0 release notes

### DIFF
--- a/docs/release/release_0_7_0.md
+++ b/docs/release/release_0_7_0.md
@@ -221,7 +221,7 @@ in the inheritance madness, you can also hover over the buttons to get details a
 
 PS -- You can now also create these new layers from the `File -> New Layer` menu!
 
-#### Better text overalys 🔡
+#### Better text overlays 🔡
 
 With [#8236](https://github.com/napari/napari/pull/8236), we've not only refactored text overlays
 so they're easier to implement, but we've also introduced two new long-requested overlays:


### PR DESCRIPTION
# References and relevant issues

# Description
We probably didn't need to be overaly concerned about this, but may as well fix it.