### PR TITLE
Clean Pydantic BaseModel objects out of API docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -743,65 +743,43 @@ def qt_docstrings(app, what, name, obj, options, lines):
 # -- Pydantic model internals ---------------------------------------------
 
 
-#: Attributes inherited from pydantic's ``BaseModel`` that are internal
-#: schema/serialization bookkeeping.  They are rendered with pydantic's own
-#: docstrings and only clutter napari's API reference, so we hide them.
-_PYDANTIC_MODEL_ATTRIBUTES = frozenset({
-    'model_computed_fields',
-    'model_config',
-    'model_extra',
-    'model_fields',
-    'model_fields_set',
-})
+def _skip_pydantic_base_model_methods(app, what, name, obj, skip, options):
+    """Skip methods inherited from pydantic's ``BaseModel``.
 
-
-def _skip_pydantic_model_members(app, what, name, obj, skip, options):
-    """Skip members inherited from pydantic's ``BaseModel``.
-
-    Every ``napari.utils.events.EventedModel`` subclass (Viewer, Camera,
-    Colormap, ...) inherits pydantic v2's public serialization/schema
-    machinery (``model_validate``, ``model_dump``, ``model_fields``, ...).
-    Those render pydantic's own docstrings and make the API reference much
-    harder to parse, so we hide them from both the
-    autosummary member tables and the autodoc "Details" sections.
-
-    napari's own overrides of some of these methods (e.g.
-    ``ViewerModel.model_dump``, ``ViewerModel.json``,
-    ``EventedModel.model_json_schema``) are preserved, since they carry real
-    napari docstrings.
+    Keep napari overrides (e.g. ``ViewerModel.model_dump``, ``ViewerModel.json``,
+    ``EventedModel.model_json_schema``), so we preserve those because they don't
+    have the same qualname as pydantic's ``BaseModel`` methods.
     """
-    # Methods: skip only when they genuinely originate from pydantic's
-    # ``BaseModel`` (identified by qualname), so napari overrides with real
-    # docstrings are kept.
     qualname = getattr(obj, '__qualname__', None)
     if qualname:
         module = getattr(obj, '__module__', '')
         if module == 'pydantic.main' and qualname.startswith('BaseModel.'):
             return True
-
-    # Attributes don't expose a qualname; match the pydantic-only names.
-    if name in _PYDANTIC_MODEL_ATTRIBUTES:
-        return True
-
-    # No opinion: return None so Sphinx keeps its default public/private
-    # filtering.  (Returning the ``skip`` value here would make autosummary
-    # treat every member as "show forcedly" and leak private members like
-    # ``__pydantic_*`` into the summary tables.)
     return None
 
 
-def _clean_pydantic_signatures(app, what, name, obj, options, signature, retann):
-    """Replace pydantic's ``<factory>`` sentinel with ``None`` in signatures.
+def _skip_pydantic_named_members(app, what, name, obj, skip, options):
+    """Skip pydantic members that don't expose a ``BaseModel.*`` qualname.
 
-    pydantic v2 renders fields declared with ``default_factory`` as
-    ``= <factory>`` in generated ``__init__`` signatures (an internal
-    ``_HAS_DEFAULT_FACTORY`` sentinel whose repr is ``<factory>``).  That is
-    unhelpful in the docs, so we show ``= None`` instead -- matching what
-    pydantic v1 (napari <= 0.6) rendered.
+    Attributes (``model_config``, ``model_fields``, ...) don't expose a
+    qualname at all, and ``model_post_init`` is aliased by pydantic to an
+    internal function (``init_private_attributes``) rather than
+    ``BaseModel.model_post_init``, so neither is caught by the qualname
+    check.  We match those by name instead.
     """
-    if signature and '<factory>' in signature:
-        signature = signature.replace(' = <factory>', ' = None')
-    return signature, retann
+    _PYDANTIC_MODEL_MEMBERS = frozenset({
+        'model_computed_fields',
+        'model_config',
+        'model_extra',
+        'model_fields',
+        'model_fields_set',
+        'model_post_init',
+    })
+
+    if name in _PYDANTIC_MODEL_MEMBERS:
+        return True
+    return None
+
 
 # -- Docs build setup ------------------------------------------------------
 
@@ -816,7 +794,6 @@ def setup(app):
     * Filters out 'duplicate object description' Sphinx warnings
     * Cleans out Qt threading docstrings
     * Hides pydantic BaseModel internals from the API reference
