### PR TITLE
Update circle ci workflow with PyQt6 and `docs` dependency group

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
           name: Install napari-dev
           command: |
             . .venv/bin/activate
-            uv pip install -e "napari/[pyqt5,docs]"
+            uv pip install -e "napari/[pyqt6]" --group docs
           environment:
             UV_CONSTRAINT: napari/resources/constraints/constraints_py3.12_docs.txt
       - run:

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install "napari/[pyqt5, docs]"
+          python -m pip install "napari/[pyqt5]" --group docs
         env:
           PIP_CONSTRAINT: ${{ github.workspace }}/napari/resources/constraints/constraints_py3.10_docs.txt
 


### PR DESCRIPTION
# References and relevant issues

napari/napari#8704

# Description

1. Uses `docs` PEP735 dependency group for Circle CI config
2. Uses pyqt6 instead of pyqt5 for docs build, to bring in line with the napari workflows