### PR TITLE
Reorganize cards in homepage

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -122,8 +122,8 @@ html[data-theme="dark"] div.sphx-glr-download a:hover {
 /* ── Homepage quicklinks (icon columns) ──────────────────────────────── */
 
 .homepage-quicklinks {
-  border-top: 1px solid var(--napari-dark-gray);
-  border-bottom: 1px solid var(--napari-dark-gray);
+  border-top: 1px solid #68686817;
+  border-bottom: 1px solid #68686817;
   display: flex;
   flex-wrap: nowrap;
   gap: 0.75rem 0;
@@ -134,7 +134,7 @@ html[data-theme="dark"] div.sphx-glr-download a:hover {
 
 .homepage-quicklinks a {
   align-items: center;
-  border-right: 1px solid var(--napari-dark-gray);
+  border-right: 1px solid #68686817;
   display: flex;
   flex-direction: column;
   font-size: 0.9rem;
@@ -179,16 +179,44 @@ html[data-theme="dark"] div.sphx-glr-download a:hover {
    Install, Download cards with theme-aware napari blue.
    sphinx-design marks every property !important, so we must too.     */
 
-html[data-theme="light"] .homepage-card-accent,
+/* html[data-theme="light"] .homepage-card-accent,
 html[data-theme="light"] .homepage-card-accent .sd-card-body {
-  background-color: var(--napari-light-blue) !important;
-  border-color: var(--napari-primary-blue) !important;
+  padding-left: 0.3rem !important;
+  padding-right: 0.3rem !important;
 }
 
 html[data-theme="dark"] .homepage-card-accent,
 html[data-theme="dark"] .homepage-card-accent .sd-card-body {
-  background-color: color-mix(in srgb, var(--napari-deep-blue), transparent 75%) !important;
+  padding-left: 0.3rem !important;
+  padding-right: 0.3rem !important;
+} */
+
+.start-button {
+  display: block;
+}
+
+html[data-theme="light"] .start-button:hover {
+  background-color: var(--napari-deep-blue) !important;
   border-color: var(--napari-deep-blue) !important;
+  color: var(--napari-color-text-base) !important;
+}
+
+html[data-theme="dark"] .start-button:hover {
+  background-color: var(--napari-dark-gray) !important;
+  border-color: var(--napari-dark-gray) !important;
+  color: var(--napari-color-text-base) !important;
+}
+
+html[data-theme="light"] .start-button {
+  background-color: var(--napari-primary-blue) !important;
+  border-color: var(--napari-primary-blue) !important;
+  color: var(--napari-color-text-base) !important;
+}
+
+html[data-theme="dark"] .start-button {
+  background-color: var(--napari-purple) !important;
+  border-color: var(--napari-purple) !important;
+  color: var(--napari-color-text-base) !important;
 }
 
 /* ── Homepage featured example buttons ───────────────────────────────
@@ -212,17 +240,17 @@ html[data-theme="light"] .homepage-featured-example__actions .sd-btn-primary:foc
 }
 
 html[data-theme="dark"] .homepage-featured-example__actions .sd-btn-primary {
-  background-color: color-mix(in srgb, var(--napari-deep-blue), transparent 75%) !important;
+  background-color: color-mix(in srgb, var(--napari-purple), transparent 5%) !important;
   background-image: none !important;
-  border-color: var(--napari-deep-blue) !important;
+  border-color: var(--napari-purple) !important;
   color: var(--napari-color-text-base) !important;
 }
 
 html[data-theme="dark"] .homepage-featured-example__actions .sd-btn-primary:hover,
 html[data-theme="dark"] .homepage-featured-example__actions .sd-btn-primary:focus {
-  background-color: var(--napari-deep-blue) !important;
+  background-color: var(--napari-purple) !important;
   background-image: none !important;
-  border-color: var(--napari-deep-blue) !important;
+  border-color: var(--napari-purple) !important;
   color: var(--napari-color-text-base) !important;
 }
 
@@ -239,4 +267,8 @@ html[data-theme="dark"] .homepage-featured-example__actions .sd-btn-primary:focu
   background-image: none !important;
   border-color: var(--pst-color-border) !important;
   color: var(--napari-color-text-base) !important;
+}
+
+html[data-theme="dark"] img#homepage-featured-example-image {
+  background-color: var(--pst-color-background) !important;
 }

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -67,28 +67,28 @@ html[data-theme="dark"] div.sphx-glr-download a:hover {
    Install, Download cards with theme-aware napari blue.
    sphinx-design marks every property !important, so we must too.     */
 
-.start-button {
+.homepage-button {
   display: block;
 }
 
-html[data-theme="light"] .start-button {
+html[data-theme="light"] .homepage-button {
   background-color: var(--napari-primary-blue) !important;
   border-color: var(--napari-primary-blue) !important;
   color: var(--napari-color-text-base) !important;
 }
 
-html[data-theme="dark"] .start-button {
+html[data-theme="dark"] .homepage-button {
   background-color: var(--napari-purple) !important;
   border-color: var(--napari-purple) !important;
   color: var(--napari-color-text-base) !important;
 }
 
-html[data-theme="light"] .start-button:hover {
+html[data-theme="light"] .homepage-button:hover {
   text-decoration: underline;
   background-color: color-mix(in srgb, var(--napari-primary-blue), transparent 25%) !important;
 }
 
-html[data-theme="dark"] .start-button:hover {
+html[data-theme="dark"] .homepage-button:hover {
   text-decoration: underline;
   background-color: color-mix(in srgb, var(--napari-purple), transparent 25%) !important;
 }
@@ -218,56 +218,6 @@ html[data-theme="dark"] .homepage-quicklinks a {
   .homepage-featured-example__media {
     order: -1;
   }
-}
-
-/* ── Homepage featured example buttons ───────────────────────────────
-   "Examples gallery" (sd-btn-primary) matches the accent card napari blue.
-   "Show another example" (sd-btn-outline-primary) is a neutral card-style button.
-   background-image reset prevents any sphinx-design gradient from bleeding through. */
-
-html[data-theme="light"] .homepage-featured-example__actions .sd-btn-primary {
-  background-color: var(--napari-primary-blue) !important;
-  background-image: none !important;
-  border-color: var(--napari-primary-blue) !important;
-  color: var(--napari-color-text-base) !important;
-}
-
-html[data-theme="light"] .homepage-featured-example__actions .sd-btn-primary:hover,
-html[data-theme="light"] .homepage-featured-example__actions .sd-btn-primary:focus {
-  background-color: color-mix(in srgb, var(--napari-primary-blue), transparent 25%) !important;
-  background-image: none !important;
-  border-color: var(--napari-primary-blue) !important;
-  color: var(--napari-color-text-base) !important;
-}
-
-html[data-theme="dark"] .homepage-featured-example__actions .sd-btn-primary {
-  background-color: color-mix(in srgb, var(--napari-purple), transparent 25%) !important;
-  background-image: none !important;
-  border-color: var(--napari-purple) !important;
-  color: var(--napari-color-text-base) !important;
-}
-
-html[data-theme="dark"] .homepage-featured-example__actions .sd-btn-primary:hover,
-html[data-theme="dark"] .homepage-featured-example__actions .sd-btn-primary:focus {
-  background-color: color-mix(in srgb, var(--napari-purple), transparent 5%) !important;
-  background-image: none !important;
-  border-color: var(--napari-purple) !important;
-  color: var(--napari-color-text-base) !important;
-}
-
-.homepage-featured-example__actions .sd-btn-outline-primary {
-  background-color: var(--pst-color-on-background) !important;
-  background-image: none !important;
-  border-color: var(--pst-color-border) !important;
-  color: var(--napari-color-text-base) !important;
-}
-
-.homepage-featured-example__actions .sd-btn-outline-primary:hover,
-.homepage-featured-example__actions .sd-btn-outline-primary:focus {
-  background-color: var(--pst-color-border) !important;
-  background-image: none !important;
-  border-color: var(--pst-color-border) !important;
-  color: var(--napari-color-text-base) !important;
 }
 
 html[data-theme="dark"] img#homepage-featured-example-image {

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -63,6 +63,107 @@ html[data-theme="dark"] div.sphx-glr-download a:hover {
   font-weight: 700;
 }
 
+/* ── Homepage accent cards ───────────────────────────────────────────
+   Install, Download cards with theme-aware napari blue.
+   sphinx-design marks every property !important, so we must too.     */
+
+.start-button {
+  display: block;
+}
+
+html[data-theme="light"] .start-button {
+  background-color: var(--napari-primary-blue) !important;
+  border-color: var(--napari-primary-blue) !important;
+  color: var(--napari-color-text-base) !important;
+}
+
+html[data-theme="dark"] .start-button {
+  background-color: var(--napari-purple) !important;
+  border-color: var(--napari-purple) !important;
+  color: var(--napari-color-text-base) !important;
+}
+
+html[data-theme="light"] .start-button:hover {
+  text-decoration: underline;
+  background-color: color-mix(in srgb, var(--napari-primary-blue), transparent 25%) !important;
+}
+
+html[data-theme="dark"] .start-button:hover {
+  text-decoration: underline;
+  background-color: color-mix(in srgb, var(--napari-purple), transparent 25%) !important;
+}
+
+/* ── Homepage quicklinks (icon columns) ──────────────────────────────── */
+
+.homepage-quicklinks {
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 0.75rem 0;
+  justify-content: center;
+  margin: 1rem 0 1.5rem;
+  padding: 1rem 0;
+}
+
+html[data-theme="light"] .homepage-quicklinks {
+  border-top: 1px solid rgba(0, 0, 0, 0.25);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.25);
+}
+
+html[data-theme="dark"] .homepage-quicklinks {
+  border-top: 1px solid rgba(255, 255, 255, 0.25);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.25);
+}
+
+.homepage-quicklinks a {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  font-size: 0.9rem;
+  font-weight: 500;
+  gap: 0.5rem;
+  padding: 0.25rem 2rem;
+  text-align: center;
+  text-decoration: none;
+}
+
+html[data-theme="light"] .homepage-quicklinks a {
+  border-right: 1px solid rgba(0, 0, 0, 0.25);
+}
+
+html[data-theme="dark"] .homepage-quicklinks a {
+  border-right: 1px solid rgba(255, 255, 255, 0.25);
+}
+
+.homepage-quicklinks a:last-child {
+  border-right: none !important;
+}
+
+.homepage-quicklinks a:hover {
+  text-decoration: underline;
+}
+
+.homepage-quicklinks i {
+  color: var(--pst-color-primary);
+  font-size: 4rem;
+  line-height: 1;
+}
+
+@media (max-width: 640px) {
+  .homepage-quicklinks {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 0.75rem 0;
+  }
+
+  .homepage-quicklinks a {
+    padding: 0.5rem 1.5rem;
+  }
+
+  .homepage-quicklinks a:nth-child(2n) {
+    border-right: none;
+  }
+}
+
 /* ── Homepage featured example ─────────────────────────────────────── */
 
 .homepage-featured-example {
@@ -119,113 +220,13 @@ html[data-theme="dark"] div.sphx-glr-download a:hover {
   }
 }
 
-/* ── Homepage quicklinks (icon columns) ──────────────────────────────── */
-
-.homepage-quicklinks {
-  border-top: 1px solid #68686817;
-  border-bottom: 1px solid #68686817;
-  display: flex;
-  flex-wrap: nowrap;
-  gap: 0.75rem 0;
-  justify-content: center;
-  margin: 1rem 0 1.5rem;
-  padding: 1rem 0;
-}
-
-.homepage-quicklinks a {
-  align-items: center;
-  border-right: 1px solid #68686817;
-  display: flex;
-  flex-direction: column;
-  font-size: 0.9rem;
-  font-weight: 500;
-  gap: 0.5rem;
-  padding: 0.25rem 2rem;
-  text-align: center;
-  text-decoration: none;
-}
-
-.homepage-quicklinks a:last-child {
-  border-right: none;
-}
-
-.homepage-quicklinks a:hover {
-  text-decoration: underline;
-}
-
-.homepage-quicklinks i {
-  color: var(--pst-color-primary);
-  font-size: 4rem;
-  line-height: 1;
-}
-
-@media (max-width: 640px) {
-  .homepage-quicklinks {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    gap: 0.75rem 0;
-  }
-
-  .homepage-quicklinks a {
-    padding: 0.5rem 1.5rem;
-  }
-
-  .homepage-quicklinks a:nth-child(2n) {
-    border-right: none;
-  }
-}
-
-/* ── Homepage accent cards ───────────────────────────────────────────
-   Install, Download cards with theme-aware napari blue.
-   sphinx-design marks every property !important, so we must too.     */
-
-/* html[data-theme="light"] .homepage-card-accent,
-html[data-theme="light"] .homepage-card-accent .sd-card-body {
-  padding-left: 0.3rem !important;
-  padding-right: 0.3rem !important;
-}
-
-html[data-theme="dark"] .homepage-card-accent,
-html[data-theme="dark"] .homepage-card-accent .sd-card-body {
-  padding-left: 0.3rem !important;
-  padding-right: 0.3rem !important;
-} */
-
-.start-button {
-  display: block;
-}
-
-html[data-theme="light"] .start-button:hover {
-  background-color: var(--napari-deep-blue) !important;
-  border-color: var(--napari-deep-blue) !important;
-  color: var(--napari-color-text-base) !important;
-}
-
-html[data-theme="dark"] .start-button:hover {
-  background-color: var(--napari-dark-gray) !important;
-  border-color: var(--napari-dark-gray) !important;
-  color: var(--napari-color-text-base) !important;
-}
-
-html[data-theme="light"] .start-button {
-  background-color: var(--napari-primary-blue) !important;
-  border-color: var(--napari-primary-blue) !important;
-  color: var(--napari-color-text-base) !important;
-}
-
-html[data-theme="dark"] .start-button {
-  background-color: var(--napari-purple) !important;
-  border-color: var(--napari-purple) !important;
-  color: var(--napari-color-text-base) !important;
-}
-
 /* ── Homepage featured example buttons ───────────────────────────────
    "Examples gallery" (sd-btn-primary) matches the accent card napari blue.
    "Show another example" (sd-btn-outline-primary) is a neutral card-style button.
    background-image reset prevents any sphinx-design gradient from bleeding through. */
 
 html[data-theme="light"] .homepage-featured-example__actions .sd-btn-primary {
-  background-color: var(--napari-light-blue) !important;
+  background-color: var(--napari-primary-blue) !important;
   background-image: none !important;
   border-color: var(--napari-primary-blue) !important;
   color: var(--napari-color-text-base) !important;
@@ -233,14 +234,14 @@ html[data-theme="light"] .homepage-featured-example__actions .sd-btn-primary {
 
 html[data-theme="light"] .homepage-featured-example__actions .sd-btn-primary:hover,
 html[data-theme="light"] .homepage-featured-example__actions .sd-btn-primary:focus {
-  background-color: var(--napari-primary-blue) !important;
+  background-color: color-mix(in srgb, var(--napari-primary-blue), transparent 25%) !important;
   background-image: none !important;
   border-color: var(--napari-primary-blue) !important;
   color: var(--napari-color-text-base) !important;
 }
 
 html[data-theme="dark"] .homepage-featured-example__actions .sd-btn-primary {
-  background-color: color-mix(in srgb, var(--napari-purple), transparent 5%) !important;
+  background-color: color-mix(in srgb, var(--napari-purple), transparent 25%) !important;
   background-image: none !important;
   border-color: var(--napari-purple) !important;
   color: var(--napari-color-text-base) !important;
@@ -248,7 +249,7 @@ html[data-theme="dark"] .homepage-featured-example__actions .sd-btn-primary {
 
 html[data-theme="dark"] .homepage-featured-example__actions .sd-btn-primary:hover,
 html[data-theme="dark"] .homepage-featured-example__actions .sd-btn-primary:focus {
-  background-color: var(--napari-purple) !important;
+  background-color: color-mix(in srgb, var(--napari-purple), transparent 5%) !important;
   background-image: none !important;
   border-color: var(--napari-purple) !important;
   color: var(--napari-color-text-base) !important;

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -105,13 +105,13 @@ html[data-theme="dark"] .homepage-button:hover {
 }
 
 html[data-theme="light"] .homepage-quicklinks {
-  border-top: 1px solid rgba(0, 0, 0, 0.25);
-  border-bottom: 1px solid rgba(0, 0, 0, 0.25);
+  border-top: 1px solid rgba(0, 0, 0, 0.15);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.15);
 }
 
 html[data-theme="dark"] .homepage-quicklinks {
-  border-top: 1px solid rgba(255, 255, 255, 0.25);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.25);
+  border-top: 1px solid rgba(255, 255, 255, 0.15);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.15);
 }
 
 .homepage-quicklinks a {
@@ -222,4 +222,9 @@ html[data-theme="dark"] .homepage-quicklinks a {
 
 html[data-theme="dark"] img#homepage-featured-example-image {
   background-color: var(--pst-color-background) !important;
+}
+
+.homepage-example-button:hover {
+  background-color: var(--pst-color-background) !important;
+  color: var(--napari-color-text-base) !important;
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,9 +64,9 @@ theme:
 :color: primary
 :ref-type: myst
 :shadow:
-:class: start-button
+:class: homepage-button
 
-{material-regular}`arrow_forward;1.2em` Get started
+{material-regular}`arrow_forward;1.2em` **Get started**
 ```
 ````
 
@@ -133,7 +133,7 @@ A standalone installer for when you want napari without setting up Python first.
       Display an image in napari and explore the viewer with a minimal example.
     </p>
     <div class="homepage-featured-example__actions">
-      <a class="sd-btn sd-btn-primary sd-shadow-sm" href="gallery.html">Examples gallery</a>
+      <a class="sd-btn sd-btn-primary sd-shadow-sm homepage-button" href="gallery.html">Examples gallery</a>
       <button class="sd-btn sd-btn-outline-primary sd-shadow-sm" id="homepage-featured-example-reroll" type="button">Show another example</button>
     </div>
   </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,6 +58,16 @@ theme:
   such as NumPy or Zarr arrays, allowing you to
 - **seamlessly weave** exploration, computation, and annotation together in
   imaging data analysis.
+
+
+```{button-ref} napari-quick-start
+:color: primary
+:ref-type: myst
+:shadow:
+:class: start-button
+
+{material-regular}`arrow_forward;1.2em` Get started
+```
 ````
 
 ````{grid-item}
@@ -82,39 +92,24 @@ theme:
 
 `````
 
-`````{grid} 1 2 2 4
+`````{grid} 1 2 2 2
 :gutter: 3
 
-````{grid-item-card} Install with Python
+::::{grid-item-card} {material-regular}`terminal;1.3em` Install with Python
 :link: install-python-package
 :link-type: ref
 :class-card: homepage-card-accent
 
 Install napari in a Python environment for the most customizable experience.
-````
+::::
 
-````{grid-item-card} Download napari app
+::::{grid-item-card} {material-regular}`install_desktop;1.3em` Download napari app
 :link: installation_bundle_conda
 :link-type: ref
 :class-card: homepage-card-accent
 
 A standalone installer for when you want napari without setting up Python first.
-````
-
-````{grid-item-card} Quick start
-:link: napari-quick-start
-:link-type: ref
-
-Launch napari, open images, and learn the core interactions of the viewer.
-````
-
-````{grid-item-card} Plugins
-:link: plugins-index
-:link-type: ref
-
-Discover how plugins extend napari and learn to build your own.
-````
-
+::::
 `````
 
 ```{raw} html

--- a/docs/index.md
+++ b/docs/index.md
@@ -134,7 +134,7 @@ A standalone installer for when you want napari without setting up Python first.
     </p>
     <div class="homepage-featured-example__actions">
       <a class="sd-btn sd-btn-primary sd-shadow-sm homepage-button" href="gallery.html">Examples gallery</a>
-      <button class="sd-btn sd-btn-outline-primary sd-shadow-sm" id="homepage-featured-example-reroll" type="button">Show another example</button>
+      <button class="sd-btn sd-btn-outline-primary sd-shadow-sm homepage-example-button" id="homepage-featured-example-reroll" type="button">Show another example</button>
     </div>
   </div>
   <a class="homepage-featured-example__media" href="gallery/add_image.html" aria-label="View the featured napari example">


### PR DESCRIPTION
# References and relevant issues
See https://napari.zulipchat.com/#narrow/channel/298358-working-group-documentation/topic/landing.20page.20cards/with/581209472

# Description
This PR has a few suggestions for reorganization of the homepage:
- Reduce number of cards from 4 to 2, to focus on highlighting installation;
- Add button to quickstart;
- Change some highlight colors to match light/dark theme.
