### PR TITLE
Add Windows bundle signing and reputation info

### DIFF
--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -308,16 +308,14 @@ Double-click the downloaded `.exe` file to begin setup.
 
 ```{admonition} Windows Security Warning
 :class: important
-The napari Windows installer is code-signed, but newly released installers can
-still trigger a Microsoft Defender SmartScreen warning until they build enough
-reputation. This usually improves over time, but individual releases may need
-to build reputation separately.
+The napari Windows installer is code-signed. Microsoft Defender SmartScreen 
+may trigger a warning when a new app version is newly released until the cooling
+period ends.
 
 If Windows shows a warning for an installer downloaded from the official
 napari GitHub releases page, click **More info** and confirm that the publisher
-is **NumFOCUS, Inc.** before choosing **Run anyway**. On managed work
-computers, your IT or security software may still block the installer until the
-signed publisher is explicitly allowed.
+is **NumFOCUS, Inc.** before choosing **Run anyway**. If you continue
+seeing the warning on managed devices, contact your IT department.
 ```
 
 ![Montage of the napari EXE installer icon with an arrow pointing to the Welcome page of the napari EXE installer on Windows.](../_static/images/bundle_17.png)

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -304,6 +304,20 @@ Each release (0.4.15 and above) includes installers for all platforms under the 
 
 Download from GitHub: {{ '[napari-REL-Windows-x86_64.exe](https://github.com/napari/napari/releases/download/vREL/napari-REL-Windows-x86_64.exe)'.replace('REL', bundle_version) }}
 
+```{admonition} Windows Security Warning
+:class: important
+The napari Windows installer is code-signed, but newly released installers can
+still trigger a Microsoft Defender SmartScreen warning until they build enough
+reputation. This usually improves over time, but individual releases may need
+to build reputation separately.
+
+If Windows shows a warning for an installer downloaded from the official
+napari GitHub releases page, click **More info** and confirm that the publisher
+is **NumFOCUS, Inc.** before choosing **Run anyway**. On managed work
+computers, your IT or security software may still block the installer until the
+signed publisher is explicitly allowed.
+```
+
 Double-click the downloaded `.exe` file to begin setup.
 
 ![Montage of the napari EXE installer icon with an arrow pointing to the Welcome page of the napari EXE installer on Windows.](../_static/images/bundle_17.png)

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -304,6 +304,8 @@ Each release (0.4.15 and above) includes installers for all platforms under the 
 
 Download from GitHub: {{ '[napari-REL-Windows-x86_64.exe](https://github.com/napari/napari/releases/download/vREL/napari-REL-Windows-x86_64.exe)'.replace('REL', bundle_version) }}
 
+Double-click the downloaded `.exe` file to begin setup.
+
 ```{admonition} Windows Security Warning
 :class: important
 The napari Windows installer is code-signed, but newly released installers can
@@ -317,8 +319,6 @@ is **NumFOCUS, Inc.** before choosing **Run anyway**. On managed work
 computers, your IT or security software may still block the installer until the
 signed publisher is explicitly allowed.
 ```
-
-Double-click the downloaded `.exe` file to begin setup.
 
 ![Montage of the napari EXE installer icon with an arrow pointing to the Welcome page of the napari EXE installer on Windows.](../_static/images/bundle_17.png)
 


### PR DESCRIPTION
# References and relevant issues

Closes napari/docs#1016
Follow up to napari/packaging#387

# Description

Adds admonition just after the Windows bundle download links notifying folks that the bundle is signed, but that there is a Windows reputation system.
I tried to add something about IT-managed systems, but since I've never been in that situation I'm not aware of how it all works.

