### PR TITLE
Update multiscale documentation to describe new level selection

### DIFF
--- a/docs/guides/rendering.md
+++ b/docs/guides/rendering.md
@@ -273,6 +273,10 @@ As a part of these calculations, {attr}`Layer.corner_pixels<napari.layers.Layer.
 This means that whenever the canvas' camera is panned or zoomed, napari fetches all the data needed to draw the current field of view.
 While this can work well with local data, it will be slow with remote or other high latency data.
 
+This automatic level selection can be overridden by setting {attr}`locked_data_level<napari.layers.Image.locked_data_level>` on the layer.
+When set, the layer always renders at that specific level and `corner_pixels` spans the full extent of that level, bypassing the automatic computation described above.
+Setting it back to `None` restores automatic behavior.
+
 ### Loading non-image data
 
 Other layer types, like {class}`Points<napari.layers.Points>` and {class}`Shapes<napari.layers.Shapes>`, have layer specific data structures.

--- a/docs/howtos/layers/image.md
+++ b/docs/howtos/layers/image.md
@@ -221,6 +221,30 @@ layer to specify if your data is a multiscale image or not. If you don't provide
 this value, then napari will try and guess whether your data is or needs to be a
 multiscale image.
 
+### Locking the multiscale level
+
+By default, napari automatically selects which resolution level to display based
+on the current zoom and viewport. In 2D this means zooming in loads
+higher-resolution data, while in 3D the coarsest level is used for performance.
+
+If you want to force a specific resolution level — for example, to keep a
+consistent view while panning or to inspect a particular level — you can set
+the `locked_data_level` property, or using the resolution dropdown in the layer controls:
+
+```python
+# Lock rendering to level 0 (highest resolution)
+layer.locked_data_level = 0
+
+# Restore automatic level selection
+layer.locked_data_level = None
+```
+
+When a level is locked, napari loads the full extent of that level on the currently
+displayed dimensions regardless of zoom or display mode. The lock is automatically 
+reset to `None` when the layer's data is replaced.
+
+This property is available on both `Image` and `Labels` layers.
+
 ## Loading multichannel images
 
 Each channel in a multichannel image can be displayed as an individual layer by

--- a/docs/howtos/layers/image.md
+++ b/docs/howtos/layers/image.md
@@ -214,7 +214,7 @@ multiscale image and the part of the image that needs to be displayed:
 This example had precomputed multiscale images stored in a `zarr` file, which is
 best for performance. If you don't have a precomputed multiscale image but try
 and show an exceptionally large image, napari will try and compute the
-multiscale image for you unless you tell it not to.
+best for performance.
 
 You can use the boolean `multiscale` keyword argument when creating an image
 layer to specify if your data is a multiscale image or not. If you don't provide


### PR DESCRIPTION
# References and relevant issues
depends on https://github.com/napari/napari/pull/8917

# Description
Update multiscale documentation to describe the functionality added in napari/napari#8917 - letting the user pick the scale level to render

<!-- Previewing the Documentation Build
When you submit this PR, jobs that preview the documentation will be kicked off.
By default, they will use the `slimfast` build (`make` target), which is fast, because
it doesn't build any content from outside the `docs` repository and doesn't run notebook cells.
You can trigger other builds by commenting on the PR with:

@napari-bot make <target>

where <target> can be:
html : a full build, just like the deployment to napari.org
html-noplot : a full build, but without the gallery examples from `napari/napari`
docs : only the content from `napari/docs`, with notebook code cells executed
slimfast : the default, only the content from `napari/docs`, without code cell execution
slimgallery : `slimfast`, but with the gallery examples from `napari/napari` built
-->

<!-- Final Checklist
- If images included: I have added [alt text](https://webaim.org/techniques/alttext/)
If workflow, documentation build or deployment change:
- My PR is the minimum possible work for the desired functionality
- I have commented my code, to let others know what it does
-->
