### PR TITLE
Add Curtis and Brian to SC members

### DIFF
--- a/docs/community/team.md
+++ b/docs/community/team.md
@@ -35,6 +35,7 @@ napari is a consensus-based community project. Anyone with an interest in the pr
 - [Ziyang Liu](https://github.com/napari/napari/commits?author=liu-ziyang) - [@liu-ziyang](https://github.com/liu-ziyang)
 
 ## Current Steering Council Members
+
 - [Brian Northan](https://github.com/napari/napari/commits?author=bnorthan) - [@bnorthan](https://github.com/bnorthan)
 - [Curtis Rueden](https://github.com/napari/napari/commits?author=ctrueden) - [@ctrueden](https://github.com/ctrueden)
 - [Draga Doncila Pop](https://github.com/napari/napari/commits?author=DragaDoncila) - [@DragaDoncila](https://github.com/DragaDoncila)

--- a/docs/community/team.md
+++ b/docs/community/team.md
@@ -35,7 +35,8 @@ napari is a consensus-based community project. Anyone with an interest in the pr
 - [Ziyang Liu](https://github.com/napari/napari/commits?author=liu-ziyang) - [@liu-ziyang](https://github.com/liu-ziyang)
 
 ## Current Steering Council Members
-
+- [Brian Northan](https://github.com/napari/napari/commits?author=bnorthan) - [@bnorthan](https://github.com/bnorthan)
+- [Curtis Rueden](https://github.com/napari/napari/commits?author=ctrueden) - [@ctrueden](https://github.com/ctrueden)
 - [Draga Doncila Pop](https://github.com/napari/napari/commits?author=DragaDoncila) - [@DragaDoncila](https://github.com/DragaDoncila)
 - [Juan Nunez-Iglesias](https://github.com/napari/napari/commits?author=jni) - [@jni](https://github.com/jni)
 - [Kyle Harrington](https://github.com/napari/napari/commits?author=kephale) - [@kephale](https://github.com/kephale)


### PR DESCRIPTION
# Description

We welcome Brian Northan (@bnorthan) and Curtis Rueden (@ctrueden) to the napari Steering Council!
We look forward to their leadership 🤩

Names have been added alphabetically by first name.