### PR TITLE
Update organization ownership policy

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -185,6 +185,7 @@ subtrees:
       - file: community/code_of_conduct
       - file: community/code_of_conduct_reporting
       - file: community/governance
+      - file: community/security
       - file: community/working_groups
       - file: community/meeting_schedule
       - file: community/licensing

--- a/docs/community/governance.md
+++ b/docs/community/governance.md
@@ -141,12 +141,14 @@ The SC has the responsibility to:
 - Ensure the publication of an annual State of Napari report that provides a
   summary of the previous year's activities across the entire napari community,
   and highlights the current and future direction of the project.
-- Members of the SC also have the "owner" role within the [napari GitHub
-  organization](https://github.com/napari)
-  and are ultimately responsible for managing the napari GitHub account, the
-  [@napari@fosstodon.org](https://fosstodon.org/@napari) Mastodon account, the
-  [napari website](https://napari.org), and other similar napari owned
-  resources.
+- The SC is ultimately responsible for managing the [napari GitHub
+  organization](https://github.com/napari),
+  the [napari website](https://napari.org),
+  the [@napari.org](https://bsky.app/profile/napari.org) Bluesky account,
+  the [@napari@fosstodon.org](https://fosstodon.org/@napari) Mastodon account,
+  the [napari Zulip](https://napari.zulipchat.com/) chat,
+  the [napari LinkedIn](https://www.linkedin.com/company/napari) page,
+  and other similar napari owned resources.
 - When the core team member community (including the SC members) fails to reach
   a consensus in a reasonable timeframe, the SC is the entity that resolves the
   issue.

--- a/docs/community/security.md
+++ b/docs/community/security.md
@@ -1,0 +1,95 @@
+(security-policy)=
+
+# Organization security policy
+
+This page documents the security practices for the
+[napari GitHub organization](https://github.com/napari), including
+who has Owner permissions on the organization, how those permissions
+are granted and reviewed, and the process for requesting temporary
+elevated access.
+
+(org-owners)=
+
+## GitHub organization owners
+
+GitHub organization owners have elevated permissions over the entire
+napari GitHub organization, including the ability to manage repositories,
+teams, and settings across all projects in the organization. Because
+these permissions carry security risk, ownership is limited
+to a small number of trusted individuals rather than granted broadly.
+
+### Criteria
+
+Owners should meet the following criteria:
+
+- Regularly work with infrastructure and/or repositories across the
+  napari organization.
+- Have enough availability on the project to be generally responsive
+  to security and administrative requests.
+- Be geographically distributed to provide timezone coverage.
+- Be willing to take on the responsibilities of the owner role,
+  including responding promptly to urgent security issues.
+
+### Authentication and review
+
+Ownership requests are made via the private `#auth-security` Zulip channel
+and are reviewed by the current owners and the Steering Council.
+
+Ownership designations are reviewed annually, typically at the same time
+as the [core team reaffirmation](napari-governance) process (reviewed every
+January). The Steering Council and Core Team reviews the current list of owners
+and confirms or adjusts it based on current needs and the criteria above.
+If an owner is no longer regularly active in the organization, or no
+longer meets the criteria, they may be removed from the owner role.
+
+(temporary-access)=
+
+## Requesting temporary owner access
+
+Sometimes a task requires temporary owner-level permissions — for
+example, to manage a critical repository migration, handle a security
+incident, or perform bulk administrative actions. A process exists
+for requesting and granting temporary owner access.
+
+### How to request
+
+Requests for temporary owner access or other elevated permissions should be made
+in the private `#auth-security` channel on the [napari Zulip](https://napari.zulipchat.com).
+Requests should include:
+
+- **Who** is requesting the access.
+- **Why** the access is needed (what task requires elevated permissions).
+- **Duration** — how long the access is needed (e.g., "for the next
+  48 hours", "until the repository migration is complete").
+- **Scope** — what specific actions the access will be used for.
+
+### Approval
+
+Requests are reviewed by the designated owners and/or the
+[Steering Council](napari-governance). Temporary owner access is
+granted by consensus of the current owners. The request and its
+resolution should be recorded in the Zulip thread for
+accountability and future reference.
+
+### Revocation
+
+Temporary owner permissions are revoked once the stated duration has
+elapsed or the task is complete, whichever comes first. It is the
+responsibility of the individual who requested the access to notify
+the owners when the task is complete so that permissions can be
+removed promptly. The designated owners may also revoke temporary
+access at any time if they deem it no longer necessary.
+
+## Roles and permissions overview
+
+| Role | GitHub permissions | Default holders |
+|---|---|---|
+| **Organization owner** | Full administrative access to the organization and all its repositories | Four designated owners |
+| **Admin** | Repository-level admin, team management | Core team members on repositories they maintain |
+| **Write** | Push access, PR management | Core team members |
+| **Read** | Read-only access | All organization members |
+
+For questions about organization security, reach out on the
+`#auth-security` Zulip channel or contact the
+[Steering Council](napari-governance) at
+`napari-steering-council@googlegroups.com`.

--- a/docs/community/security.md
+++ b/docs/community/security.md
@@ -32,7 +32,7 @@ Owners should meet the following criteria:
 
 ### Authentication and review
 
-Ownership requests are made via the private `#auth-security` Zulip channel
+Request to become an owner are made via the private `#auth-security` Zulip channel
 and are reviewed by the current owners and the Steering Council.
 
 Ownership designations are reviewed annually, typically at the same time
@@ -67,7 +67,7 @@ Requests should include:
 
 Requests are reviewed by the designated owners and/or the
 [Steering Council](napari-governance). Temporary owner access is
-granted by consensus of the current owners. The request and its
+granted by any of the current owners. The request and its
 resolution should be recorded in the Zulip thread for
 accountability and future reference.
 
@@ -89,7 +89,6 @@ access at any time if they deem it no longer necessary.
 | **Write** | Push access, PR management | Core team members |
 | **Read** | Read-only access | All organization members |
 
-For questions about organization security, reach out on the
-`#auth-security` Zulip channel or contact the
+For questions about organization security, contact the
 [Steering Council](napari-governance) at
 `napari-steering-council@googlegroups.com`.


### PR DESCRIPTION
# References and relevant issues

(private) https://napari.zulipchat.com/#narrow/channel/320379-core-devs/topic/Proposal.3A.20GitHub.20owners.20.2F.20permission/with/608576082
and Core Team meeting on June 23/24, 2026.

# Description

Removes Ownership responisbility from the SC (governance page) and updates the language to imply instead *responsbility* for management of napari resources (adding a few socials).

Then, adds `security.md` as a page which discusses the new approach to ownership/permissions authorization. I added as a new document so that we can add more upcoming security-related protocols (like a Security team and policy) in the future.


