### PR TITLE
Use stable version for dev docs bundle links

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,7 @@ import re
 from datetime import datetime
 from importlib import import_module
 from importlib.metadata import distribution, version as metadata_version
+from pathlib import Path
 from urllib.parse import urlparse, urlunparse
 
 import napari

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -267,10 +267,6 @@ min_python_version = min(napari_supported_python_versions)
 max_python_version = max(napari_supported_python_versions)
 
 version_string = '.'.join(str(x) for x in __version_tuple__[:3])
-bundle_release = release
-if napari_version.pre and napari_version.pre[0] in {'a', 'rc'}:
-    pre_label, pre_number = napari_version.pre
-    bundle_release = f'{napari_version.base_version}{pre_label}{pre_number}'
 # when updating the version below, ensure to also update napari/napari README
 python_version = '3.11'
 python_version_range = f'{min_python_version}-{max_python_version}'
@@ -279,7 +275,6 @@ myst_substitutions = {
     'napari_conda_version': f'`napari={version_string}`',
     'napari_version': version_string,
     'release': release,
-    'bundle_release': bundle_release,
     'python_version': python_version,
     'python_version_range': python_version_range,
     'python_version_code': f'`python={python_version}`',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,7 +15,6 @@ import re
 from datetime import datetime
 from importlib import import_module
 from importlib.metadata import distribution, version as metadata_version
-from pathlib import Path
 from urllib.parse import urlparse, urlunparse
 
 import napari
@@ -267,6 +266,10 @@ min_python_version = min(napari_supported_python_versions)
 max_python_version = max(napari_supported_python_versions)
 
 version_string = '.'.join(str(x) for x in __version_tuple__[:3])
+bundle_release = release
+if napari_version.pre and napari_version.pre[0] in {'a', 'rc'}:
+    pre_label, pre_number = napari_version.pre
+    bundle_release = f'{napari_version.base_version}{pre_label}{pre_number}'
 # when updating the version below, ensure to also update napari/napari README
 python_version = '3.11'
 python_version_range = f'{min_python_version}-{max_python_version}'
@@ -275,6 +278,7 @@ myst_substitutions = {
     'napari_conda_version': f'`napari={version_string}`',
     'napari_version': version_string,
     'release': release,
+    'bundle_release': bundle_release,
     'python_version': python_version,
     'python_version_range': python_version_range,
     'python_version_code': f'`python={python_version}`',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,6 +12,7 @@ individual extension documentation for more information on specific settings.
 import logging
 import os
 import re
+import subprocess
 from datetime import datetime
 from importlib import import_module
 from importlib.metadata import distribution, version as metadata_version
@@ -267,6 +268,26 @@ min_python_version = min(napari_supported_python_versions)
 max_python_version = max(napari_supported_python_versions)
 
 version_string = '.'.join(str(x) for x in __version_tuple__[:3])
+
+# For bundle download links, always use a version that has published assets.
+# On dev builds the current version_string refers to an unreleased version,
+# so fall back to the latest stable tag from git instead.
+def _latest_stable_tag() -> str:
+    """Return the most recent vX.Y.Z git tag (no pre-release suffix)."""
+    try:
+        result = subprocess.run(
+            ['git', 'tag', '--sort=-version:refname'],
+            capture_output=True, text=True, check=True,
+        )
+        for tag in result.stdout.splitlines():
+            tag = tag.strip()
+            if re.fullmatch(r'v\d+\.\d+\.\d+', tag):
+                return tag.lstrip('v')
+    except Exception:
+        pass
+    return version_string  # fallback
+
+bundle_version = _latest_stable_tag() if napari_version.is_prerelease else version_string
 # when updating the version below, ensure to also update napari/napari README
 python_version = '3.11'
 python_version_range = f'{min_python_version}-{max_python_version}'
@@ -274,6 +295,7 @@ python_version_range = f'{min_python_version}-{max_python_version}'
 myst_substitutions = {
     'napari_conda_version': f'`napari={version_string}`',
     'napari_version': version_string,
+    'bundle_version': bundle_version,
     'release': release,
     'python_version': python_version,
     'python_version_range': python_version_range,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,9 +10,9 @@ individual extension documentation for more information on specific settings.
 # -- Imports --------------------------------------------------------------
 
 import logging
+import json
 import os
 import re
-import subprocess
 from datetime import datetime
 from importlib import import_module
 from importlib.metadata import distribution, version as metadata_version
@@ -269,25 +269,20 @@ max_python_version = max(napari_supported_python_versions)
 
 version_string = '.'.join(str(x) for x in __version_tuple__[:3])
 
-# For bundle download links, always use a version that has published assets.
-# On dev builds the current version_string refers to an unreleased version,
-# so fall back to the latest stable tag from git instead.
-def _latest_stable_tag() -> str:
-    """Return the most recent vX.Y.Z git tag (no pre-release suffix)."""
-    try:
-        result = subprocess.run(
-            ['git', 'tag', '--sort=-version:refname'],
-            capture_output=True, text=True, check=True,
-        )
-        for tag in result.stdout.splitlines():
-            tag = tag.strip()
-            if re.fullmatch(r'v\d+\.\d+\.\d+', tag):
-                return tag.lstrip('v')
-    except Exception:
-        pass
-    return version_string  # fallback
+def _stable_version_from_switcher() -> str:
+    """Return the stable docs version advertised in the version switcher."""
+    switcher_path = Path(__file__).parent / '_static' / 'version_switcher.json'
+    switcher_entries = json.loads(switcher_path.read_text(encoding='utf-8'))
+    return next(
+        entry['version']
+        for entry in switcher_entries if entry.get('preferred')
+    )
 
-bundle_version = _latest_stable_tag() if napari_version.is_prerelease else version_string
+bundle_version = (
+    _stable_version_from_switcher()
+    if napari_version.is_prerelease
+    else version_string
+)
 # when updating the version below, ensure to also update napari/napari README
 python_version = '3.11'
 python_version_range = f'{min_python_version}-{max_python_version}'

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -294,7 +294,9 @@ Select your platform below to download napari {{ bundle_version }} directly:
 
 ````
 
-For earlier versions of the napari app, scroll below the latest release on the [napari GitHub releases page](https://github.com/napari/napari/releases). Each release (0.4.15 and above) includes installers for all platforms under the "Assets" section.
+For pre-release versions or earlier stable versions of the napari app,
+scroll below the latest release on the [napari GitHub releases page](https://github.com/napari/napari/releases).
+Each release (0.4.15 and above) includes installers for all platforms under the "Assets" section.
 
 (windows-bundle)=
 

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -268,7 +268,6 @@ Select your platform below to download napari {{ bundle_release }} directly:
 {ref}`Installation steps <windows-bundle>`
 ```
 
-```{grid-item-card} macOS Apple Silicon (arm64) —  M1 and later
 :text-align: center
 
 {{ '[Download (.pkg)](https://github.com/napari/napari/releases/download/vREL/napari-REL-macOS-arm64.pkg)'.replace('REL', bundle_release) }}
@@ -300,7 +299,7 @@ For earlier versions of the napari app, scroll below the latest release on the [
 
 ### Windows
 
-Download from Github: {{ '[napari-REL-Windows-x86_64.exe](https://github.com/napari/napari/releases/download/vREL/napari-REL-Windows-x86_64.exe)'.replace('REL', bundle_release) }}
+Download from GitHub: {{ '[napari-REL-Windows-x86_64.exe](https://github.com/napari/napari/releases/download/vREL/napari-REL-Windows-x86_64.exe)'.replace('REL', bundle_release) }}
 
 Double-click the downloaded `.exe` file to begin setup.
 
@@ -338,7 +337,7 @@ Next, check out our [tutorial on the viewer](viewer-tutorial) or explore the [Us
 
 Download the installer for your Mac:
 
-- {{ '[napari-REL-macOS-arm64.pkg](https://github.com/napari/napari/releases/download/vREL/napari-REL-macOS-arm64.pkg)'.replace('REL', bundle_release) }} — Apple Silicon (M1 and later)
+- {{ '[napari-REL-macOS-arm64.pkg](https://github.com/napari/napari/releases/download/vREL/napari-REL-macOS-arm64.pkg)'.replace('REL', bundle_release) }} — Apple Silicon (ARM)
 - {{ '[napari-REL-macOS-x86_64.pkg](https://github.com/napari/napari/releases/download/vREL/napari-REL-macOS-x86_64.pkg)'.replace('REL', bundle_release) }} — Intel
 
 Double-click the downloaded `.pkg` file to launch the Installer.
@@ -383,7 +382,7 @@ Next, check out our [tutorial on the viewer](viewer-tutorial) or explore the [Us
 
 ### Linux
 
-Download from Github: {{ '[napari-REL-Linux-x86_64.sh](https://github.com/napari/napari/releases/download/vREL/napari-REL-Linux-x86_64.sh)'.replace('REL', bundle_release) }}
+Download from GitHub: {{ '[napari-REL-Linux-x86_64.sh](https://github.com/napari/napari/releases/download/vREL/napari-REL-Linux-x86_64.sh)'.replace('REL', bundle_release) }}
 
 Open a terminal, navigate to your downloads folder (`cd ~/Downloads`), and run:
 

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -268,6 +268,7 @@ Select your platform below to download napari {{ bundle_release }} directly:
 {ref}`Installation steps <windows-bundle>`
 ```
 
+```{grid-item-card} macOS Apple Silicon (ARM)
 :text-align: center
 
 {{ '[Download (.pkg)](https://github.com/napari/napari/releases/download/vREL/napari-REL-macOS-arm64.pkg)'.replace('REL', bundle_release) }}

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -268,7 +268,7 @@ Select your platform below to download napari {{ bundle_release }} directly:
 {ref}`Installation steps <windows-bundle>`
 ```
 
-```{grid-item-card} macOS Apple Silicon (arm64)
+```{grid-item-card} macOS Apple Silicon (arm64) —  M1 and later
 :text-align: center
 
 {{ '[Download (.pkg)](https://github.com/napari/napari/releases/download/vREL/napari-REL-macOS-arm64.pkg)'.replace('REL', bundle_release) }}

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -255,7 +255,7 @@ pip install napari[pyqt6, optional] -c constraints_py3.10.txt
 
 napari can be installed as a standalone application on macOS, Windows, and Linux — no Python knowledge required. This is the simplest way to get started and works best if you want to use napari as a standalone GUI app. Note that some plugins may not be available without a full Python environment.
 
-Select your platform below to download napari {{ napari_version }} directly:
+Select your platform below to download napari {{ bundle_version }} directly:
 
 ````{grid} 1 2 2 4
 :gutter: 2
@@ -263,7 +263,7 @@ Select your platform below to download napari {{ napari_version }} directly:
 ```{grid-item-card} Windows
 :text-align: center
 
-{{ '[Download (.exe)](https://github.com/napari/napari/releases/download/vREL/napari-REL-Windows-x86_64.exe)'.replace('REL', napari_version) }}
+{{ '[Download (.exe)](https://github.com/napari/napari/releases/download/vREL/napari-REL-Windows-x86_64.exe)'.replace('REL', bundle_version) }}
 +++
 {ref}`Installation steps <windows-bundle>`
 ```
@@ -271,7 +271,7 @@ Select your platform below to download napari {{ napari_version }} directly:
 ```{grid-item-card} macOS Apple Silicon (ARM)
 :text-align: center
 
-{{ '[Download (.pkg)](https://github.com/napari/napari/releases/download/vREL/napari-REL-macOS-arm64.pkg)'.replace('REL', napari_version) }}
+{{ '[Download (.pkg)](https://github.com/napari/napari/releases/download/vREL/napari-REL-macOS-arm64.pkg)'.replace('REL', bundle_version) }}
 +++
 {ref}`Installation steps <macos-bundle>`
 ```
@@ -279,7 +279,7 @@ Select your platform below to download napari {{ napari_version }} directly:
 ```{grid-item-card} macOS Intel (x86_64)
 :text-align: center
 
-{{ '[Download (.pkg)](https://github.com/napari/napari/releases/download/vREL/napari-REL-macOS-x86_64.pkg)'.replace('REL', napari_version) }}
+{{ '[Download (.pkg)](https://github.com/napari/napari/releases/download/vREL/napari-REL-macOS-x86_64.pkg)'.replace('REL', bundle_version) }}
 +++
 {ref}`Installation steps <macos-bundle>`
 ```
@@ -287,7 +287,7 @@ Select your platform below to download napari {{ napari_version }} directly:
 ```{grid-item-card} Linux
 :text-align: center
 
-{{ '[Download (.sh)](https://github.com/napari/napari/releases/download/vREL/napari-REL-Linux-x86_64.sh)'.replace('REL', napari_version) }}
+{{ '[Download (.sh)](https://github.com/napari/napari/releases/download/vREL/napari-REL-Linux-x86_64.sh)'.replace('REL', bundle_version) }}
 +++
 {ref}`Installation steps <linux-bundle>`
 ```
@@ -300,7 +300,7 @@ For earlier versions of the napari app, scroll below the latest release on the [
 
 ### Windows
 
-Download from GitHub: {{ '[napari-REL-Windows-x86_64.exe](https://github.com/napari/napari/releases/download/vREL/napari-REL-Windows-x86_64.exe)'.replace('REL', napari_version) }}
+Download from GitHub: {{ '[napari-REL-Windows-x86_64.exe](https://github.com/napari/napari/releases/download/vREL/napari-REL-Windows-x86_64.exe)'.replace('REL', bundle_version) }}
 
 Double-click the downloaded `.exe` file to begin setup.
 
@@ -338,8 +338,8 @@ Next, check out our [tutorial on the viewer](viewer-tutorial) or explore the [Us
 
 Download the installer for your Mac:
 
-- {{ '[napari-REL-macOS-arm64.pkg](https://github.com/napari/napari/releases/download/vREL/napari-REL-macOS-arm64.pkg)'.replace('REL', napari_version) }} — Apple Silicon (ARM)
-- {{ '[napari-REL-macOS-x86_64.pkg](https://github.com/napari/napari/releases/download/vREL/napari-REL-macOS-x86_64.pkg)'.replace('REL', napari_version) }} — Intel
+- {{ '[napari-REL-macOS-arm64.pkg](https://github.com/napari/napari/releases/download/vREL/napari-REL-macOS-arm64.pkg)'.replace('REL', bundle_version) }} — Apple Silicon (ARM)
+- {{ '[napari-REL-macOS-x86_64.pkg](https://github.com/napari/napari/releases/download/vREL/napari-REL-macOS-x86_64.pkg)'.replace('REL', bundle_version) }} — Intel
 
 Double-click the downloaded `.pkg` file to launch the Installer.
 
@@ -383,7 +383,7 @@ Next, check out our [tutorial on the viewer](viewer-tutorial) or explore the [Us
 
 ### Linux
 
-Download from GitHub: {{ '[napari-REL-Linux-x86_64.sh](https://github.com/napari/napari/releases/download/vREL/napari-REL-Linux-x86_64.sh)'.replace('REL', napari_version) }}
+Download from GitHub: {{ '[napari-REL-Linux-x86_64.sh](https://github.com/napari/napari/releases/download/vREL/napari-REL-Linux-x86_64.sh)'.replace('REL', bundle_version) }}
 
 Open a terminal, navigate to your downloads folder (`cd ~/Downloads`), and run:
 

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -255,7 +255,7 @@ pip install napari[pyqt6, optional] -c constraints_py3.10.txt
 
 napari can be installed as a standalone application on macOS, Windows, and Linux — no Python knowledge required. This is the simplest way to get started and works best if you want to use napari as a standalone GUI app. Note that some plugins may not be available without a full Python environment.
 
-Select your platform below to download napari {{ bundle_release }} directly:
+Select your platform below to download napari {{ napari_version }} directly:
 
 ````{grid} 1 2 2 4
 :gutter: 2
@@ -263,7 +263,7 @@ Select your platform below to download napari {{ bundle_release }} directly:
 ```{grid-item-card} Windows
 :text-align: center
 
-{{ '[Download (.exe)](https://github.com/napari/napari/releases/download/vREL/napari-REL-Windows-x86_64.exe)'.replace('REL', bundle_release) }}
+{{ '[Download (.exe)](https://github.com/napari/napari/releases/download/vREL/napari-REL-Windows-x86_64.exe)'.replace('REL', napari_version) }}
 +++
 {ref}`Installation steps <windows-bundle>`
 ```
@@ -271,7 +271,7 @@ Select your platform below to download napari {{ bundle_release }} directly:
 ```{grid-item-card} macOS Apple Silicon (ARM)
 :text-align: center
 
-{{ '[Download (.pkg)](https://github.com/napari/napari/releases/download/vREL/napari-REL-macOS-arm64.pkg)'.replace('REL', bundle_release) }}
+{{ '[Download (.pkg)](https://github.com/napari/napari/releases/download/vREL/napari-REL-macOS-arm64.pkg)'.replace('REL', napari_version) }}
 +++
 {ref}`Installation steps <macos-bundle>`
 ```
@@ -279,7 +279,7 @@ Select your platform below to download napari {{ bundle_release }} directly:
 ```{grid-item-card} macOS Intel (x86_64)
 :text-align: center
 
-{{ '[Download (.pkg)](https://github.com/napari/napari/releases/download/vREL/napari-REL-macOS-x86_64.pkg)'.replace('REL', bundle_release) }}
+{{ '[Download (.pkg)](https://github.com/napari/napari/releases/download/vREL/napari-REL-macOS-x86_64.pkg)'.replace('REL', napari_version) }}
 +++
 {ref}`Installation steps <macos-bundle>`
 ```
@@ -287,7 +287,7 @@ Select your platform below to download napari {{ bundle_release }} directly:
 ```{grid-item-card} Linux
 :text-align: center
 
-{{ '[Download (.sh)](https://github.com/napari/napari/releases/download/vREL/napari-REL-Linux-x86_64.sh)'.replace('REL', bundle_release) }}
+{{ '[Download (.sh)](https://github.com/napari/napari/releases/download/vREL/napari-REL-Linux-x86_64.sh)'.replace('REL', napari_version) }}
 +++
 {ref}`Installation steps <linux-bundle>`
 ```
@@ -300,7 +300,7 @@ For earlier versions of the napari app, scroll below the latest release on the [
 
 ### Windows
 
-Download from GitHub: {{ '[napari-REL-Windows-x86_64.exe](https://github.com/napari/napari/releases/download/vREL/napari-REL-Windows-x86_64.exe)'.replace('REL', bundle_release) }}
+Download from GitHub: {{ '[napari-REL-Windows-x86_64.exe](https://github.com/napari/napari/releases/download/vREL/napari-REL-Windows-x86_64.exe)'.replace('REL', napari_version) }}
 
 Double-click the downloaded `.exe` file to begin setup.
 
@@ -338,8 +338,8 @@ Next, check out our [tutorial on the viewer](viewer-tutorial) or explore the [Us
 
 Download the installer for your Mac:
 
-- {{ '[napari-REL-macOS-arm64.pkg](https://github.com/napari/napari/releases/download/vREL/napari-REL-macOS-arm64.pkg)'.replace('REL', bundle_release) }} — Apple Silicon (ARM)
-- {{ '[napari-REL-macOS-x86_64.pkg](https://github.com/napari/napari/releases/download/vREL/napari-REL-macOS-x86_64.pkg)'.replace('REL', bundle_release) }} — Intel
+- {{ '[napari-REL-macOS-arm64.pkg](https://github.com/napari/napari/releases/download/vREL/napari-REL-macOS-arm64.pkg)'.replace('REL', napari_version) }} — Apple Silicon (ARM)
+- {{ '[napari-REL-macOS-x86_64.pkg](https://github.com/napari/napari/releases/download/vREL/napari-REL-macOS-x86_64.pkg)'.replace('REL', napari_version) }} — Intel
 
 Double-click the downloaded `.pkg` file to launch the Installer.
 
@@ -383,7 +383,7 @@ Next, check out our [tutorial on the viewer](viewer-tutorial) or explore the [Us
 
 ### Linux
 
-Download from GitHub: {{ '[napari-REL-Linux-x86_64.sh](https://github.com/napari/napari/releases/download/vREL/napari-REL-Linux-x86_64.sh)'.replace('REL', bundle_release) }}
+Download from GitHub: {{ '[napari-REL-Linux-x86_64.sh](https://github.com/napari/napari/releases/download/vREL/napari-REL-Linux-x86_64.sh)'.replace('REL', napari_version) }}
 
 Open a terminal, navigate to your downloads folder (`cd ~/Downloads`), and run:
 

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -336,7 +336,10 @@ Next, check out our [tutorial on the viewer](viewer-tutorial) or explore the [Us
 
 ### macOS
 
-Download the installer for your Mac:
+Download the installer for your Mac. If you are unsure which version to choose,
+check "About this Mac" from the Apple menu or check the
+[official Apple documentation](https://support.apple.com/en-us/116943)
+to identify if your machine is Apple Silicon (ARM).
 
 - {{ '[napari-REL-macOS-arm64.pkg](https://github.com/napari/napari/releases/download/vREL/napari-REL-macOS-arm64.pkg)'.replace('REL', bundle_version) }} — Apple Silicon (ARM)
 - {{ '[napari-REL-macOS-x86_64.pkg](https://github.com/napari/napari/releases/download/vREL/napari-REL-macOS-x86_64.pkg)'.replace('REL', bundle_version) }} — Intel

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -255,7 +255,7 @@ pip install napari[pyqt6, optional] -c constraints_py3.10.txt
 
 napari can be installed as a standalone application on macOS, Windows, and Linux — no Python knowledge required. This is the simplest way to get started and works best if you want to use napari as a standalone GUI app. Note that some plugins may not be available without a full Python environment.
 
-Select your platform below to download napari {{ release }} directly:
+Select your platform below to download napari {{ bundle_release }} directly:
 
 ````{grid} 1 2 2 4
 :gutter: 2
@@ -263,7 +263,7 @@ Select your platform below to download napari {{ release }} directly:
 ```{grid-item-card} Windows
 :text-align: center
 
-{{ '[Download (.exe)](https://github.com/napari/napari/releases/download/vREL/napari-REL-Windows-x86_64.exe)'.replace('REL', release) }}
+{{ '[Download (.exe)](https://github.com/napari/napari/releases/download/vREL/napari-REL-Windows-x86_64.exe)'.replace('REL', bundle_release) }}
 +++
 {ref}`Installation steps <windows-bundle>`
 ```
@@ -271,7 +271,7 @@ Select your platform below to download napari {{ release }} directly:
 ```{grid-item-card} macOS Apple Silicon (arm64)
 :text-align: center
 
-{{ '[Download (.pkg)](https://github.com/napari/napari/releases/download/vREL/napari-REL-macOS-arm64.pkg)'.replace('REL', release) }}
+{{ '[Download (.pkg)](https://github.com/napari/napari/releases/download/vREL/napari-REL-macOS-arm64.pkg)'.replace('REL', bundle_release) }}
 +++
 {ref}`Installation steps <macos-bundle>`
 ```
@@ -279,7 +279,7 @@ Select your platform below to download napari {{ release }} directly:
 ```{grid-item-card} macOS Intel (x86_64)
 :text-align: center
 
-{{ '[Download (.pkg)](https://github.com/napari/napari/releases/download/vREL/napari-REL-macOS-x86_64.pkg)'.replace('REL', release) }}
+{{ '[Download (.pkg)](https://github.com/napari/napari/releases/download/vREL/napari-REL-macOS-x86_64.pkg)'.replace('REL', bundle_release) }}
 +++
 {ref}`Installation steps <macos-bundle>`
 ```
@@ -287,7 +287,7 @@ Select your platform below to download napari {{ release }} directly:
 ```{grid-item-card} Linux
 :text-align: center
 
-{{ '[Download (.sh)](https://github.com/napari/napari/releases/download/vREL/napari-REL-Linux-x86_64.sh)'.replace('REL', release) }}
+{{ '[Download (.sh)](https://github.com/napari/napari/releases/download/vREL/napari-REL-Linux-x86_64.sh)'.replace('REL', bundle_release) }}
 +++
 {ref}`Installation steps <linux-bundle>`
 ```
@@ -300,7 +300,7 @@ For earlier versions of the napari app, scroll below the latest release on the [
 
 ### Windows
 
-Download from Github: {{ '[napari-REL-Windows-x86_64.exe](https://github.com/napari/napari/releases/download/vREL/napari-REL-Windows-x86_64.exe)'.replace('REL', release) }}
+Download from Github: {{ '[napari-REL-Windows-x86_64.exe](https://github.com/napari/napari/releases/download/vREL/napari-REL-Windows-x86_64.exe)'.replace('REL', bundle_release) }}
 
 Double-click the downloaded `.exe` file to begin setup.
 
@@ -338,8 +338,8 @@ Next, check out our [tutorial on the viewer](viewer-tutorial) or explore the [Us
 
 Download the installer for your Mac:
 
-- {{ '[napari-REL-macOS-arm64.pkg](https://github.com/napari/napari/releases/download/vREL/napari-REL-macOS-arm64.pkg)'.replace('REL', release) }} — Apple Silicon (M1 and later)
-- {{ '[napari-REL-macOS-x86_64.pkg](https://github.com/napari/napari/releases/download/vREL/napari-REL-macOS-x86_64.pkg)'.replace('REL', release) }} — Intel
+- {{ '[napari-REL-macOS-arm64.pkg](https://github.com/napari/napari/releases/download/vREL/napari-REL-macOS-arm64.pkg)'.replace('REL', bundle_release) }} — Apple Silicon (M1 and later)
+- {{ '[napari-REL-macOS-x86_64.pkg](https://github.com/napari/napari/releases/download/vREL/napari-REL-macOS-x86_64.pkg)'.replace('REL', bundle_release) }} — Intel
 
 Double-click the downloaded `.pkg` file to launch the Installer.
 
@@ -383,7 +383,7 @@ Next, check out our [tutorial on the viewer](viewer-tutorial) or explore the [Us
 
 ### Linux
 
-Download from Github: {{ '[napari-REL-Linux-x86_64.sh](https://github.com/napari/napari/releases/download/vREL/napari-REL-Linux-x86_64.sh)'.replace('REL', release) }}
+Download from Github: {{ '[napari-REL-Linux-x86_64.sh](https://github.com/napari/napari/releases/download/vREL/napari-REL-Linux-x86_64.sh)'.replace('REL', bundle_release) }}
 
 Open a terminal, navigate to your downloads folder (`cd ~/Downloads`), and run:
 


### PR DESCRIPTION
# References and relevant issues

Closes #969

# Description

Instead of just the raw release link, which can be broken for dev releases (i.e. `0.7.1dev#sha`) this changes  it so that
It will be the latest stable release.

To do this, I have it check whether the current ref is a prerelease, and if it is, then it checks `version_switcher.json` for the entry with "preferred" and returns it's "version". Thus both 0.7.1rc0 and 0.7.1dev+hash will point back to the preferred version (0.7.0). 

Then, when a new stable release is pushed, the ref is no longer a pre-release and will instead use the version string (which I think in all cases is X.Y.Z from how I read the code) so releasing 0.7.1 should use 0.7.1 for the links, despite the version_switcher not yet being updated.

I also slightly updated the Mac buttons and install section so that it cleared up uncertainty re: the intro-workshop download