### PR TITLE
Add Carlos to Core Team page

### DIFF
--- a/docs/community/team.md
+++ b/docs/community/team.md
@@ -17,7 +17,7 @@ napari is a consensus-based community project. Anyone with an interest in the pr
 - [Lorenzo Gaifas](https://github.com/napari/napari/commits?author=brisvag) - [@brisvag](https://github.com/brisvag)
 - [Melissa Weber Mendonça](https://github.com/napari/napari/commits?author=melissawm) - [@melissawm](https://github.com/melissawm)
 - [Peter Sobolewski](https://github.com/napari/napari/commits?author=psobolewskiPhD) - [@psobolewskiPhD](https://github.com/psobolewskiPhD)
-- [Tim Monko](https://github.com/napari/napari/commits?author:timmonko) - [@TimMonko](https://github.com/TimMonko)
+- [Tim Monko](https://github.com/napari/napari/commits?author=TimMonko) - [@TimMonko](https://github.com/TimMonko)
 - [Wouter-Michiel Vierdag](https://github.com/napari/napari/commits?author=melonora) - [@melonora](https://github.com/melonora)
 
 ## Emeritus Core Team Members
@@ -32,7 +32,7 @@ napari is a consensus-based community project. Anyone with an interest in the pr
 - [Nicholas Sofroniew](https://github.com/napari/napari/commits?author=sofroniewn) - [@sofroniewn](https://github.com/sofroniewn)
 - [Shannon Axelrod](https://github.com/napari/napari/commits?author=shanaxel42) - [@shanaxel42](https://github.com/shanaxel42)
 - [Talley Lambert](https://github.com/napari/napari/commits?author=tlambert03) - [@tlambert03](https://github.com/tlambert03)
-- [Ziyang Liu](https://github.com/napari/napari/commits?author=potating-potato) - [@potating-potato](https://github.com/potating-potato)
+- [Ziyang Liu](https://github.com/napari/napari/commits?author=liu-ziyang) - [@liu-ziyang](https://github.com/liu-ziyang)
 
 ## Current Steering Council Members
 

--- a/docs/community/team.md
+++ b/docs/community/team.md
@@ -5,6 +5,8 @@ napari is a consensus-based community project. Anyone with an interest in the pr
 ## Current Core Team Members
 
 - [Ashley Anderson](https://github.com/napari/napari/commits?author=aganders3) - [@aganders3](https://github.com/aganders3)
+- [Carlos M. Rodríguez-Reza](https://github.com/napari/napari/commits?author=carlosmariorr) - [@carlosmariorr](https://github.com/carlosmariorr)
+- [Carol Willing](https://github.com/napari/napari/commits?author=willingc) - [@willingc](https://github.com/willingc)
 - [Draga Doncila Pop](https://github.com/napari/napari/commits?author=DragaDoncila) - [@DragaDoncila](https://github.com/DragaDoncila)
 - [Grzegorz Bokota](https://github.com/napari/napari/commits?author=Czaki) - [@Czaki](https://github.com/Czaki)
 - [Jaime Rodríguez-Guerra](https://github.com/napari/napari/commits?author=jaimergp) - [@jaimergp](https://github.com/jaimergp)
@@ -17,7 +19,6 @@ napari is a consensus-based community project. Anyone with an interest in the pr
 - [Peter Sobolewski](https://github.com/napari/napari/commits?author=psobolewskiPhD) - [@psobolewskiPhD](https://github.com/psobolewskiPhD)
 - [Tim Monko](https://github.com/napari/napari/commits?author:timmonko) - [@TimMonko](https://github.com/TimMonko)
 - [Wouter-Michiel Vierdag](https://github.com/napari/napari/commits?author=melonora) - [@melonora](https://github.com/melonora)
-- [Carol Willing](https://github.com/napari/napari/commits?author=willingc) - [@willingc](https://github.com/willingc)
 
 ## Emeritus Core Team Members
 


### PR DESCRIPTION
# Description

Add new core team member, @carlosmariorr, to the core team page!!!!!! 🥳🤩

Again still working on the permissions bit, but Carlos please feel free to approve, and then merge when you can!

I also updated Ziyang Liu's handle to correctly point to their current Github handle, found here: https://github.com/chanzuckerberg/napari-demo/releases