### PR TITLE
Info about Xarray metadata inheritance

### DIFF
--- a/docs/guides/units.md
+++ b/docs/guides/units.md
@@ -54,7 +54,7 @@ names become the layer's axis labels, coordinate values are used for `scale`
 and `translate`, and CF-convention `units` attributes on coordinates (validated
 with [pint](https://pint.readthedocs.io/)) become the layer units. Even
 `datetime64` coordinates are converted to a sensible time unit. See the
-[xarray example](:ref:`sphx_glr_gallery_xarray-latlon-timeseries.py`) for a
+[xarray example](sphx_glr_gallery_xarray-latlon-timeseries.py) for a
 full demonstration.
 
 ## When units are consistent across layers

--- a/docs/guides/units.md
+++ b/docs/guides/units.md
@@ -46,6 +46,17 @@ Pint also has logic to disambiguate unit names, for example,
 If you do not set units, napari assumes pixels.
 To set *no* units, use `layer.units = ('dimensionless',...)`.
 
+## Inheriting scale and units from xarray
+
+If you pass an [Xarray](https://docs.xarray.dev/en/stable/generated/xarray.DataArray.html)
+`DataArray` to napari, it automatically inherits metadata from it: dimension
+names become the layer's axis labels, coordinate values are used for `scale`
+and `translate`, and CF-convention `units` attributes on coordinates (validated
+with [pint](https://pint.readthedocs.io/)) become the layer units. Even
+`datetime64` coordinates are converted to a sensible time unit. See the
+[xarray example]({ref}`sphx_glr_gallery_xarray-latlon-timeseries.py`) for a
+full demonstration.
+
 ## When units are consistent across layers
 
 napari can use units to render layers in the same physical space even when the

--- a/docs/guides/units.md
+++ b/docs/guides/units.md
@@ -54,7 +54,7 @@ names become the layer's axis labels, coordinate values are used for `scale`
 and `translate`, and CF-convention `units` attributes on coordinates (validated
 with [pint](https://pint.readthedocs.io/)) become the layer units. Even
 `datetime64` coordinates are converted to a sensible time unit. See the
-[xarray example]({ref}`sphx_glr_gallery_xarray-latlon-timeseries.py`) for a
+[xarray example](:ref:`sphx_glr_gallery_xarray-latlon-timeseries.py`) for a
 full demonstration.
 
 ## When units are consistent across layers

--- a/docs/howtos/layers/image.md
+++ b/docs/howtos/layers/image.md
@@ -180,7 +180,7 @@ conversions. napari handles all of that for you.
 If you pass an [Xarray](https://docs.xarray.dev/en/stable/generated/xarray.DataArray.html)
 `DataArray` to napari, it automatically inherits metadata from it, such as axis
 labels, `scale`, `translate`, and units. For details on how this metadata is
-used for rendering, see the [units guide]({ref}`units-guide`).
+used for rendering, see the [units guide](units-guide).
 ```
 
 napari will also wait until just before it displays data onto the screen to

--- a/docs/howtos/layers/image.md
+++ b/docs/howtos/layers/image.md
@@ -176,6 +176,17 @@ The great thing about napari support of array-like objects is that you get to
 keep on using your favorite array libraries without worrying about any
 conversions. napari handles all of that for you.
 
+```{note}
+If you pass an [Xarray](https://docs.xarray.dev/en/stable/generated/xarray.DataArray.html)
+`DataArray` to napari, it automatically inherits metadata from it: dimension
+names become the layer's axis labels, coordinate values are used for `scale`
+and `translate`, and CF-convention `units` attributes on coordinates (validated
+with [pint](https://pint.readthedocs.io/)) become the layer units. Even
+`datetime64` coordinates are converted to a sensible time unit. See the
+[xarray example]({ref}`sphx_glr_gallery_xarray-latlon-timeseries.py`) for a
+full demonstration.
+```
+
 napari will also wait until just before it displays data onto the screen to
 actually generate a NumPy array from your data, and so if you're using a library
 like `dask` or `zarr` that supports lazy loading and lazy evaluation, we won't

--- a/docs/howtos/layers/image.md
+++ b/docs/howtos/layers/image.md
@@ -178,13 +178,9 @@ conversions. napari handles all of that for you.
 
 ```{note}
 If you pass an [Xarray](https://docs.xarray.dev/en/stable/generated/xarray.DataArray.html)
-`DataArray` to napari, it automatically inherits metadata from it: dimension
-names become the layer's axis labels, coordinate values are used for `scale`
-and `translate`, and CF-convention `units` attributes on coordinates (validated
-with [pint](https://pint.readthedocs.io/)) become the layer units. Even
-`datetime64` coordinates are converted to a sensible time unit. See the
-[xarray example]({ref}`sphx_glr_gallery_xarray-latlon-timeseries.py`) for a
-full demonstration.
+`DataArray` to napari, it automatically inherits metadata from it, such as axis
+labels, `scale`, `translate`, and units. For details on how this metadata is
+used for rendering, see the [units guide]({ref}`units-guide`).
 ```
 
 napari will also wait until just before it displays data onto the screen to


### PR DESCRIPTION
# References and relevant issues

Follow-up to napari/napari#9316

# Description

Update: per Lorenzo's suggestion, this has been primarily added to the units and scale guide.

Feedback requested: Where should this info actually live?

I placed some info about the Xarray metadata inheritance into the Image guide, but it is still applicable also to Labels layers.
This is just the section where we talk about array types, so it seemed like a level-of-detail appropriate place to stick it.
