### PR TITLE
Update version switch to set 0.9.1 to default release 

### DIFF
--- a/docs/_static/version_switcher.json
+++ b/docs/_static/version_switcher.json
@@ -5,10 +5,15 @@
         "url": "https://napari.org/dev/"
     },
     {
-        "name": "stable (0.9.0)",
-        "version": "0.9.0",
+        "name": "stable (0.9.1)",
+        "version": "0.9.1",
         "url": "https://napari.org/stable/",
         "preferred": true
+    },
+    {
+        "name": "0.9.0",
+        "version": "0.9.0",
+        "url": "https://napari.org/0.9.0/"
     },
     {
         "name": "0.8.0",


### PR DESCRIPTION
# References and relevant issues

# Description

Update version switcher