### PR TITLE
Use shared workflow for remove ready to merge label

### DIFF
--- a/.github/workflows/remove_ready_to_merge.yml
+++ b/.github/workflows/remove_ready_to_merge.yml
@@ -16,4 +16,4 @@ jobs:
     name: Remove ready to merge label
     uses: napari/shared-workflows/.github/workflows/remove_ready_to_merge.yml@main
     with:
-      label_name+: "Full docs preview/ready to merge"
+      label_name: "Full docs preview/ready to merge"

--- a/.github/workflows/remove_ready_to_merge.yml
+++ b/.github/workflows/remove_ready_to_merge.yml
@@ -1,4 +1,4 @@
-name: Remove "ready to merge" label
+name: Remove ready to merge label
 
 on:
   push:

--- a/.github/workflows/remove_ready_to_merge.yml
+++ b/.github/workflows/remove_ready_to_merge.yml
@@ -1,4 +1,4 @@
-name: Remove ready to merge label
+name: Remove "ready to merge" label
 
 on:
   push:

--- a/.github/workflows/remove_ready_to_merge.yml
+++ b/.github/workflows/remove_ready_to_merge.yml
@@ -1,9 +1,11 @@
 name: Remove "ready to merge" label
 
 on:
-  pull_request_target:
-    types: [closed]
-  workflow_call:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "6 6 * * *" # every morning
 
 
 permissions:
@@ -12,4 +14,6 @@ permissions:
 jobs:
   remove_label:
     name: Remove ready to merge label
-    uses: napari/napari/.github/workflows/remove_ready_to_merge.yml@48fcd2f4351845419303b1d3a102dcb5ce6923ab # v0.7.0
+    uses: napari/shared-workflows/.github/workflows/remove_ready_to_merge.yml@main
+    with:
+      label_name+: "Full docs preview/ready to merge"


### PR DESCRIPTION
# References and relevant issues

# Description

<img width="1525" height="692" alt="image" src="https://github.com/user-attachments/assets/c97c79d7-980d-4e70-9eb8-7e3aae70bd73" />

Our workflow has been failing for a long time as it is wrongly called and the label name is incorrect. 

This PR fixes it. 