### PR TITLE
Bring several NAPs up to date

### DIFF
--- a/docs/naps/1-institutional-funding-partners.md
+++ b/docs/naps/1-institutional-funding-partners.md
@@ -6,7 +6,7 @@
 :Author: "Juan Nunez-Iglesias <mailto:jni@fastmail.com>"
 :Author: "Nicholas Sofroniew <mailto:sofroniewn@gmail.com>"
 :Created: '2022-04-21'
-:Status: Accepted
+:Status: Final
 :Type: Process
 ```
 

--- a/docs/naps/2-conda-based-packaging.md
+++ b/docs/naps/2-conda-based-packaging.md
@@ -8,7 +8,7 @@
 :Created: 2022-05-05
 :Resolution: https://github.com/napari/napari/pull/4602#pullrequestreview-1028720579
 :Resolved: 2022-07-14
-:Status: Accepted
+:Status: Final
 :Type: <Standards Track | Process>
 :Version effective: 0.4.17, 0.5
 ```

--- a/docs/naps/3-spaces.md
+++ b/docs/naps/3-spaces.md
@@ -5,9 +5,13 @@
 ```{eval-rst}
 :Author: Lorenzo Gaifas, brisvag@gmail.com
 :Created: 2022-06-08
-:Status: Draft
+:Status: Withdrawn
 :Type: Standards Track
 ```
+
+:::{note}
+This NAP has been withdrawn in favour of the more comprehensive [NAP-9 - Multiple Views](nap-9).
+:::
 
 
 ## Abstract

--- a/docs/naps/5-new-logo.md
+++ b/docs/naps/5-new-logo.md
@@ -12,6 +12,10 @@
 :Version effective: 0.5
 ```
 
+:::{note}
+This NAP has been withdrawn due to lack of interest. It is now moot as a new logo has been made differently.
+:::
+
 ## Abstract
 
 This NAP proposes a new, mathematically-defined logo for napari.

--- a/docs/naps/6-contributable-menus.md
+++ b/docs/naps/6-contributable-menus.md
@@ -7,7 +7,7 @@
 :Created: 2022-12-02
 :Resolution: TBD
 :Resolved: TBD
-:Status: Draft
+:Status: Provisional
 :Type: Standards Track
 :Version effective: TBD
 ```

--- a/docs/naps/8-telemetry.md
+++ b/docs/naps/8-telemetry.md
@@ -7,10 +7,14 @@
  :Created: 2023-08-11
  :Resolution: <url> (required for Accepted | Rejected | Withdrawn) 
  :Resolved: <date resolved, in yyyy-mm-dd format> 
- :Status: Draft
+ :Status: Withdrawn
  :Type: Standards Track 
  :Version effective: <version-number> (for accepted NAPs) 
  ``` 
+
+:::{note}
+This NAP has been withdrawn after polling the community, which was generally either against or uninterested in opting in.
+:::
   
  ## Abstract 
   


### PR DESCRIPTION
# Description
NAPs are supposed to be Accepted, Widthdrawn or made Final when appropriate. We haven't been on top of this and several NAPs that have _effectively_ changed status were never formally changed. This PR does that, for those naps whose informal status is hopefully obvious :P

Feel free to disagree below and I'll update accordingly, let's leave this open for a while!

cc @napari/core-devs