### PR TITLE
Add `--override-channels` flag to the `conda install` commands. 

### DIFF
--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -87,7 +87,7 @@ conda-forge channel. We also recommend this path for users of arm64 macOS machin
 ([Apple Silicon](https://support.apple.com/en-us/116943), meaning a processor with a name like "M1"). You can install it with:
 
 ```sh
-conda install -c conda-forge napari pyqt6
+conda install -c conda-forge napari pyqt6 --override-channels
 ```
 
 You can then upgrade to a new version of napari using:
@@ -99,7 +99,7 @@ conda update napari
 If you want to install napari with PySide6 as the backend you need to install it using
 
 ```sh
-conda install -c conda-forge napari pyside6
+conda install -c conda-forge napari pyside6 --override-channels
 ```
 
 ````{note}


### PR DESCRIPTION
# References and relevant issues
builds on #1023

# Description
This adds the flag `--override-channels` to the `conda install` commands since installing from an anaconda distribution might result in a different `PyQt` version due to priorities to the default channel. 

# Edit:
 This was incorrect, the priorities are working as expected. PyQt is not the culprit. installing python without `-c conda-forge` was the culprit. Installing this from conda-forge is already addressed in the docs so this PR is unnecessary. 
