### PR TITLE
Distinguish navbar active state from hover state

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -250,3 +250,8 @@ html[data-theme="dark"] .homepage-quicklinks a {
 html[data-theme="dark"] img#homepage-featured-example-image {
   background-color: var(--pst-color-background) !important;
 }
+
+/* ── Navbar: distinguish active from hover ─────────────────────────────── */
+.bd-header ul.navbar-nav > li.nav-item.current > .nav-link {
+  border-bottom: 4px solid var(--napari-color-text-base);
+}


### PR DESCRIPTION
```markdown
# References and relevant issues

Closes #(issue-number)

# Description

The hover and active states in the top navigation bar shared the same styling — both showed a `3px` solid bottom border in the text color. This made it confusing to tell which page was currently active when hovering over other nav items.

The fix increases the active state's bottom border from **3px to 4px**, keeping the same color and style, so the active page is visually distinguishable from a hovered item at a glance.

| State   | Before | After  | Font weight |
|---------|--------|--------|-------------|
| Hover   | 3px    | 3px    | 500         |
| Active  | 3px    | **4px** | **700**     |
```

Fill in the issue number (e.g. `Closes #1080`) once confirmed.