### PR TITLE
Minimal all-contributors setup

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,4 @@
+{
+  "projectName": "docs",
+  "projectOwner": "napari"
+}

--- a/README.md
+++ b/README.md
@@ -144,3 +144,14 @@ the bug report template. If you think something isn't working, don't hesitate to
   <source media="(prefers-color-scheme: dark)" srcset="https://chanzuckerberg.com/wp-content/themes/czi/img/logo-white.svg">
   <img alt="CZI logo" src="https://chanzuckerberg.com/wp-content/themes/czi/img/logo.svg">
 </picture>
+
+## contributors
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->


### PR DESCRIPTION
# Description

We recently discussed adding [All Contributors](https://allcontributors.org/) bot to the napari org.
I am starting with napari/docs because there are many contributors, but also because it is easier to iterate upon than starting with napari/napari.

I followed the bot setup directions here: https://allcontributors.org/en/bot/installation/

If we call the bot in a PR or Issue with natural language like `Yo @all-contributors please add our homeslice @timmonko for code and doc`, then it will open a PR to add the contributor to the README (or we can move to CONTRIBUTING.md but we have to start with README)

Here is a list of all the contribution types: https://allcontributors.org/en/emoji-key/

