### PR TITLE
Rename navbar entries (API and Contribute)

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,6 +1,6 @@
 (api)=
 
-# API Reference
+# API
 
 Information on specific functions, classes, and methods.
 

--- a/docs/developers/index.md
+++ b/docs/developers/index.md
@@ -1,6 +1,6 @@
 (contributing-index)=
 
-# Contributing
+# Contribute
 
 We welcome your contributions! Here you will find resources to help you contribute
 to napari.

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ theme:
       content: See what’s been updated in the latest releases
       url: /release/index.html
 
-    - title: API reference
+    - title: API
       content: Information on specific functions, classes, and methods
       url: /api/index.html
 


### PR DESCRIPTION
# References and relevant issues

napari/napari-sphinx-theme#200

# Description

Shortens the name from "API Reference" to "API" with the hopes that this was enough to prevent the wonky navbar, however, it was not enough so we would need to modify the max-width in napari-sphinx-theme (or remove napari-hub as a link). I think from a content perspective "Reference" is redundant as a navbar name because _all_ docs are reference material, so "API" (Reference) is implied.
It's _quickly grown on me and I quite like it actually_ Compare how "busy" the current navbar looks on napari.org
<img width="1992" height="570" alt="image" src="https://github.com/user-attachments/assets/4eb6187a-3816-4600-8f03-3a2eb543d6ac" />


Q: Should napari-hub be removed? We link to it in the plugins page, and could make that more prominent in the plugin page, or go _back_ to linking it more prominently on the homepage.

<img width="2231" height="1417" alt="image" src="https://github.com/user-attachments/assets/9ba39b58-f064-4af9-aba1-a797c61d6453" />

And just to show a different solution that is left aligned:
<img width="2245" height="613" alt="image" src="https://github.com/user-attachments/assets/b7f172e3-ac95-442f-925e-0bd2e90c1ec4" />
