### PR TITLE
Update version switcher for 0.9.0

### DIFF
--- a/docs/_static/version_switcher.json
+++ b/docs/_static/version_switcher.json
@@ -5,10 +5,15 @@
         "url": "https://napari.org/dev/"
     },
     {
-        "name": "stable (0.8.0)",
-        "version": "0.8.0",
+        "name": "stable (0.9.0)",
+        "version": "0.9.0",
         "url": "https://napari.org/stable/",
         "preferred": true
+    },
+    {
+        "name": "0.8.0",
+        "version": "0.8.0",
+        "url": "https://napari.org/0.8.0/"
     },
     {
         "name": "0.7.1",


### PR DESCRIPTION
# References and relevant issues

# Description

Change the version switcher to point to 0.9.0 as the default. 