### PR TITLE
Remove draft note from 0.7.0 release notes.

### DIFF
--- a/docs/release/release_0_7_0.md
+++ b/docs/release/release_0_7_0.md
@@ -1,5 +1,4 @@
 # napari 0.7.0
-⚠️ *Note: these release notes are still in draft while 0.7.0 is in release candidate testing.* ⚠️
 
 *Fri, Mar 20, 2026*
 

--- a/docs/release/release_0_7_0.md
+++ b/docs/release/release_0_7_0.md
@@ -1,6 +1,6 @@
 # napari 0.7.0
 
-*Fri, Mar 20, 2026*
+*Mon, Mar 23, 2026*
 
 We're happy to announce the release of napari 0.7.0!
 napari is a fast, interactive, multi-dimensional image viewer for Python.


### PR DESCRIPTION
# References and relevant issues
Follow up to https://github.com/napari/napari.github.io/pull/443

# Description
Removes draft note from 0.7.0 release notes.