### PR TITLE
Update version switcher to point to 0.8.0 as stable

### DIFF
--- a/docs/_static/version_switcher.json
+++ b/docs/_static/version_switcher.json
@@ -5,12 +5,18 @@
         "url": "https://napari.org/dev/"
     },
     {
-        "name": "stable (0.7.1)",
-        "version": "0.7.1",
+        "name": "stable (0.8.0)",
+        "version": "0.8.0",
         "url": "https://napari.org/stable/",
         "preferred": true
+    }, 
+    {
+        "name": "0.7.1",
+        "version": "0.7.1",
+        "url": "https://napari.org/0.7.1/",
+        "preferred": true
     },
-	{
+    {
         "name": "0.7.0",
         "version": "0.7.0",
         "url": "https://napari.org/0.7.0/"

--- a/docs/_static/version_switcher.json
+++ b/docs/_static/version_switcher.json
@@ -9,7 +9,7 @@
         "version": "0.8.0",
         "url": "https://napari.org/stable/",
         "preferred": true
-    }, 
+    },
     {
         "name": "0.7.1",
         "version": "0.7.1",

--- a/docs/_static/version_switcher.json
+++ b/docs/_static/version_switcher.json
@@ -13,8 +13,7 @@
     {
         "name": "0.7.1",
         "version": "0.7.1",
-        "url": "https://napari.org/0.7.1/",
-        "preferred": true
+        "url": "https://napari.org/0.7.1/"
     },
     {
         "name": "0.7.0",


### PR DESCRIPTION
# References and relevant issues


# Description

One of last steep in 0.8.0 release 
