### PR TITLE
Enable search as you type and remove sidebar search

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -145,7 +145,7 @@ html_theme_options = {
 
 # sidebar content
 html_sidebars = {
-    '**': ['search-field.html', 'sidebar-nav-bs'],
+    '**': ['sidebar-nav-bs'],
     'index': [],
 }
 


### PR DESCRIPTION
# References and relevant issues

Closes #979

# Description

This removes the sidebar search to enable search-as-you-type functionality in the navbar search.
The functionality needs the newest release of napari-sphinx-theme so if you build locally make sure to use `pixi update`.
:grin:

I want to follow-this up to potentially improve the visual of the search bar