### PR TITLE
Mention guided viewer tour

### DIFF
--- a/docs/getting_started/quick_start.md
+++ b/docs/getting_started/quick_start.md
@@ -72,6 +72,8 @@ napari
 Starting with release 0.6.0, you can use the [command palette](command-palette) to launch any command. 🎨
 ```
 
+After napari opens, you can start an interactive overview of the viewer from **Help > Take a tour**.
+
 ## Open an image
 
 napari natively supports tiff and many other formats supported by [skimage.io.imread](https://scikit-image.org/docs/dev/api/skimage.io.html) as input image file format.

--- a/docs/getting_started/viewer.md
+++ b/docs/getting_started/viewer.md
@@ -21,6 +21,10 @@ This tour assumes you have already installed **napari** and know how to launch t
 
 This tour will teach you about the **napari** viewer, including how to use its graphical user interface (GUI) and how the data within it is organized. At the end, you should understand both the layout of the viewer on the screen and the data inside of it.
 
+```{tip}
+napari also includes an interactive version of this viewer overview at **Help > Take a tour**.
+```
+
 +++
 
 ## Launching the viewer


### PR DESCRIPTION
# References and relevant issues

Depends on napari/napari#9290, which added the guided viewer tour.

# Description

Adds a short mention of **Help > Take a tour** to the two getting started pages requested in napari/napari#9290:

- `getting_started/quick_start.md`
- `getting_started/viewer.md`