### PR TITLE
Use PyQt6 when build docs on circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
           name: Install napari-dev
           command: |
             . .venv/bin/activate
-            uv pip install -e "napari/[pyqt5,docs]"
+            uv pip install -e "napari/[pyqt6,docs]"
           environment:
             UV_CONSTRAINT: napari/resources/constraints/constraints_py3.12_docs.txt
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ parameters:
 # Orbs are reusable packages of CircleCI configuration that you may share across projects.
 # See: https://circleci.com/docs/2.1/orb-intro/
 orbs:
-  python: circleci/python@3.0.0
+  python: circleci/python@4.0.0
 
 jobs:
   build-docs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
           command: git clone git@github.com:napari/napari.git napari
       - run:
           name: Install qt libs + xvfb
-          command: sudo apt-get update && sudo apt-get install -y xvfb libegl1 libdbus-1-3 libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0 x11-utils
+          command: sudo apt-get update && sudo apt-get install -y xvfb libegl1 libdbus-1-3 libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0 x11-utils libxcb-cursor0
       - run:
           name: Setup virtual environment
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ orbs:
 jobs:
   build-docs:
     docker:
-      - image: cimg/python:3.12.11
+      - image: cimg/python:3.12.13
     environment:
       XDG_CACHE_HOME: /home/circleci/.cache
     parameters:


### PR DESCRIPTION
# References and relevant issues

follow-up #1102

# Description

Just change circleci configuration in napari/docs to use PyQt6.