### PR TITLE
Prefetch data that are problematic and causing docs build failure

### DIFF
--- a/docs/_scripts/prefetch_data.py
+++ b/docs/_scripts/prefetch_data.py
@@ -1,3 +1,6 @@
+import os
+from pathlib import Path
+
 from nilearn import datasets
 import pooch
 
@@ -8,6 +11,9 @@ def main():
     datasets.fetch_surf_fsaverage()
 
     #getting_started/open_images.md
+    download_folder = Path(os.path.expanduser("~")).joinpath("Desktop", "napari-docs-build")
+    if not download_folder.is_dir():
+        download_folder.mkdir(parents=True, exist_ok=True)
     pooch.retrieve(
         url="https://ftp.ebi.ac.uk/biostudies/fire/S-BIAD/582/S-BIAD582/Files/01_wt_Dprotein555-TL/raw_mps/5-2b_01_wt_Dprotein555-TL_003_rawmp.tif",
         known_hash='5b43ed0269eaa1eebf4c48079270a30e6cc40e87f20cc36c1b3d5a07c51c7b20',

--- a/docs/_scripts/prefetch_data.py
+++ b/docs/_scripts/prefetch_data.py
@@ -1,0 +1,16 @@
+from nilearn import datasets
+import pooch
+
+
+def main():
+    # example surface timeseries
+    datasets.fetch_surf_nki_enhanced(n_subjects=1)
+    datasets.fetch_surf_fsaverage()
+
+    #getting_started/open_images.md
+    pooch.retrieve(
+        url="https://ftp.ebi.ac.uk/biostudies/fire/S-BIAD/582/S-BIAD582/Files/01_wt_Dprotein555-TL/raw_mps/5-2b_01_wt_Dprotein555-TL_003_rawmp.tif",
+        known_hash='5b43ed0269eaa1eebf4c48079270a30e6cc40e87f20cc36c1b3d5a07c51c7b20',
+        fname='5-2b_01_wt_Dprotein555-TL_003_rawmp.tif',
+        path=download_folder
+    )

--- a/docs/_scripts/prep_docs.py
+++ b/docs/_scripts/prep_docs.py
@@ -123,7 +123,7 @@ def main(stubs=False):
         __import__("update_event_docs").main()
         __import__("update_ui_sections_docs").main()
         __import__("update_release_docs").main()
-
+    __import__("prefetch_data").main()
 
 if __name__ == '__main__':
     import argparse


### PR DESCRIPTION
# References and relevant issues

closes #1089

# Description

This PR adds a step of prefetching fragile data required during the build of docs. It does not prevent docs build from failing, but it should happen in the first minute. 

So it should be easier to understand why docs build fails and use less CI time. 

The next step might be to use this script to download data from an alternative location and put it in the expected place. 