### PR TITLE
API Docs: Move type hints out of signature and into params

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -338,6 +338,10 @@ myst_substitutions = {
 
 }
 
+# -- Autodoc ----------------------------------------------------------------
+
+autodoc_typehints = 'description'  # Render parameter types in the descriptions rather than the signature.
+
 # -- Autosummary ------------------------------------------------------------
 
 autosummary_generate = True


### PR DESCRIPTION
# Description

Moves the type hints out of the API docs signature. https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autodoc_typehints
and into the parameters section of the docstring. This does mean that parameters without descriptions are now shown in the bulleted (napolean? I think is what its called) parameter list.

Personally, I find this to be overall much more readable, and any issues with it are **our** problem because of lack of docstrings and means that we should be doing better inside teh napari source code.

This PR on left, 0.8 on right:

<img width="3836" height="2032" alt="image" src="https://github.com/user-attachments/assets/bb902551-f086-4bca-9b6b-fb98ce12a93d" />

