### PR TITLE
Fix: Opaque, instead of translucent, sticky version banner

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -101,11 +101,11 @@ html[data-theme="dark"] .button-alt:hover {
 
 /* Version warning banner color */
 #bd-header-version-warning {
-  background-color: color-mix(in srgb, var(--pst-color-secondary-bg), transparent 30%);
+  background-color: color-mix(in oklab, var(--pst-color-secondary-bg), var(--pst-color-target) 15%);
 }
 
 #bd-header-version-warning .pst-button-link-to-stable-version {
-  background-color: color-mix(in srgb, var(--pst-color-secondary-bg), transparent 0%);
+  background-color: var(--pst-color-secondary-bg);
   border-color: var(--pst-color-secondary-bg);
   color: var(--napari-color-text-base);
   font-weight: 700;


### PR DESCRIPTION
# References and relevant issues

Follow-up to napari/napari-sphinx-theme#228

# Description

The version banner had some transparency (see screenshots), likely as a hack to make the button more prominent. This modifies the css to blend with a theme-appropriate color (namely `napari-gray` for light, and `napari-dark-gray` for dark) so that there is no longer transparency. This _mostly_ matches what we saw before.

Top is current, bottom is this PR:
<img width="1392" height="324" alt="image" src="https://github.com/user-attachments/assets/c25652b8-f96b-445b-90d5-22cfb58ab814" />

<img width="1374" height="315" alt="image" src="https://github.com/user-attachments/assets/839fbd89-7409-474e-9c0e-9e77041922a3" />

**Note:** I actually like the transparent banner because I feel like it makes it more noticeable, but for it to look intentional we would also want transparency on the navbar.

**Note 2:** We should also consider having our own theme color set in napari-sphinx-theme for the banner, because this is inheriting from pydata-sphinx-theme colors. I just wanted to mention. It's also potentially a good thing that it's quite noticeably a different color from the theme, but still vaguely matches the palette -- I think that makes it stand out more.