### PR TITLE
Add deprecation warning section in contributing guide

### DIFF
--- a/docs/developers/contributing/index.md
+++ b/docs/developers/contributing/index.md
@@ -145,6 +145,23 @@ the corresponding docstring to contain the `.. versionadded::` or
 Please also consider documenting any major features/changes in our
 [tutorials](tutorials) and other [usage documentation](usage).
 
+#### Deprecation Warnings
+
+When deprecating a feature, use `DeprecationWarning` instead of `FutureWarning`.
+`FutureWarning` is silenced by Python's default warning filters, making it invisible
+to library users. `DeprecationWarning` is the correct signal for developer-facing deprecations.
+
+**In the code**, always pass `stacklevel=2` to `warnings.warn()` so the warning
+points to the caller's location rather than inside napari's internals.
+
+**In the docstring**, use the `.. deprecated::` directive alongside any related
+`.. versionadded::` notes:
+
+```rst
+.. deprecated:: X.Y.Z
+   :func:`old_function` is deprecated. Use :func:`new_function` instead.
+```
+
 ### Tests
 
 We use unit tests, integration tests, and functional tests to ensure that

--- a/docs/developers/contributing/index.md
+++ b/docs/developers/contributing/index.md
@@ -154,7 +154,7 @@ to library users. `DeprecationWarning` is the correct signal for developer-facin
 **In the code**, always pass `stacklevel=2` to `warnings.warn()` so the warning
 points to the caller's location rather than inside napari's internals.
 
-**In the docstring**, use the `.. deprecated::` directive alongside any related
+In the docstring below the short summary, use the [`.. deprecated::` directive](https://numpydoc.readthedocs.io/en/latest/format.html#deprecation-warning) alongside any related
 `.. versionadded::` notes:
 
 ```rst


### PR DESCRIPTION
# References and relevant issues
Closes #983 
<!-- What relevant resources were used in the creation of this PR?
If this PR addresses an existing issue on the repo,
please link to that issue here as "Closes #(issue-number)".
If this PR adds docs for a napari PR please add a "Depends on <napari PR link>" -->

# Description
<!-- What does this pull request (PR) do? Does it add new content, improve/fix existing
context, improve/fix workflow/documentation build/deployment or something else?
<!-- If relevant, please include a screenshot or a screen capture in your content
change: "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations. -->
<!-- You can also see a preview of the documentation changes you are submitting by
clicking on "Details" to the right of the "Check the rendered docs here!" check on your PR.-->

<!-- Previewing the Documentation Build
When you submit this PR, jobs that preview the documentation will be kicked off.
By default, they will use the `slimfast` build (`make` target), which is fast, because
it doesn't build any content from outside the `docs` repository and doesn't run notebook cells.
You can trigger other builds by commenting on the PR with:

@napari-bot make <target>

where <target> can be:
html : a full build, just like the deployment to napari.org
html-noplot : a full build, but without the gallery examples from `napari/napari`
docs : only the content from `napari/docs`, with notebook code cells executed
slimfast : the default, only the content from `napari/docs`, without code cell execution
slimgallery : `slimfast`, but with the gallery examples from `napari/napari` built
-->

<!-- Final Checklist
- If images included: I have added [alt text](https://webaim.org/techniques/alttext/)
If workflow, documentation build or deployment change:
- My PR is the minimum possible work for the desired functionality
- I have commented my code, to let others know what it does
-->
@TimMonko please let me know if we need any improvements in this.
- I was facing issue, during building docs, haven't verified locally yet. I'll do verify if getting any doc- failure. Thankyou 😊 
