### PR TITLE
Clean up button css for homepage and gallery

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,7 +1,7 @@
 /* ── Buttons for homepage and gallery ───────────────────────────────────── */
 
-.homepage-button,
-.homepage-example-button,
+.button-primary,
+.button-alt,
 div.sphx-glr-download a {
   background-image: none !important;
   border-radius: 4px;
@@ -10,7 +10,7 @@ div.sphx-glr-download a {
 }
 
 /* makes homepage button take up width of column */
-.homepage-button {
+.button-primary {
   display: block;
 }
 
@@ -39,52 +39,52 @@ div.sphx-glr-download a code.download {
   margin: 0;
 }
 
-html[data-theme="light"] .homepage-button,
+html[data-theme="light"] .button-primary,
 html[data-theme="light"] div.sphx-glr-download a {
   background-color: var(--napari-primary-blue) !important;
   border-color: var(--napari-primary-blue) !important;
   color: var(--napari-color-text-base) !important;
 }
 
-html[data-theme="dark"] .homepage-button,
+html[data-theme="dark"] .button-primary,
 html[data-theme="dark"] div.sphx-glr-download a {
   background-color: var(--napari-purple) !important;
   border-color: var(--napari-purple) !important;
   color: var(--napari-color-text-base) !important;
 }
 
-html[data-theme="light"] .homepage-button:hover,
+html[data-theme="light"] .button-primary:hover,
 html[data-theme="light"] div.sphx-glr-download a:hover {
   background-color: color-mix(in srgb, var(--napari-primary-blue), transparent 25%) !important;
   text-decoration: underline;
 }
 
-html[data-theme="dark"] .homepage-button:hover,
+html[data-theme="dark"] .button-primary:hover,
 html[data-theme="dark"] div.sphx-glr-download a:hover {
   background-color: color-mix(in srgb, var(--napari-purple), transparent 25%) !important;
   text-decoration: underline;
 }
 
-html[data-theme="light"] .homepage-example-button {
+html[data-theme="light"] .button-alt {
   background-color: var(--pst-color-background) !important;
   border-color: var(--napari-primary-blue) !important;
   color: var(--napari-color-text-base) !important;
 }
 
-html[data-theme="dark"] .homepage-example-button {
+html[data-theme="dark"] .button-alt {
   background-color: var(--pst-color-background) !important;
   border-color: var(--napari-purple) !important;
   color: var(--napari-color-text-base) !important;
 }
 
-html[data-theme="light"] .homepage-example-button:hover {
+html[data-theme="light"] .button-alt:hover {
   background-color: var(--pst-color-background) !important;
   border-color: var(--napari-primary-blue) !important;
   color: var(--napari-color-text-base) !important;
   text-decoration: underline;
 }
 
-html[data-theme="dark"] .homepage-example-button:hover {
+html[data-theme="dark"] .button-alt:hover {
   background-color: var(--pst-color-background) !important;
   border-color: var(--napari-purple) !important;
   color: var(--napari-color-text-base) !important;

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,7 +1,7 @@
 /* ── Buttons for homepage and gallery ───────────────────────────────────── */
 
 .homepage-button,
-.napari-gallery-downloads .sphx-glr-download a {
+div.sphx-glr-download a {
   background-image: none !important;
   border-radius: 4px;
   text-align: center;
@@ -9,28 +9,61 @@
 }
 
 html[data-theme="light"] .homepage-button,
-html[data-theme="light"] .napari-gallery-downloads .sphx-glr-download a {
+html[data-theme="light"] div.sphx-glr-download a {
   background-color: var(--napari-primary-blue) !important;
   border-color: var(--napari-primary-blue) !important;
   color: var(--napari-color-text-base) !important;
 }
 
 html[data-theme="dark"] .homepage-button,
-html[data-theme="dark"] .napari-gallery-downloads .sphx-glr-download a {
+html[data-theme="dark"] div.sphx-glr-download a {
   background-color: var(--napari-purple) !important;
   border-color: var(--napari-purple) !important;
   color: var(--napari-color-text-base) !important;
 }
 
 html[data-theme="light"] .homepage-button:hover,
-html[data-theme="light"] .napari-gallery-downloads .sphx-glr-download a:hover {
+html[data-theme="light"] div.sphx-glr-download a:hover {
   background-color: color-mix(in srgb, var(--napari-primary-blue), transparent 25%) !important;
   text-decoration: underline;
 }
 
 html[data-theme="dark"] .homepage-button:hover,
-html[data-theme="dark"] .napari-gallery-downloads .sphx-glr-download a:hover {
+html[data-theme="dark"] div.sphx-glr-download a:hover {
   background-color: color-mix(in srgb, var(--napari-purple), transparent 25%) !important;
+  text-decoration: underline;
+}
+
+
+.homepage-example-button {
+  border-radius: 4px;
+  text-align: center;
+  text-decoration: none;
+}
+
+html[data-theme="light"] .homepage-example-button {
+  background-color: var(--pst-color-background) !important;
+  border-color: var(--napari-primary-blue) !important;
+  color: var(--napari-color-text-base) !important;
+}
+
+html[data-theme="dark"] .homepage-example-button {
+  background-color: var(--pst-color-background) !important;
+  border-color: var(--napari-purple) !important;
+  color: var(--napari-color-text-base) !important;
+}
+
+html[data-theme="light"] .homepage-example-button:hover {
+  background-color: var(--pst-color-background) !important;
+  border-color: var(--napari-primary-blue) !important;
+  color: var(--napari-color-text-base) !important;
+  text-decoration: underline;
+}
+
+html[data-theme="dark"] .homepage-example-button:hover {
+  background-color: var(--pst-color-background) !important;
+  border-color: var(--napari-purple) !important;
+  color: var(--napari-color-text-base) !important;
   text-decoration: underline;
 }
 
@@ -40,14 +73,14 @@ html[data-theme="dark"] .napari-gallery-downloads .sphx-glr-download a:hover {
 }
 
 /* Allow border override to show through on example buttons */
-.napari-gallery-downloads .sphx-glr-download a {
+div.sphx-glr-download a {
   border: 1px solid transparent;
   display: inline-block;
   padding: 0.45rem 0.8rem;
 }
 
 /* force sphinx-gallery download code to inherit text color */
-.napari-gallery-downloads .sphx-glr-download a code.download {
+div.sphx-glr-download a code.download {
   color: inherit !important;
 }
 
@@ -63,6 +96,14 @@ html[data-theme="dark"] .napari-gallery-downloads .sphx-glr-download a:hover {
 .napari-gallery-downloads .sphx-glr-download {
   margin: 0;
 }
+
+/* Remove the sphinx-gallery downloads note and footer buttons. */
+/* .sphx-glr-download-link-note,
+.sphx-glr-download-jupyter,
+.sphx-glr-download-python,
+.sphx-glr-download-zip {
+  display: none;
+} */
 
 /* Version warning banner color */
 #bd-header-version-warning {

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -64,14 +64,6 @@ html[data-theme="dark"] .napari-gallery-downloads .sphx-glr-download a:hover {
   margin: 0;
 }
 
-/* Remove the sphinx-gallery downloads note and buttons */
-.sphx-glr-download-link-note,
-.sphx-glr-download-jupyter,
-.sphx-glr-download-python,
-.sphx-glr-download-zip {
-  display: none;
-}
-
 /* Version warning banner color */
 #bd-header-version-warning {
   background-color: color-mix(in srgb, var(--pst-color-secondary-bg), transparent 30%);

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,47 +1,74 @@
-/*
-Sphinx-Gallery has compatible CSS to fix default sphinx themes
-Tested for Sphinx 1.3.1 for all themes: default, alabaster, sphinxdoc,
-scrolls, agogo, traditional, nature, haiku, pyramid
-Tested for Read the Docs theme 0.1.7 */
+/* ── Homepage accent cards ───────────────────────────────────────────
+   Install, Download cards with theme-aware napari blue.
+   sphinx-design marks every property !important, so we must too.     */
 
-html[data-theme="light"] div.sphx-glr-download a {
-  background-color: rgb(255, 255, 255) !important;
-  background-image: linear-gradient(to bottom, rgb(255, 255, 255), #ffffff) !important;
+.homepage-button {
+  display: block;
+}
+
+/* Reuse the homepage CTA skin for gallery download buttons. */
+
+.homepage-button,
+.napari-gallery-downloads .sphx-glr-download a {
+  background-image: none !important;
   border-radius: 4px;
-  border: 1px solid #ffffff !important;
-  color: #000;
-  display: inline-block;
   font-weight: bold;
-  padding: 1ex;
   text-align: center;
-}
-
-html[data-theme="light"] div.sphx-glr-download a:hover {
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1),
-    0 1px 5px rgba(0, 0, 0, 0.25);
   text-decoration: none;
-  background-image: none;
-  background-color: #ffffff !important;
 }
 
-html[data-theme="dark"] div.sphx-glr-download a {
-  background-color: #222832 !important;
-  background-image: linear-gradient(to bottom, #222832, #222832) !important;
-  border-radius: 4px;
-  border: 1px solid #222832 !important;
-  color: #000;
+.napari-gallery-downloads .sphx-glr-download a {
+  border: 1px solid transparent;
   display: inline-block;
-  font-weight: bold;
-  padding: 1ex;
-  text-align: center;
+  padding: 0.45rem 0.8rem;
 }
 
-html[data-theme="dark"] div.sphx-glr-download a:hover {
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1),
-    0 1px 5px rgba(0, 0, 0, 0.25);
-  text-decoration: none;
-  background-image: none;
-  background-color: #222832 !important;
+html[data-theme="light"] .homepage-button,
+html[data-theme="light"] .napari-gallery-downloads .sphx-glr-download a {
+  background-color: var(--napari-primary-blue) !important;
+  border-color: var(--napari-primary-blue) !important;
+  color: var(--napari-color-text-base) !important;
+}
+
+html[data-theme="dark"] .homepage-button,
+html[data-theme="dark"] .napari-gallery-downloads .sphx-glr-download a {
+  background-color: var(--napari-purple) !important;
+  border-color: var(--napari-purple) !important;
+  color: var(--napari-color-text-base) !important;
+}
+
+html[data-theme="light"] .homepage-button:hover,
+html[data-theme="light"] .napari-gallery-downloads .sphx-glr-download a:hover {
+  background-color: color-mix(in srgb, var(--napari-primary-blue), transparent 25%) !important;
+  text-decoration: underline;
+}
+
+html[data-theme="dark"] .homepage-button:hover,
+html[data-theme="dark"] .napari-gallery-downloads .sphx-glr-download a:hover {
+  background-color: color-mix(in srgb, var(--napari-purple), transparent 25%) !important;
+  text-decoration: underline;
+}
+
+.napari-gallery-downloads .sphx-glr-download a:hover {
+  box-shadow: none;
+}
+
+.napari-gallery-downloads {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+  margin: 0 0 0.5rem;
+}
+
+.napari-gallery-downloads .sphx-glr-download {
+  margin: 0;
+}
+
+.sphx-glr-download-link-note,
+.sphx-glr-download-jupyter,
+.sphx-glr-download-python,
+.sphx-glr-download-zip {
+  display: none;
 }
 
 /* Version warning banner color */
@@ -63,35 +90,6 @@ html[data-theme="dark"] div.sphx-glr-download a:hover {
   font-weight: 700;
 }
 
-/* ── Homepage accent cards ───────────────────────────────────────────
-   Install, Download cards with theme-aware napari blue.
-   sphinx-design marks every property !important, so we must too.     */
-
-.homepage-button {
-  display: block;
-}
-
-html[data-theme="light"] .homepage-button {
-  background-color: var(--napari-primary-blue) !important;
-  border-color: var(--napari-primary-blue) !important;
-  color: var(--napari-color-text-base) !important;
-}
-
-html[data-theme="dark"] .homepage-button {
-  background-color: var(--napari-purple) !important;
-  border-color: var(--napari-purple) !important;
-  color: var(--napari-color-text-base) !important;
-}
-
-html[data-theme="light"] .homepage-button:hover {
-  text-decoration: underline;
-  background-color: color-mix(in srgb, var(--napari-primary-blue), transparent 25%) !important;
-}
-
-html[data-theme="dark"] .homepage-button:hover {
-  text-decoration: underline;
-  background-color: color-mix(in srgb, var(--napari-purple), transparent 25%) !important;
-}
 
 /* ── Homepage quicklinks (icon columns) ──────────────────────────────── */
 
@@ -222,9 +220,4 @@ html[data-theme="dark"] .homepage-quicklinks a {
 
 html[data-theme="dark"] img#homepage-featured-example-image {
   background-color: var(--pst-color-background) !important;
-}
-
-.homepage-example-button:hover {
-  background-color: var(--pst-color-background) !important;
-  color: var(--napari-color-text-base) !important;
 }

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,26 +1,11 @@
-/* ── Homepage accent cards ───────────────────────────────────────────
-   Install, Download cards with theme-aware napari blue.
-   sphinx-design marks every property !important, so we must too.     */
-
-.homepage-button {
-  display: block;
-}
-
-/* Reuse the homepage CTA skin for gallery download buttons. */
+/* ── Buttons for homepage and gallery ───────────────────────────────────── */
 
 .homepage-button,
 .napari-gallery-downloads .sphx-glr-download a {
   background-image: none !important;
   border-radius: 4px;
-  font-weight: bold;
   text-align: center;
   text-decoration: none;
-}
-
-.napari-gallery-downloads .sphx-glr-download a {
-  border: 1px solid transparent;
-  display: inline-block;
-  padding: 0.45rem 0.8rem;
 }
 
 html[data-theme="light"] .homepage-button,
@@ -49,21 +34,37 @@ html[data-theme="dark"] .napari-gallery-downloads .sphx-glr-download a:hover {
   text-decoration: underline;
 }
 
-.napari-gallery-downloads .sphx-glr-download a:hover {
-  box-shadow: none;
+/* makes homepage button take up width of column */
+.homepage-button {
+  display: block;
 }
 
+/* Allow border override to show through on example buttons */
+.napari-gallery-downloads .sphx-glr-download a {
+  border: 1px solid transparent;
+  display: inline-block;
+  padding: 0.45rem 0.8rem;
+}
+
+/* force sphinx-gallery download code to inherit text color */
+.napari-gallery-downloads .sphx-glr-download a code.download {
+  color: inherit !important;
+}
+
+/* horizontally align and reduce lower margin of container */
 .napari-gallery-downloads {
   display: flex;
   flex-wrap: wrap;
   gap: 0.375rem;
-  margin: 0 0 0.5rem;
+  margin: 0 0 0.35rem;
 }
 
+/* remove spacing around download buttons */
 .napari-gallery-downloads .sphx-glr-download {
   margin: 0;
 }
 
+/* Remove the sphinx-gallery downloads note and buttons */
 .sphx-glr-download-link-note,
 .sphx-glr-download-jupyter,
 .sphx-glr-download-python,
@@ -89,7 +90,6 @@ html[data-theme="dark"] .napari-gallery-downloads .sphx-glr-download a:hover {
   color: var(--napari-color-text-base);
   font-weight: 700;
 }
-
 
 /* ── Homepage quicklinks (icon columns) ──────────────────────────────── */
 

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,70 +1,12 @@
 /* ── Buttons for homepage and gallery ───────────────────────────────────── */
 
 .homepage-button,
+.homepage-example-button,
 div.sphx-glr-download a {
   background-image: none !important;
   border-radius: 4px;
   text-align: center;
   text-decoration: none;
-}
-
-html[data-theme="light"] .homepage-button,
-html[data-theme="light"] div.sphx-glr-download a {
-  background-color: var(--napari-primary-blue) !important;
-  border-color: var(--napari-primary-blue) !important;
-  color: var(--napari-color-text-base) !important;
-}
-
-html[data-theme="dark"] .homepage-button,
-html[data-theme="dark"] div.sphx-glr-download a {
-  background-color: var(--napari-purple) !important;
-  border-color: var(--napari-purple) !important;
-  color: var(--napari-color-text-base) !important;
-}
-
-html[data-theme="light"] .homepage-button:hover,
-html[data-theme="light"] div.sphx-glr-download a:hover {
-  background-color: color-mix(in srgb, var(--napari-primary-blue), transparent 25%) !important;
-  text-decoration: underline;
-}
-
-html[data-theme="dark"] .homepage-button:hover,
-html[data-theme="dark"] div.sphx-glr-download a:hover {
-  background-color: color-mix(in srgb, var(--napari-purple), transparent 25%) !important;
-  text-decoration: underline;
-}
-
-
-.homepage-example-button {
-  border-radius: 4px;
-  text-align: center;
-  text-decoration: none;
-}
-
-html[data-theme="light"] .homepage-example-button {
-  background-color: var(--pst-color-background) !important;
-  border-color: var(--napari-primary-blue) !important;
-  color: var(--napari-color-text-base) !important;
-}
-
-html[data-theme="dark"] .homepage-example-button {
-  background-color: var(--pst-color-background) !important;
-  border-color: var(--napari-purple) !important;
-  color: var(--napari-color-text-base) !important;
-}
-
-html[data-theme="light"] .homepage-example-button:hover {
-  background-color: var(--pst-color-background) !important;
-  border-color: var(--napari-primary-blue) !important;
-  color: var(--napari-color-text-base) !important;
-  text-decoration: underline;
-}
-
-html[data-theme="dark"] .homepage-example-button:hover {
-  background-color: var(--pst-color-background) !important;
-  border-color: var(--napari-purple) !important;
-  color: var(--napari-color-text-base) !important;
-  text-decoration: underline;
 }
 
 /* makes homepage button take up width of column */
@@ -97,13 +39,57 @@ div.sphx-glr-download a code.download {
   margin: 0;
 }
 
-/* Remove the sphinx-gallery downloads note and footer buttons. */
-/* .sphx-glr-download-link-note,
-.sphx-glr-download-jupyter,
-.sphx-glr-download-python,
-.sphx-glr-download-zip {
-  display: none;
-} */
+html[data-theme="light"] .homepage-button,
+html[data-theme="light"] div.sphx-glr-download a {
+  background-color: var(--napari-primary-blue) !important;
+  border-color: var(--napari-primary-blue) !important;
+  color: var(--napari-color-text-base) !important;
+}
+
+html[data-theme="dark"] .homepage-button,
+html[data-theme="dark"] div.sphx-glr-download a {
+  background-color: var(--napari-purple) !important;
+  border-color: var(--napari-purple) !important;
+  color: var(--napari-color-text-base) !important;
+}
+
+html[data-theme="light"] .homepage-button:hover,
+html[data-theme="light"] div.sphx-glr-download a:hover {
+  background-color: color-mix(in srgb, var(--napari-primary-blue), transparent 25%) !important;
+  text-decoration: underline;
+}
+
+html[data-theme="dark"] .homepage-button:hover,
+html[data-theme="dark"] div.sphx-glr-download a:hover {
+  background-color: color-mix(in srgb, var(--napari-purple), transparent 25%) !important;
+  text-decoration: underline;
+}
+
+html[data-theme="light"] .homepage-example-button {
+  background-color: var(--pst-color-background) !important;
+  border-color: var(--napari-primary-blue) !important;
+  color: var(--napari-color-text-base) !important;
+}
+
+html[data-theme="dark"] .homepage-example-button {
+  background-color: var(--pst-color-background) !important;
+  border-color: var(--napari-purple) !important;
+  color: var(--napari-color-text-base) !important;
+}
+
+html[data-theme="light"] .homepage-example-button:hover {
+  background-color: var(--pst-color-background) !important;
+  border-color: var(--napari-primary-blue) !important;
+  color: var(--napari-color-text-base) !important;
+  text-decoration: underline;
+}
+
+html[data-theme="dark"] .homepage-example-button:hover {
+  background-color: var(--pst-color-background) !important;
+  border-color: var(--napari-purple) !important;
+  color: var(--napari-color-text-base) !important;
+  text-decoration: underline;
+}
 
 /* Version warning banner color */
 #bd-header-version-warning {

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,7 +64,7 @@ theme:
 :color: primary
 :ref-type: myst
 :shadow:
-:class: homepage-button
+:class: button-primary
 
 {material-regular}`arrow_forward;1.2em` **Get started**
 ```
@@ -133,8 +133,8 @@ A standalone installer for when you want napari without setting up Python first.
       Display an image in napari and explore the viewer with a minimal example.
     </p>
     <div class="homepage-featured-example__actions">
-      <a class="sd-btn sd-btn-primary sd-shadow-sm homepage-button" href="gallery.html">Examples gallery</a>
-      <button class="sd-btn sd-btn-outline-primary sd-shadow-sm homepage-example-button" id="homepage-featured-example-reroll" type="button">Show another example</button>
+      <a class="sd-btn sd-btn-primary sd-shadow-sm button-primary" href="gallery.html">Examples gallery</a>
+      <button class="sd-btn sd-btn-outline-primary sd-shadow-sm button-alt" id="homepage-featured-example-reroll" type="button">Show another example</button>
     </div>
   </div>
   <a class="homepage-featured-example__media" href="gallery/add_image.html" aria-label="View the featured napari example">


### PR DESCRIPTION
# Description

In working on #1021, this work was made more difficult by our messy css.
This PR cleans up the class names and combines the css.
It also sets up for #1021 (and #1024) to reduce the review diff.

This improves the css for the gallery buttons by actually override text and outline, instead of the almost invisible buttons of before

Note that before we did *not* style the "alt" homepage button and it was just inheriting from pydata-sphinx-theme. This PR explicitly styles the button to vaguely match what was before, but with a shared outline and text color to not be so intense. This is what I had originally intended for the homepage but got quite
confused by the css. 

I added lots of comments as I debugged along what each was for. :)

<img width="451" height="153" alt="image" src="https://github.com/user-attachments/assets/b3d92c37-864b-44e9-9f00-0a3007e16740" />

<img width="439" height="100" alt="image" src="https://github.com/user-attachments/assets/1be6de87-7d4b-4d40-a321-f3d5da51611d" />


<img width="715" height="238" alt="image" src="https://github.com/user-attachments/assets/13e44ee4-f8cf-4975-804c-ba9572348c41" />

<img width="634" height="214" alt="image" src="https://github.com/user-attachments/assets/07ac92f8-3e6b-4172-8295-0e841392402a" />

Main: 

<img width="441" height="150" alt="image" src="https://github.com/user-attachments/assets/1dbeadf6-fcca-4c45-88ba-806a758ed9df" />

<img width="552" height="231" alt="image" src="https://github.com/user-attachments/assets/221e14b5-e652-4229-b390-c676d2047414" />

<img width="502" height="205" alt="image" src="https://github.com/user-attachments/assets/016c9192-e866-4902-b2cc-49edcb7acfe4" />


