### PR TITLE
docs: add list of built-in `sample images`

### DIFF
--- a/docs/getting_started/open_images.md
+++ b/docs/getting_started/open_images.md
@@ -37,7 +37,7 @@ Many samples come from the scikit-image example images available in [`skimage.da
 | Cell | Grayscale microscopy image of a single cell. |
 | Cells (3D+2Ch) | 3D fluorescence image with two channels. |
 | Checkerboard | Synthetic checkerboard target pattern. |
-| Clock | Photograph of a wall clock. |
+| Clock | Photograph of a motion blurred wall clock. |
 | Coffee (RGB) | Color photograph of a cup of coffee. |
 | Coins | Grayscale photograph of several coins. |
 | Colorwheel (RGB) | Color-wheel test image. |

--- a/docs/getting_started/open_images.md
+++ b/docs/getting_started/open_images.md
@@ -54,7 +54,7 @@ Many samples come from the scikit-image example images available in [`skimage.da
 | Lily (4Ch) | 4-channel fluorescence image of a lily. |
 | Microaneurysms | Retinal image showing microaneurysms. |
 | Moon | Grayscale photograph of the moon. |
-| Page | Grayscale image of a text page. |
+| Page | Grayscale image of a printed text page. |
 | Retina (RGB) | Color retinal fundus image. |
 | Rocket (RGB) | Color photograph of a rocket launch. |
 | Shepp Logan Phantom | Synthetic medical imaging phantom. |

--- a/docs/getting_started/open_images.md
+++ b/docs/getting_started/open_images.md
@@ -21,6 +21,48 @@ Sometimes you just need to open images to test some functionality of napari or a
 
 ![Open sample image](../_static/images/open_image.png)
 
+### Available built-in sample images
+
+The following sample images are bundled with napari and are available from `File -> Open Sample -> napari builtins`.
+
+| Sample image | Notes |
+| ------------ | ----- |
+| Astronaut (RGB) | Color photograph of an astronaut. |
+| Balls | 2D synthetic pattern of filled circles. |
+| Balls (3D) | 3D synthetic volume of spheres. |
+| Binary Blobs | 2D synthetic binary blob image. |
+| Binary Blobs (3D) | 3D synthetic binary blob volume. |
+| Brick | Photograph of a brick wall texture. |
+| Brain (3D) | 3D MRI brain volume. |
+| Camera | Standard grayscale "cameraman" test image. |
+| Cat (RGB) | Color photograph of a cat. |
+| Cell | Grayscale microscopy image of a single cell. |
+| Cells (3D+2Ch) | 3D fluorescence image with two channels. |
+| Checkerboard | Synthetic checkerboard target pattern. |
+| Clock | Photograph of a wall clock. |
+| Coffee (RGB) | Color photograph of a cup of coffee. |
+| Coins | Grayscale photograph of several coins. |
+| Colorwheel (RGB) | Color-wheel test image. |
+| Eagle | Grayscale photograph of an eagle. |
+| Grass | Photograph of a grass texture. |
+| Gravel | Photograph of a gravel texture. |
+| Heat diffusion (4D) | 4D synthetic heat-diffusion volume (time + 3D). |
+| Horse | Silhouette image of a horse. |
+| Hubble Deep Field (RGB) | Deep-field astronomy image. |
+| Human Mitosis | Microscopy image of dividing cells. |
+| Immunohistochemistry (RGB) | Immunohistochemistry-stained tissue image. |
+| Kidney (3D+3Ch) | 3D kidney tissue data with three channels. |
+| Labeled Faces in the Wild | Subset of the LFW face dataset. |
+| Lily (4Ch) | 4-channel fluorescence image of a lily. |
+| Microaneurysms | Retinal image showing microaneurysms. |
+| Moon | Grayscale photograph of the moon. |
+| Page | Grayscale image of a text page. |
+| Retina (RGB) | Color retinal fundus image. |
+| Rocket (RGB) | Color photograph of a rocket launch. |
+| Shepp Logan Phantom | Synthetic medical imaging phantom. |
+| Skin (RGB) | Color microscopy image of skin tissue. |
+| Text | Grayscale image containing text. |
+
 ## Builtin napari reader
 
 napari natively supports TIFF and many other standard formats like PNG, JPG etc. When drag-and-dropping files, using one of the `File -> Open File/Folder` menu options, or using the `File -> Open Sample` menu with such formats, images will be read via the [imageio](https://imageio.readthedocs.io/en/stable/) library and appear in the viewer.

--- a/docs/getting_started/open_images.md
+++ b/docs/getting_started/open_images.md
@@ -23,8 +23,6 @@ Sometimes you just need to open images to test some functionality of napari or a
 
 ### Available built-in sample images
 
-The following sample images are bundled with napari and are available from `File -> Open Sample -> napari builtins`.
-
 | Sample image | Notes |
 | ------------ | ----- |
 | Astronaut (RGB) | Color photograph of an astronaut. |

--- a/docs/getting_started/open_images.md
+++ b/docs/getting_started/open_images.md
@@ -59,7 +59,7 @@ Many samples come from the scikit-image example images available in [`skimage.da
 | Rocket (RGB) | Color photograph of a rocket launch. |
 | Shepp Logan Phantom | Synthetic medical imaging phantom. |
 | Skin (RGB) | Color microscopy image of skin tissue. |
-| Text | Grayscale image containing text. |
+| Text | Grayscale image containing handwritten text. |
 
 ## Builtin napari reader
 

--- a/docs/getting_started/open_images.md
+++ b/docs/getting_started/open_images.md
@@ -30,7 +30,7 @@ Many samples come from the scikit-image example images available in [`skimage.da
 | Balls (3D) | 3D synthetic volume of spheres. |
 | Binary Blobs | 2D synthetic binary blob image. |
 | Binary Blobs (3D) | 3D synthetic binary blob volume. |
-| Brick | Photograph of a brick wall texture. |
+| Brick | Grayscale photograph of a brick wall texture. |
 | Brain (3D) | 3D MRI brain volume. |
 | Camera | Grayscale "cameraman" test image. |
 | Cat (RGB) | Color photograph of a cat. |

--- a/docs/getting_started/open_images.md
+++ b/docs/getting_started/open_images.md
@@ -22,7 +22,7 @@ Sometimes you just need to open images to test some functionality of napari or a
 ![Open sample image](../_static/images/open_image.png)
 
 ### Available built-in sample images
-
+Many samples come from the scikit-image example images available in [`skimage.data`](https://scikit-image.org/docs/stable/api/skimage.data.html#) which you can read to learn more about the images, including source and copyright status.
 | Sample image | Notes |
 | ------------ | ----- |
 | Astronaut (RGB) | Color photograph of an astronaut. |

--- a/docs/getting_started/open_images.md
+++ b/docs/getting_started/open_images.md
@@ -32,7 +32,7 @@ Sometimes you just need to open images to test some functionality of napari or a
 | Binary Blobs (3D) | 3D synthetic binary blob volume. |
 | Brick | Photograph of a brick wall texture. |
 | Brain (3D) | 3D MRI brain volume. |
-| Camera | Standard grayscale "cameraman" test image. |
+| Camera | Grayscale "cameraman" test image. |
 | Cat (RGB) | Color photograph of a cat. |
 | Cell | Grayscale microscopy image of a single cell. |
 | Cells (3D+2Ch) | 3D fluorescence image with two channels. |


### PR DESCRIPTION
# References and relevant issues
fixes #1080 
<!-- What relevant resources were used in the creation of this PR?
If this PR addresses an existing issue on the repo,
please link to that issue here as "Closes #(issue-number)".
If this PR adds docs for a napari PR please add a "Depends on <napari PR link>" -->

# Description
- added sample images with Notes (defining that image)

<!-- What does this pull request (PR) do? Does it add new content, improve/fix existing
context, improve/fix workflow/documentation build/deployment or something else?
<!-- If relevant, please include a screenshot or a screen capture in your content
change: "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations. -->
<!-- You can also see a preview of the documentation changes you are submitting by
clicking on "Details" to the right of the "Check the rendered docs here!" check on your PR.-->

<!-- Previewing the Documentation Build
When you submit this PR, jobs that preview the documentation will be kicked off.
By default, they will use the `slimfast` build (`make` target), which is fast, because
it doesn't build any content from outside the `docs` repository and doesn't run notebook cells.
You can trigger other builds by commenting on the PR with:

@napari-bot make <target>

where <target> can be:
html : a full build, just like the deployment to napari.org
html-noplot : a full build, but without the gallery examples from `napari/napari`
docs : only the content from `napari/docs`, with notebook code cells executed
slimfast : the default, only the content from `napari/docs`, without code cell execution
slimgallery : `slimfast`, but with the gallery examples from `napari/napari` built
-->

<!-- Final Checklist
- If images included: I have added [alt text](https://webaim.org/techniques/alttext/)
If workflow, documentation build or deployment change:
- My PR is the minimum possible work for the desired functionality
- I have commented my code, to let others know what it does
-->
