### PR TITLE
python >=3.11 for all docs references

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Please read our [contributing guide](https://napari.org/dev/developers/contribut
 #### Option 1: Manual setup
 
 * __Check the prerequisites__
-    1. Create a clean Python (>=3.10) environment (e.g., with conda).
+    1. Create a clean Python (>=3.11) environment (e.g., with conda).
     1. In that environment, create an editable `napari` installation with the `docs` [dependency group](https://packaging.python.org/en/latest/specifications/dependency-groups/) and a Qt backend. For example, after first forking and cloning the main `napari` project if you've not previously done so, run `python -m pip install -e ".[pyqt]" --group docs` from your `napari/napari` clone directory. This will use the default Qt backend.
     1. Fork *this* repository, `napari/docs`, and then clone your fork to your local machine. NB: you may want to name your fork e.g. `napari-docs` rather than just `docs`.
 * __Build__ locally

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -235,7 +235,7 @@ PySide2 is no longer maintained, so we dropped support for it in napari 0.7.0. P
 Since napari 0.4.18, we store constraints files with information about each exact dependency version against which napari was tested.
 This could be useful if you need to install napari as a package from PyPI, and prevents creating environments where napari does not start or work properly.
 
-The constraints files are stored in the napari repository under `resources/constraints/constraints_py3.10.txt`. To find
+The constraints files are stored in the napari repository under `resources/constraints/constraints_py3.14.txt`. To find
 constraints for specific releases, go under the link `https://github.com/napari/napari/tree/{tag}/resources/constraints`
 replacing `{tag}` with the desired napari version.
 
@@ -243,10 +243,10 @@ replacing `{tag}` with the desired napari version.
 pip install napari[backend_selection] -c path/to/constraints/file
 ```
 
-For example, if you would like to install napari with PyQt6 on python 3.10:
+For example, if you would like to install napari with PyQt6 on python 3.14:
 
 ```sh
-pip install napari[pyqt6, optional] -c constraints_py3.10.txt
+pip install napari[pyqt6, optional] -c constraints_py3.14.txt
 ```
 
 (installation_bundle_conda)=

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -235,7 +235,7 @@ PySide2 is no longer maintained, so we dropped support for it in napari 0.7.0. P
 Since napari 0.4.18, we store constraints files with information about each exact dependency version against which napari was tested.
 This could be useful if you need to install napari as a package from PyPI, and prevents creating environments where napari does not start or work properly.
 
-The constraints files are stored in the napari repository under `resources/constraints/constraints_py3.14.txt`. To find
+The constraints files are stored in the napari repository under `resources/constraints`. To find
 constraints for specific releases, go under the link `https://github.com/napari/napari/tree/{tag}/resources/constraints`
 replacing `{tag}` with the desired napari version.
 

--- a/docs/plugins/testing_and_publishing/hub_customization.md
+++ b/docs/plugins/testing_and_publishing/hub_customization.md
@@ -179,8 +179,8 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering :: Image Processing",
 ]
 dependencies = [

--- a/docs/plugins/testing_and_publishing/hub_customization.md
+++ b/docs/plugins/testing_and_publishing/hub_customization.md
@@ -102,21 +102,21 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering :: Image Processing",
 ]
 ```
 
 #### Python version requirements
 
-Additionally, specify the Python versions your plugin supports. If you specify `">=3.10"`, the hub will tag your plugin as supporting Python 3.10, 3.11, 3.12, etc.
+Additionally, specify the Python versions your plugin supports. If you specify `">=3.11"`, the hub will tag your plugin as supporting Python 3.11, 3.12, etc.
 
 ```toml
 [project]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 ```
 
 #### Dependencies
@@ -167,7 +167,7 @@ description = "Advanced image segmentation using deep learning"
 readme = "README.md"
 license = "BSD-3-Clause"
 license-files = ["LICENSE"]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 authors = [
     {name = "Jane Doe", email = "jane@example.com"},
 ]
@@ -177,8 +177,8 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Image Processing",


### PR DESCRIPTION
# References and relevant issues

napari/napari#9104

# Description

Small updates to bump everything >3.11 and maxing at 3.14 for now

