### PR TITLE
Remove napari-hub from navbar and add to sidebar

### DIFF
--- a/docs/_templates/sidebar-link-items.html
+++ b/docs/_templates/sidebar-link-items.html
@@ -19,6 +19,9 @@
             <li class="toctree-l1">
                 <a class="reference external" href="https://napari.org/island-dispatch">Blog</a>
             </li>
+            <li class="toctree-l1">
+                <a class="reference external" href="https://napari-hub.org">Plugin hub</a>
+            </li>
         </ul>
     </div>
 </nav>

--- a/docs/_templates/sidebar-nav-bs.html
+++ b/docs/_templates/sidebar-nav-bs.html
@@ -36,6 +36,9 @@
       <li class="toctree-l1">
           <a class="reference external" href="https://napari.org/island-dispatch">Blog</a>
       </li>
+      <li class="toctree-l1">
+          <a class="reference external" href="https://napari-hub.org">Plugin hub</a>
+      </li>
     </ul>
   </div>
 </nav>

--- a/docs/_templates/sidebar-nav-bs.html
+++ b/docs/_templates/sidebar-nav-bs.html
@@ -37,7 +37,7 @@
           <a class="reference external" href="https://napari.org/island-dispatch">Blog</a>
       </li>
       <li class="toctree-l1">
-          <a class="reference external" href="https://napari-hub.org">Plugin hub</a>
+          <a class="reference external" href="https://napari-hub.org">Discover plugins</a>
       </li>
     </ul>
   </div>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -114,9 +114,6 @@ favicons = [
 
 # napari sphinx theme options
 html_theme_options = {
-    'external_links': [
-        {'name': 'napari hub', 'url': 'https://napari-hub.org'},
-    ],
     'github_url': 'https://github.com/napari/napari',
     'navbar_start': ['navbar-logo', 'navbar-project'],
     'navbar_end': ['version-switcher', 'navbar-icon-links', 'theme-switcher'],

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -2,12 +2,6 @@
 
 # Plugins
 
-```{warning}
-In napari 0.7.0, legacy "npe1" plugins will only work by auto-conversion to the new plugin engine, `npe2`.
-The vast majority of plugins will continue working as before. If you notice any issues with a plugin, check out the
-[Changes to the plugin engine in 0.6.0](adapted-plugin-guide) document to see if this is affecting you.
-```
-
 Plugins extend napari's functionality, allowing for customization and sharing with the community.
 While you can use scripts and widgets to extend napari, plugins provide great flexibility.
 Existing plugins extend napari to add:
@@ -18,7 +12,7 @@ Existing plugins extend napari to add:
 
 Share and discover napari plugins on [napari hub](https://napari-hub.org),
 [PyPI](https://pypi.org/search/?q=napari), or [conda-forge](https://conda-forge.org/packages/).
-Interested in creating a plugin? A [napari-plugin-template](https://github.com/napari/napari-plugin-template),
+Interested in creating a plugin? [napari-plugin-template](https://github.com/napari/napari-plugin-template),
 a [copier](https://copier.readthedocs.io/en/stable/) template, bootstraps authoring
 [npe](https://github.com/napari/npe2)-based napari plugins.
 
@@ -96,3 +90,9 @@ Submit issues to the [napari github repository][napari_issues].
 
 [napari_issues]: https://github.com/napari/napari/issues/new/choose
 [napari_zulip]: https://napari.zulipchat.com/
+
+```{warning}
+In napari 0.7.0, legacy "npe1" plugins will only work by auto-conversion to the new plugin engine, `npe2`.
+The vast majority of plugins will continue working as before. If you notice any issues with a plugin, check out the
+[Changes to the plugin engine in 0.6.0](adapted-plugin-guide) document to see if this is affecting you.
+```


### PR DESCRIPTION
# References and relevant issues

Closes #988 
xref napari/napari-sphinx-theme#200

# Description

Removes the napari-hub link from the navbar, this _should_ finally keep our navbar from going wonky.
Adds the link to the persistent sidebar ... ~~should it be "Plugin hub" or "napari hub"? I went with the former just because its more self-descriptive for such a location~~ named "Discover plugins"

It moves down the npe1 admonition to the need help? section to highlight the plugin cards (including the hubs) in the index page (navigated to from the navbar).


