### PR TITLE
Add tip to use `-h` or `--help` flags with the `compile_constraints.sh` script

### DIFF
--- a/docs/developers/coredev/release.md
+++ b/docs/developers/coredev/release.md
@@ -175,6 +175,8 @@ tools/compile_constraints.sh pyside6
 tools/compile_constraints.sh pyside6 pyqt6-qt6
 ```
 
+Run the `compile_constraints.sh` script with the flags `-h` or `--help` for usage details within the CLI.
+
 ```{admonition} Package name matching
 :class: note
 The script checks whether each named package already appears in an existing constraint


### PR DESCRIPTION
# References and relevant issues
#1043, napari/napari#9090

# Description
This adds a brief line to introduce the `-h` and `--help` flags of the `compile_constraints.sh` script.