### PR TITLE
Add auto labeling as maintenance PR that edit `.pre-commit-config.yml`

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,4 +5,4 @@ documentation:
 
 maintenance:
 - changed-files:
-  - any-glob-to-any-file: ['.circleci/*', '.github/**/*']
+  - any-glob-to-any-file: ['.circleci/*', '.github/**/*', '.pre-commit-config.yaml']


### PR DESCRIPTION
# References and relevant issues


# Description

I found that we report pre-commit updates as documentation changes because we forget to add labels to PRs. 

This change is to automatically add this label. 