-    * Replaces pydantic's ``<factory>`` signature sentinel with ``None``
 
     """
     app.registry.source_suffix.pop('.ipynb', None)
@@ -824,8 +801,8 @@ def setup(app):
     app.connect('source-read', augment_gallery_example)
     app.connect('linkcheck-process-uri', rewrite_github_anchor)
     app.connect('autodoc-process-docstring', qt_docstrings)
-    app.connect('autodoc-skip-member', _skip_pydantic_model_members)
-    app.connect('autodoc-process-signature', _clean_pydantic_signatures)
+    app.connect('autodoc-skip-member', _skip_pydantic_base_model_methods)
+    app.connect('autodoc-skip-member', _skip_pydantic_named_members)
 
     logger = logging.getLogger('sphinx')
     warning_handler, *_ = [

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,21 +14,25 @@ import json
 import logging
 import os
 import re
-import tomllib
 from datetime import datetime
 from functools import cache
 from importlib import import_module
 from importlib.metadata import (
     distribution,
     packages_distributions,
+)
+from importlib.metadata import (
     version as metadata_version,
 )
 from pathlib import Path
 from urllib.parse import urlparse, urlunparse
 
 import napari
+import pooch.core
+import tomllib
 from jinja2.filters import FILTERS
 from napari._version import __version_tuple__
+from napari.utils._examples_data import napari_choose_downloader
 from packaging.requirements import Requirement
 from packaging.utils import canonicalize_name
 from packaging.version import parse as parse_version
@@ -37,9 +41,6 @@ from sphinx.highlighting import lexers
 from sphinx.util import logging as sphinx_logging
 from sphinx_gallery import gen_rst, scrapers
 from sphinx_gallery.sorting import ExampleTitleSortKey
-import pooch.core
-
-from napari.utils._examples_data import napari_choose_downloader
 
 # -- Detect build on CI PR ----------------------------------------------------
 
@@ -739,6 +740,55 @@ def qt_docstrings(app, what, name, obj, options, lines):
     if any(f in name for f in ignore_list) and len(lines) > 0:
         del lines[1:]
 
+# -- Pydantic model internals ---------------------------------------------
+
+
+#: Attributes inherited from pydantic's ``BaseModel`` that are internal
+#: schema/serialization bookkeeping.  They are rendered with pydantic's own
+#: docstrings and only clutter napari's API reference, so we hide them.
+_PYDANTIC_MODEL_ATTRIBUTES = frozenset({
+    'model_computed_fields',
+    'model_config',
+    'model_extra',
+    'model_fields',
+    'model_fields_set',
+})
+
+
+def _skip_pydantic_model_members(app, what, name, obj, skip, options):
+    """Skip members inherited from pydantic's ``BaseModel``.
+
+    Every ``napari.utils.events.EventedModel`` subclass (Viewer, Camera,
+    Colormap, ...) inherits pydantic v2's public serialization/schema
+    machinery (``model_validate``, ``model_dump``, ``model_fields``, ...).
+    Those render pydantic's own docstrings and make the API reference much
+    harder to parse (napari/docs#964), so we hide them from both the
+    autosummary member tables and the autodoc "Details" sections.
+
+    napari's own overrides of some of these methods (e.g.
+    ``ViewerModel.model_dump``, ``ViewerModel.json``,
+    ``EventedModel.model_json_schema``) are preserved, since they carry real
+    napari docstrings.
+    """
+    # Methods: skip only when they genuinely originate from pydantic's
+    # ``BaseModel`` (identified by qualname), so napari overrides with real
+    # docstrings are kept.
+    qualname = getattr(obj, '__qualname__', None)
+    if qualname:
+        module = getattr(obj, '__module__', '')
+        if module == 'pydantic.main' and qualname.startswith('BaseModel.'):
+            return True
+
+    # Attributes don't expose a qualname; match the pydantic-only names.
+    if name in _PYDANTIC_MODEL_ATTRIBUTES:
+        return True
+
+    # No opinion: return None so Sphinx keeps its default public/private
+    # filtering.  (Returning the ``skip`` value here would make autosummary
+    # treat every member as "show forcedly" and leak private members like
+    # ``__pydantic_*`` into the summary tables.)
+    return None
+
 # -- Docs build setup ------------------------------------------------------
 
 
@@ -751,6 +801,7 @@ def setup(app):
     * Adds google calendar api key to meetings schedule page
     * Filters out 'duplicate object description' Sphinx warnings
     * Cleans out Qt threading docstrings
+    * Hides pydantic BaseModel internals from the API reference
 
     """
     app.registry.source_suffix.pop('.ipynb', None)
@@ -758,6 +809,7 @@ def setup(app):
     app.connect('source-read', augment_gallery_example)
     app.connect('linkcheck-process-uri', rewrite_github_anchor)
     app.connect('autodoc-process-docstring', qt_docstrings)
+    app.connect('autodoc-skip-member', _skip_pydantic_model_members)
 
     logger = logging.getLogger('sphinx')
     warning_handler, *_ = [

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -762,7 +762,7 @@ def _skip_pydantic_model_members(app, what, name, obj, skip, options):
     Colormap, ...) inherits pydantic v2's public serialization/schema
     machinery (``model_validate``, ``model_dump``, ``model_fields``, ...).
     Those render pydantic's own docstrings and make the API reference much
