### PR TITLE
Add "Edit on Github" to secondary sidebar

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -126,7 +126,8 @@ html_theme_options = {
     'show_version_warning_banner': True,
     'navbar_persistent': ['search-button'],
     'header_links_before_dropdown': 6,
-    'secondary_sidebar_items': ['page-toc'],
+    'use_edit_page_button': True,
+    'secondary_sidebar_items': ['page-toc', 'edit-this-page'],
     'pygments_light_style': 'napari',
     'pygments_dark_style': 'dracula',
     'announcement': '',
@@ -154,6 +155,11 @@ html_context = {
     # add release version to context
     'release': release,
     'version': version,
+    # GitHub info for "Edit on GitHub" links
+    'github_user': 'napari',
+    'github_repo': 'docs',
+    'github_version': 'main',
+    'doc_path': 'docs',
 }
 
 # intersphinx configuration for frequently used links to other projects

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -127,7 +127,7 @@ html_theme_options = {
     'navbar_persistent': ['search-button'],
     'header_links_before_dropdown': 6,
     'use_edit_page_button': True,
-    'secondary_sidebar_items': ['page-toc', 'edit-this-page', 'sourcelink'],
+    'secondary_sidebar_items': ['page-toc', 'edit-this-page'],
     'pygments_light_style': 'napari',
     'pygments_dark_style': 'dracula',
     'announcement': '',
@@ -160,6 +160,11 @@ html_context = {
     'github_repo': 'docs',
     'github_version': 'main',
     'doc_path': 'docs',
+    'edit_page_provider_name': 'GitHub',
+    'edit_page_url_template': (
+        '{{ github_url }}/{{ github_user }}/{{ github_repo }}'
+        '/blob/{{ github_version }}/{{ doc_path }}{{ file_name }}'
+    ),
 }
 
 # intersphinx configuration for frequently used links to other projects

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -127,7 +127,7 @@ html_theme_options = {
     'navbar_persistent': ['search-button'],
     'header_links_before_dropdown': 6,
     'use_edit_page_button': True,
-    'secondary_sidebar_items': ['page-toc', 'edit-this-page'],
+    'secondary_sidebar_items': ['page-toc', 'edit-this-page', 'sourcelink'],
     'pygments_light_style': 'napari',
     'pygments_dark_style': 'dracula',
     'announcement': '',


### PR DESCRIPTION
# References and relevant issues

xref https://github.com/napari/napari-sphinx-theme/pull/216

# Description

This adds an "Edit this Page" button to the secondary (right) sidebar on our docs. 
Minimal setup was done via here: https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/source-buttons.html

And `edit_page_url_template` points not to the `edit` URL but instead to `blob`. I noticed from pydantic sphinx theme that clicking through leads me to the "You need to fork this" and not a nice clean document. I think being met with the fork screen would be a WTF moment as a new contributor, so I'd prefer something more welcoming (and where you can actually see the code right away)

Also ran into #981 while developing

<img width="375" height="359" alt="image" src="https://github.com/user-attachments/assets/a06a6a3f-9578-49d5-9fc8-3abdc5a8fd95" />

