### PR TITLE
docs: document GitHub org owner policy and update governance

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -56,6 +56,7 @@ subtrees:
           - file: guides/axis-names
           - file: guides/units
           - file: guides/handedness
+          - file: guides/histogram
           - file: guides/triangulation
           - file: guides/rendering
           - file: guides/performance
@@ -185,6 +186,7 @@ subtrees:
       - file: community/code_of_conduct
       - file: community/code_of_conduct_reporting
       - file: community/governance
+      - file: community/security
       - file: community/working_groups
       - file: community/meeting_schedule
       - file: community/licensing

--- a/docs/community/governance.md
+++ b/docs/community/governance.md
@@ -141,12 +141,14 @@ The SC has the responsibility to:
 - Ensure the publication of an annual State of Napari report that provides a
   summary of the previous year's activities across the entire napari community,
   and highlights the current and future direction of the project.
-- Members of the SC also have the "owner" role within the [napari GitHub
-  organization](https://github.com/napari)
-  and are ultimately responsible for managing the napari GitHub account, the
+- The SC is ultimately responsible for managing the napari GitHub account, the
   [@napari@fosstodon.org](https://fosstodon.org/@napari) Mastodon account, the
   [napari website](https://napari.org), and other similar napari owned
-  resources.
+  resources. By default, SC members do not hold the "owner" role on the
+  [napari GitHub organization](https://github.com/napari) — see the
+  [organization security policy](security) for current owner designations,
+  the criteria for becoming an owner, and the process for requesting
+  temporary owner permissions.
 - When the core team member community (including the SC members) fails to reach
   a consensus in a reasonable timeframe, the SC is the entity that resolves the
   issue.

--- a/docs/community/security.md
+++ b/docs/community/security.md
@@ -1,0 +1,111 @@
+(security-policy)=
+
+# Organization security policy
+
+This page documents the security practices for the
+[napari GitHub organization](https://github.com/napari), including
+who has "owner" permissions on the organization, how those permissions
+are granted and reviewed, and the process for requesting temporary
+elevated access.
+
+(org-owners)=
+
+## GitHub organization owners
+
+GitHub organization owners have elevated permissions over the entire
+napari GitHub organization, including the ability to manage repositories,
+teams, and settings across all projects in the organization. Because
+these permissions carry significant security risk, ownership is limited
+to a small number of trusted individuals rather than granted broadly.
+
+### Designated owners
+
+The following individuals are the designated GitHub organization owners
+for the napari organization:
+
+- [Grzegorz Bokota](https://github.com/Czaki) — {nbsp}`@Czaki`
+- [Lorenzo Gaifas](https://github.com/brisvag) — {nbsp}`@brisvag`
+- [Tim Monko](https://github.com/TimMonko) — {nbsp}`@TimMonko`
+- [Draga Doncila Pop](https://github.com/DragaDoncila) — {nbsp}`@DragaDoncila`
+
+These owners have been selected to be geographically distributed,
+providing coverage across different timezones. They include individuals
+who regularly work with infrastructure and repositories in the
+organization and have sufficient availability on the project to be
+generally responsive.
+
+### Criteria
+
+Owners should meet the following criteria:
+
+- Regularly work with infrastructure and/or repositories across the
+  napari organization.
+- Have enough availability on the project to be generally responsive
+  to security and administrative requests.
+- Be geographically distributed to provide timezone coverage.
+- Be willing to take on the responsibilities of the owner role,
+  including responding promptly to urgent security issues.
+
+### Annual review
+
+Ownership designations are reviewed annually, typically at the same time
+as the [core team reaffirmation](napari-governance) process (reviewed every
+January). The Steering Council reviews the current list of owners and
+confirms or adjusts it based on current needs and the criteria above.
+If an owner is no longer regularly active in the organization, or no
+longer meets the criteria, they may be removed from the owner role.
+
+(org-owners-temporary-access)=
+
+## Requesting temporary owner access
+
+Sometimes a task requires temporary owner-level permissions — for
+example, to manage a critical repository migration, handle a security
+incident, or perform bulk administrative actions. A process exists
+for requesting and granting temporary owner access.
+
+### How to request
+
+Requests for temporary owner access should be made in the
+`#auth-security` channel on the [napari Zulip](https://napari.zulipchat.com).
+Requests should include:
+
+- **Who** is requesting the access.
+- **Why** the access is needed (what task requires owner permissions).
+- **Duration** — how long the access is needed (e.g., "for the next
+  48 hours", "until the repository migration is complete").
+- **Scope** — what specific actions the access will be used for.
+
+A template may be provided in the Zulip channel for structuring
+requests.
+
+### Approval
+
+Requests are reviewed by the designated owners and/or the
+[Steering Council](napari-governance). Temporary owner access is
+granted by consensus of the current owners. The request and its
+resolution should be recorded in the Zulip thread for
+accountability and future reference.
+
+### Revocation
+
+Temporary owner permissions are revoked once the stated duration has
+elapsed or the task is complete, whichever comes first. It is the
+responsibility of the individual who requested the access to notify
+the owners when the task is complete so that permissions can be
+removed promptly. The designated owners may also revoke temporary
+access at any time if they deem it no longer necessary.
+
+## Roles and permissions overview
+
+| Role | GitHub permissions | Default holders |
+|---|---|---|
+| **Organization owner** | Full administrative access to the organization and all its repositories | 4 designated owners (see above) |
+| **Admin** | Repository-level admin, team management | Core team members on repositories they maintain |
+| **Write** | Push access, PR management | Core team members |
+| **Read** | Read-only access | All organization members |
+
+For questions about organization security, reach out on the
+`#auth-security` Zulip channel or contact the
+[Steering Council](napari-governance) at
+`napari-steering-council@googlegroups.com`.


### PR DESCRIPTION
:robot: *Human guided, AI assisted PR.* :robot:

This PR implements the org owner policy discussed in the core team meeting:

- **Removes the automatic GitHub owner role from Steering Council members** in the governance document. By default, SC members do not hold owner permissions on the napari GitHub organization.
- **Creates a new organization security policy page** (\community/security.md\) documenting:
  - The four designated org owners: Grzegorz Bokota, Lorenzo Gaifas, Tim Monko, and Draga Doncila Pop
  - The criteria for becoming an owner (infrastructure work, availability, geographic distribution)
  - An annual review process for ownership designations (coinciding with core team reaffirmation in January)
  - A process for requesting temporary owner access via the \#auth-security\ Zulip channel
  - A roles and permissions overview table
- **Updates the table of contents** to include the new security page