### PR TITLE
Use a pages first image for OpenGraph Preview if there is one

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -257,7 +257,7 @@ suppress_warnings = ['myst.header', 'etoc.toctree', 'config.cache']
 
 ogp_site_url = 'https://napari.org/'
 ogp_image = 'dev/_static/opengraph_image.png'
-ogp_use_first_image = False
+ogp_use_first_image = True
 ogp_description_length = 300
 ogp_type = 'website'
 ogp_site_name = 'napari'


### PR DESCRIPTION
# Description

This should use the first image on the page that isn't an svg or .ico
It doesn't filter for size or anything so maybe has weird edge cases
cc @jni