### PR TITLE
Document automatic Wayland/Nvidia workaround in troubleshooting

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -36,7 +36,7 @@ menu or you're trying to save layers and can't find the plugin in the listed wri
 plugin using the deprecated `npe1` engine.
 
 You can check if this is the problem by installing `napari<=0.6.6` and turning off the `Use npe2 adaptor` setting
- under `Preferences -> Plugins -> Use npe2 adaptor` and restarting napari.
+under `Preferences -> Plugins -> Use npe2 adaptor` and restarting napari.
 If this fixes your issue, you'll need reach out to the plugin developer to update their plugin in order to use it
 with `napari>=0.7.0`.
 
@@ -99,11 +99,13 @@ If you meet an exception starting from `RuntimeError: Mix of local and non local
    In some rare situations this solution may not fix the environment,
    so you may need to recreate, as described in the first option.
 
+(wayland-and-nvidia)=
 
 ### Running napari on Wayland with Nvidia cards
 
-The Nvidia driver is not yet fully ready for Wayland. 
-We found that on computers with Nvidia cards and a wayland-based desktop environment, napari fails to start with errors such as this:
+The Nvidia driver is not yet fully ready for Wayland.
+We found that on computers with Nvidia cards and a Wayland-based desktop environment, napari may fail to start with errors such as this:
+
 ```pytb
 OpenGL.error.GLError: GLError(
     err = 1280,
@@ -112,9 +114,24 @@ OpenGL.error.GLError: GLError(
     result = b'OpenGL ES 3.2 NVIDIA 580.126.09'
 )
 ```
-The problem might be solved by setting following environment variables:
+
+The problem can be worked around by forcing Qt to use X11 (via XWayland) and PyOpenGL to use GLX, by setting the following environment variables:
+
 ```sh
 QT_QPA_PLATFORM=xcb
 PYOPENGL_PLATFORM=glx
 ```
 
+Recent versions of napari set these variables automatically at startup, so launching via
+the `napari` command or a Python script usually works without any action on your part.
+napari only sets these variables if you haven't, so your own values are always respected.
+
+This automatic fix only works if napari is imported *before* any Qt application is created.
+If a Qt application already exists (most commonly in IPython or Jupyter when `%gui qt` runs
+before `import napari`), napari can't apply the workaround and prints a warning.
+In that case, set the variables yourself before starting the IPython or Jupyter session:
+
+```sh
+QT_QPA_PLATFORM=xcb PYOPENGL_PLATFORM=glx ipython
+QT_QPA_PLATFORM=xcb PYOPENGL_PLATFORM=glx jupyter lab
+```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -122,7 +122,17 @@ QT_QPA_PLATFORM=xcb
 PYOPENGL_PLATFORM=glx
 ```
 
-napari sets these variables automatically at startup, so launching via
+```{important}
+This workaround needs XWayland (the X11 compatibility layer) installed and running,
+since `xcb` connects to an X server rather than to Wayland directly.
+Most desktop environments ship and start it by default; 
+if yours doesn't, forcing `xcb` fails with `Could not load the Qt
+platform plugin "xcb"`. Install it via your package manager (e.g. `xwayland` on
+Debian/Ubuntu, `xorg-xwayland` on Arch) and start a new session.
+```
+
+When napari detects an Nvidia proprietary driver *and* a reachable X server,
+it sets the aforementioned environment variables automatically at startup, so launching via
 the `napari` command or a Python script usually works without any action on your part.
 napari only sets these variables _for the current session_ if you haven't, so your own values are always respected.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -122,9 +122,9 @@ QT_QPA_PLATFORM=xcb
 PYOPENGL_PLATFORM=glx
 ```
 
-Recent versions of napari set these variables automatically at startup, so launching via
+napari sets these variables automatically at startup, so launching via
 the `napari` command or a Python script usually works without any action on your part.
-napari only sets these variables if you haven't, so your own values are always respected.
+napari only sets these variables _for the current session_ if you haven't, so your own values are always respected.
 
 This automatic fix only works if napari is imported *before* any Qt application is created.
 If a Qt application already exists (most commonly in IPython or Jupyter when `%gui qt` runs


### PR DESCRIPTION
# References and relevant issues

Depends on napari/napari#9009
Related to napari/napari#8808

napari/napari#9009 makes napari automatically apply the Wayland/Nvidia startup workaround (setting `QT_QPA_PLATFORM=xcb` and `PYOPENGL_PLATFORM=glx`), and adds an in-app warning for the cases it can't cover. That warning links to the troubleshooting section updated here (`#wayland-and-nvidia`). See that PR
for the full background.

# Description

This PR updates the "Running napari on Wayland with Nvidia cards" troubleshooting section to reflect the new automatic workaround in napari/napari#9009:

- Explains that recent napari versions set the required environment variables automatically at startup, so most users (launching via the `napari` command or a Python script) no longer need to do anything.
- Documents the manual workaround for the case the automatic fix can't cover: when a Qt application is created before `import napari` (e.g. in IPython or Jupyter when `%gui qt` runs first), the user must set the variables themselves before starting the session.
- Notes that user-set values are always respected.
- Adds a stable `(wayland-and-nvidia)=` anchor that the in-app warning links to, while keeping the original heading so existing links don't break.