-    harder to parse (napari/docs#964), so we hide them from both the
+    harder to parse, so we hide them from both the
     autosummary member tables and the autodoc "Details" sections.
 
     napari's own overrides of some of these methods (e.g.
@@ -789,6 +789,20 @@ def _skip_pydantic_model_members(app, what, name, obj, skip, options):
     # ``__pydantic_*`` into the summary tables.)
     return None
 
+
+def _clean_pydantic_signatures(app, what, name, obj, options, signature, retann):
+    """Replace pydantic's ``<factory>`` sentinel with ``None`` in signatures.
+
+    pydantic v2 renders fields declared with ``default_factory`` as
+    ``= <factory>`` in generated ``__init__`` signatures (an internal
+    ``_HAS_DEFAULT_FACTORY`` sentinel whose repr is ``<factory>``).  That is
+    unhelpful in the docs, so we show ``= None`` instead -- matching what
+    pydantic v1 (napari <= 0.6) rendered.
+    """
+    if signature and '<factory>' in signature:
+        signature = signature.replace(' = <factory>', ' = None')
+    return signature, retann
+
 # -- Docs build setup ------------------------------------------------------
 
 
@@ -802,6 +816,7 @@ def setup(app):
     * Filters out 'duplicate object description' Sphinx warnings
     * Cleans out Qt threading docstrings
     * Hides pydantic BaseModel internals from the API reference
+    * Replaces pydantic's ``<factory>`` signature sentinel with ``None``
 
     """
     app.registry.source_suffix.pop('.ipynb', None)
@@ -810,6 +825,7 @@ def setup(app):
     app.connect('linkcheck-process-uri', rewrite_github_anchor)
     app.connect('autodoc-process-docstring', qt_docstrings)
     app.connect('autodoc-skip-member', _skip_pydantic_model_members)
+    app.connect('autodoc-process-signature', _clean_pydantic_signatures)
 
     logger = logging.getLogger('sphinx')
     warning_handler, *_ = [

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,6 +29,7 @@ from urllib.parse import urlparse, urlunparse
 
 import napari
 import pooch.core
+import pydantic
 import tomllib
 from jinja2.filters import FILTERS
 from napari._version import __version_tuple__
@@ -781,6 +782,28 @@ def _skip_pydantic_named_members(app, what, name, obj, skip, options):
     return None
 
 
+def _add_pydantic_model_dropdown(app, what, name, obj, options, lines):
+    """Append a collapsed link to pydantic docs on pydantic model pages."""
+    if what != 'class' or not name.startswith('napari.'):
+        return
+    if not (isinstance(obj, type) and issubclass(obj, pydantic.BaseModel)):
+        return
+    if obj is pydantic.BaseModel:
+        return
+    lines.extend(
+        [
+            '',
+            '.. dropdown:: Inherited from :external+pydantic:class:`pydantic.BaseModel`',
+            '   :animate: fade-in-slide-down',
+            '',
+            '   This class is a pydantic model. For brevity, the methods and',
+            '   attributes it inherits from :external+pydantic:class:`pydantic.BaseModel`',
+            '   are not repeated here.',
+            '',
+        ]
+    )
+
+
 # -- Docs build setup ------------------------------------------------------
 
 
@@ -794,6 +817,7 @@ def setup(app):
     * Filters out 'duplicate object description' Sphinx warnings
     * Cleans out Qt threading docstrings
     * Hides pydantic BaseModel internals from the API reference
+    * Adds a collapsed link to the pydantic docs on pydantic model pages
 
     """
     app.registry.source_suffix.pop('.ipynb', None)
@@ -801,6 +825,7 @@ def setup(app):
     app.connect('source-read', augment_gallery_example)
     app.connect('linkcheck-process-uri', rewrite_github_anchor)
     app.connect('autodoc-process-docstring', qt_docstrings)
+    app.connect('autodoc-process-docstring', _add_pydantic_model_dropdown)
     app.connect('autodoc-skip-member', _skip_pydantic_base_model_methods)
     app.connect('autodoc-skip-member', _skip_pydantic_named_members)
 


### PR DESCRIPTION
# References and relevant issues

Closes #964

# Description

Pydantic v2 causes every `EventedModel`-based API page (Viewer, Camera, Colormap, ...) cluttered with inherited `BaseModel` members. Here we use `conf.py` to hide them from the tables and the autodoc Details sections.
napari's own overrides (`model_dump`, `json`, `model_json_schema`) are kept. IMO this is desirable because the API docs aren't just for "everything" but should be a bit more opinionated, especially for _most_ users that don't need these.

Dropped from the tables:
- **20 methods** — 11 deprecated v1 (`copy`, `dict`, `construct`, `parse_*`,  `schema*`, `validate`, `from_orm`, `update_forward_refs`), 8 v2  (`model_construct`, `model_copy`, `model_dump_json`,  `model_parametrized_name`, `model_rebuild`, `model_validate*`), and  `model_post_init`
- **5 attributes** — `model_computed_fields`, `model_config`, `model_extra`,  `model_fields`, `model_fields_set`
