### PR TITLE
Fix building docs with PyQt6

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -733,10 +733,11 @@ def qt_docstrings(app, what, name, obj, options, lines):
     Avoids syntax errors since the Qt threading docstrings are written in
     Markdown, and injected into rst docstring automatically.
     """
-    ignore_list = ['WorkerBase', 'FunctionWorker', 'GeneratorWorker']
+    if not name.startswith('napari.qt'):
+        return
+    ignore_list = ['WorkerBase', 'FunctionWorker', 'GeneratorWorker', 'Shadow.from_bytes', 'Shadow.to_bytes', 'Shape.from_bytes', 'Shape.to_bytes']
     if any(f in name for f in ignore_list) and len(lines) > 0:
         del lines[1:]
-
 
 # -- Docs build setup ------------------------------------------------------
 


### PR DESCRIPTION
# References and relevant issues
Unlock https://github.com/napari/shared-workflows/pull/29

# Description

The build docs against PyQt6 fails with such warnings (and we treat warnings as errors). 

```
docstring of napari.qt.QtToolTipLabel.Shadow.from_bytes:9: WARNING: Inline interpreted text or phrase reference start-string without end-string. [docutils]
docstring of napari.qt.QtToolTipLabel.Shadow.to_bytes:8: WARNING: Inline interpreted text or phrase reference start-string without end-string. [docutils]
docstring of napari.qt.QtToolTipLabel.Shape.from_bytes:9: WARNING: Inline interpreted text or phrase reference start-string without end-string. [docutils]
docstring of napari.qt.QtToolTipLabel.Shape.to_bytes:8: WARNING: Inline interpreted text or phrase reference start-string without end-string. [docutils]
docstring of napari.qt.QtViewer.Shadow.from_bytes:9: WARNING: Inline interpreted text or phrase reference start-string without end-string. [docutils]
docstring of napari.qt.QtViewer.Shadow.to_bytes:8: WARNING: Inline interpreted text or phrase reference start-string without end-string. [docutils]
docstring of napari.qt.QtViewer.Shape.from_bytes:9: WARNING: Inline interpreted text or phrase reference start-string without end-string. [docutils]
docstring of napari.qt.QtViewer.Shape.to_bytes:8: WARNING: Inline interpreted text or phrase reference start-string without end-string. [docutils]
docstring of napari.qt.QtViewerButtons.Shadow.from_bytes:9: WARNING: Inline interpreted text or phrase reference start-string without end-string. [docutils]
docstring of napari.qt.QtViewerButtons.Shadow.to_bytes:8: WARNING: Inline interpreted text or phrase reference start-string without end-string. [docutils]
docstring of napari.qt.QtViewerButtons.Shape.from_bytes:9: WARNING: Inline interpreted text or phrase reference start-string without end-string. [docutils]
docstring of napari.qt.QtViewerButtons.Shape.to_bytes:8: WARNING: Inline interpreted text or phrase reference start-string without end-string. [docutils]
```

This PR uses our machinery to filter out problematic methods. 

It improves the Qt filter mechanism to not filter outside the `napari.qt` module  