### PR TITLE
Fix incorrect image link formatting in 0.9 release notes

### DIFF
--- a/docs/release/release_0_9_0.md
+++ b/docs/release/release_0_9_0.md
@@ -91,7 +91,7 @@ viewer buttons, the dimension sliders, and the status bar — so you can get you
 bearings in seconds. If the viewer is empty, napari opens the built-in *Balls
 (3D)* sample data so the walkthrough has something to show ([#9290](https://github.com/napari/napari/pull/9290)).
 
-![Screenshot of the napari viewer guided tour][../_static/images/guided-tour.png)
+![Screenshot of the napari viewer guided tour](../_static/images/guided-tour.png)
 
 ### Contributable plugin preferences
 


### PR DESCRIPTION
This is causing a missing image in the release notes.

It might be worth manually copying the fix to 0.9.0 once deployed.
