### PR TITLE
Update dev instructions to use prek

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -285,4 +285,4 @@ fallback-videos-clean:
 	rm -f docs/_static/images/*.mp4
 
 spellcheck:
-	pre-commit run --all-files codespell
+	prek run --all-files codespell

--- a/docs/developers/contributing/dev_install.md
+++ b/docs/developers/contributing/dev_install.md
@@ -89,14 +89,20 @@ In order to make changes to `napari`, you will need to [fork](https://docs.githu
    included with the typical end-user `napari[all]` installation.
    ```
 
-1. We use [`pre-commit`](https://pre-commit.com) to format code with
+1. We use [`prek`](https://prek.j178.dev/) to format and lint code. 
+   The `prek` is rust implementation of [`pre-commit`](https://pre-commit.com/)
+   and is faster than the python implementation.
+   Full list of used hooks can be found in pre-commit configuration file 
+   [`.pre-commit-config.yaml`](https://github.com/napari/napari/blob/main/.pre-commit-config.yaml)
+   in the root of the repository.
+   The most important hooks are formatting with
    [`ruff-format`](https://docs.astral.sh/ruff/formatter/) and lint with
-   [`ruff`](https://github.com/astral-sh/ruff) automatically prior to each commit.
-   To minimize test errors when submitting pull requests, please install `pre-commit`
-   in your environment as follows:
+   [`ruff-check`](https://docs.astral.sh/ruff/linter/).
+   To enable it to be executed on creation of every commit, reduce CI usage and reduce the number of test errors,
+   install `prek` as pre-comit hood by running the following command in your environment:
 
    ```sh
-   pre-commit install
+   prek install
    ```
 
    Upon committing, your code will be formatted according to our [`ruff-format`
@@ -112,5 +118,9 @@ In order to make changes to `napari`, you will need to [fork](https://docs.githu
    If you wish to tell the linter to ignore a specific line use the `# noqa`
    comment along with the specific error code (e.g. `import sys  # noqa: E402`) but
    please do not ignore errors lightly.
+
+   ```note
+   To run `prek` manually, without creating a commit, you can run `prek run --all-files`.
+   ```
 
 Now you are all set to start developing with napari.

--- a/docs/developers/contributing/dev_install.md
+++ b/docs/developers/contributing/dev_install.md
@@ -119,7 +119,7 @@ In order to make changes to `napari`, you will need to [fork](https://docs.githu
    comment along with the specific error code (e.g. `import sys  # noqa: E402`) but
    please do not ignore errors lightly.
 
-   ```note
+   ```{note}
    To run `prek` manually, without creating a commit, you can run `prek run --all-files`.
    ```
 

--- a/docs/developers/contributing/dev_install.md
+++ b/docs/developers/contributing/dev_install.md
@@ -99,7 +99,7 @@ In order to make changes to `napari`, you will need to [fork](https://docs.githu
    [`ruff-format`](https://docs.astral.sh/ruff/formatter/) and lint with
    [`ruff-check`](https://docs.astral.sh/ruff/linter/).
    To enable it to be executed on creation of every commit, reduce CI usage and reduce the number of test errors,
-   install `prek` as pre-comit hood by running the following command in your environment:
+   install `prek` as pre-commit hook by running the following command in your environment:
 
    ```sh
    prek install

--- a/docs/developers/coredev/core_dev_guide.md
+++ b/docs/developers/coredev/core_dev_guide.md
@@ -184,7 +184,7 @@ As a core member, you should be familiar with the following napari guides:
 - [PEP257](https://peps.python.org/pep-0257/) and the
   [NumPy documentation guide](https://numpy.org/devdocs/dev/howto-docs.html#documentation-style)
   for docstring conventions.
-- [`pre-commit`](https://pre-commit.com) hooks for autoformatting.
+- [`prek`](https://prek.j178.dev/) hooks for autoformatting.
 - [`ruff-format`](https://docs.astral.sh/ruff/formatter/) autoformatting.
 - [`ruff`](https://github.com/astral-sh/ruff) linting.
 

--- a/docs/plugins/virtual_environment_docs/4-developer-tools.md
+++ b/docs/plugins/virtual_environment_docs/4-developer-tools.md
@@ -34,15 +34,26 @@ These _auto-modify_ your code.
 
 ### Pre-commit tools
 
-- [pre-commit](https://pre-commit.com/), runs all your checks each time you run git commit, preventing bad code from ever getting checked in.
+- [pre-commit](https://pre-commit.com/) - runs all your checks each time you run git commit, preventing bad code from ever getting checked in.
 
 ```console
      $ pip install pre-commit
-     # install the pre-commit "hook"
+     # install the pre-commit "git hook"
      $ pre-commit install
      # then configure in .pre-commit-config.yaml
      # (optionally) Run hooks on demand
      $ pre-commit run --all-files
+```
+
+- [prek](https://prek.j178.dev/), Faster implementation of pre-commit, runs all your checks each time you run git commit, preventing bad code from ever getting checked in.
+
+```console
+     $ pip install prek
+     # install the pre-commit "git hook"
+     $ prek install
+     # then configure in .pre-commit-config.yaml
+     # (optionally) Run hooks on demand
+     $ prek run --all-files
 ```
 
 - [pre-commit-ci](https://pre-commit.ci/)

--- a/docs/plugins/virtual_environment_docs/4-developer-tools.md
+++ b/docs/plugins/virtual_environment_docs/4-developer-tools.md
@@ -34,17 +34,6 @@ These _auto-modify_ your code.
 
 ### Pre-commit tools
 
-- [pre-commit](https://pre-commit.com/) - runs all your checks each time you run git commit, preventing bad code from ever getting checked in.
-
-```console
-     $ pip install pre-commit
-     # install the pre-commit "git hook"
-     $ pre-commit install
-     # then configure in .pre-commit-config.yaml
-     # (optionally) Run hooks on demand
-     $ pre-commit run --all-files
-```
-
 - [prek](https://prek.j178.dev/), Faster implementation of pre-commit, runs all your checks each time you run git commit, preventing bad code from ever getting checked in.
 
 ```console


### PR DESCRIPTION
# References and relevant issues

Depends on https://github.com/napari/napari/pull/9211

# Description

As `prek` is faster than pre-commit (for example, it uses uv to install tools), we should advertise it and use it. 