### PR TITLE
Rename "latest" version switch to "dev"

### DIFF
--- a/docs/_static/version_switcher.json
+++ b/docs/_static/version_switcher.json
@@ -1,6 +1,6 @@
 [
     {
-        "name": "latest",
+        "name": "dev",
         "version": "dev",
         "url": "https://napari.org/dev/"
     },

--- a/docs/developers/contributing/documentation/docs_deployment.md
+++ b/docs/developers/contributing/documentation/docs_deployment.md
@@ -44,7 +44,7 @@ through several CI workflows detailed below.
        to GitHub pages at the `gh-pages` branch of
        [napari/napari.github.io](https://github.com/napari/napari.github.io/tree/gh-pages).
      - Always deploys to the `dev/` folder on `napari.github.io` (version
-       "latest" on the website).
+       "dev" on the website).
      - Deployment is triggered by any commit to the `main` branch on `napari/docs`
        (and consequently triggers a new deployment of the `napari.org`
        website.)

--- a/docs/howtos/docker.md
+++ b/docs/howtos/docker.md
@@ -66,7 +66,7 @@ This image features a series of environment variables you can use to customize i
 ## For development
 
 The Docker images are also useful for developers who need to debug issues on Linux.
-The images include the latest napari version published on PyPI by default, but you can also install your own local version of napari if needed.
+The images include the latest stable napari version published on PyPI by default, but you can also install your own local version of napari if needed.
 For this, you need to mount a volume as part of the `docker run` command and make sure you land in a `bash` session:
 
 ```bash

--- a/docs/howtos/docker.md
+++ b/docs/howtos/docker.md
@@ -66,7 +66,7 @@ This image features a series of environment variables you can use to customize i
 ## For development
 
 The Docker images are also useful for developers who need to debug issues on Linux.
-The images include the latest stable napari version published on PyPI by default, but you can also install your own local version of napari if needed.
+The images include the most recent stable napari version published on PyPI by default, but you can also install your own local version of napari if needed.
 For this, you need to mount a volume as part of the `docker run` command and make sure you land in a `bash` session:
 
 ```bash


### PR DESCRIPTION
# References and relevant issues

Discussed in [#community-meeting > 2026-03-26/27 Documentation Working Group @ 💬](https://napari.zulipchat.com/#narrow/channel/215290-community-meeting/topic/2026-03-26.2F27.20Documentation.20Working.20Group/near/582215519)

# Description

Having the dev docs be called "latest" is confusing, especially for folks who do not have experience in software dev as latest can ambiguously imply "the latest stable release". This renames it do "dev", as is the name too of the URL path. This should require no other changes to documentation. 

